### PR TITLE
feat: add Dial System LLM gateway (Phase 6) #7

### DIFF
--- a/pdd/context/conventions.md
+++ b/pdd/context/conventions.md
@@ -1,6 +1,6 @@
 # GrandLine Conventions
 
-**Last updated**: 2026-04-04
+**Last updated**: 2026-04-05
 
 ## Philosophy
 - **Local-first**: Docker Compose is the primary dev environment. Everything runs locally.
@@ -57,9 +57,14 @@ src/
       doctor.py             — QA agent (test writing + validation)
       helmsman.py           — DevOps agent (deployment)
     dial_system/            — LLM gateway
-      router.py             — Provider routing + role mapping
-      failover.py           — Vivre Card checkpoint + provider migration
-      providers/            — Provider adapters (Anthropic, OpenAI, local)
+      router.py             — DialSystemRouter (role routing + failover)
+      factory.py            — Adapter factory (create_adapter, build_router_from_config)
+      rate_limiter.py       — Redis sliding-window rate limiter
+      adapters/             — Provider adapters
+        base.py             — ProviderAdapter ABC + ProviderError
+        anthropic.py        — Anthropic SDK adapter
+        openai.py           — OpenAI SDK adapter
+        ollama.py           — Ollama HTTP adapter (httpx)
     den_den_mushi/          — Message bus (Redis Streams)
     models/                 — SQLAlchemy models
     schemas/                — Pydantic request/response schemas
@@ -166,10 +171,14 @@ src/
 - All actions logged to Ship's Log for full observability
 
 ## Dial System (LLM Gateway)
-- Config-driven: each crew role maps to a provider + model + parameters
-- Provider adapters: Anthropic, OpenAI, local models
-- Failover chain: primary → fallback → park
-- Rate limit awareness: track usage, switch before hitting limits
+- Config-driven: each crew role maps to a provider + model via DialConfig JSONB
+- Provider adapters: `ProviderAdapter` ABC — Anthropic, OpenAI, Ollama implementations
+- Adapter factory: `create_adapter()` creates adapters from strings; `build_router_from_config()` wires the full router from DB config
+- Failover chain: primary → fallback chain → `RuntimeError("All providers exhausted")`
+- Rate limiter: Redis sorted-set sliding window tracking tokens + requests per provider per minute
+- Error handling: SDK errors (`RateLimitError`, `APIError`) caught and re-raised as `ProviderError` for uniform failover
+- SSE streaming: `POST /completions/stream` with `text/event-stream` and `data: {token}\n\n` format
+- Failover applies to both `route()` and `stream()` — identical logic
 - All LLM calls go through the Dial System — no direct provider calls
 
 ## API protocols

--- a/pdd/context/decisions.md
+++ b/pdd/context/decisions.md
@@ -1,6 +1,6 @@
 # GrandLine — Architectural Decisions
 
-**Last updated**: 2026-04-04
+**Last updated**: 2026-04-05
 
 ---
 
@@ -29,10 +29,18 @@
 ---
 
 ## Decision: Dial System (LLM gateway) with config-driven role mapping
-**Date**: 2026-04-04
-**What was decided**: All LLM calls go through the Dial System — a gateway that routes requests based on crew role configuration. Each agent persona can be mapped to a different provider/model. Failover is automatic with Vivre Card checkpointing.
-**Why**: Provider-agnostic by design. Users can run the Captain on Claude, Shipwrights on GPT-4, and the Doctor on a local model — all via config, not code changes. When a provider hits rate limits, the Dial System checkpoints state (Vivre Card), migrates to a fallback, or parks non-critical agents. No work is lost.
+**Date**: 2026-04-04 (implemented 2026-04-05)
+**What was decided**: All LLM calls go through the Dial System — a gateway that routes requests based on crew role configuration. Each agent persona can be mapped to a different provider/model. Failover is automatic with ProviderError-driven chain traversal.
+**Why**: Provider-agnostic by design. Users can run the Captain on Claude, Shipwrights on GPT-4, and the Doctor on a local model — all via config, not code changes. When a provider hits rate limits or errors, the Dial System catches `ProviderError`, tries the fallback chain, and publishes `ProviderSwitchedEvent` via Den Den Mushi.
 **Don't suggest**: Direct provider SDK calls from agents, single-provider lock-in, manual failover
+
+---
+
+## Decision: Adapter factory pattern over global adapter instances
+**Date**: 2026-04-05
+**What was decided**: Provider adapters are created per-request via `create_adapter()` and `build_router_from_config()` in `factory.py`. No global adapter instances — the factory reads DialConfig JSONB from DB and wires a fresh `DialSystemRouter` per request via FastAPI's `Depends(get_dial_router)`.
+**Why**: Config can change at any time via `PUT /dial-config`. If adapters were global singletons, config changes would require a restart or cache invalidation. Per-request creation means the next API call picks up new config immediately. The factory also centralizes provider-to-adapter mapping, making it easy to add new providers.
+**Don't suggest**: Global adapter singletons, adapter caching without invalidation, direct adapter instantiation in route handlers
 
 ---
 

--- a/pdd/context/project.md
+++ b/pdd/context/project.md
@@ -1,6 +1,6 @@
 # Project: GrandLine
 
-**Last updated**: 2026-04-04
+**Last updated**: 2026-04-05
 
 ## What we're building
 A web-based multi-agent orchestration platform where a crew of persona-based AI agents voyage together through a structured pipeline to build, test, and deploy software solutions. Themed after One Piece — the crew, the voyage, and the platform vocabulary are all drawn from that world.
@@ -97,10 +97,15 @@ Users can intervene at any point — pause an agent, redirect work, inject conte
 - Protected routes: Middleware-level enforcement
 
 ## Dial System (LLM Gateway)
-- Provider-agnostic: Anthropic, OpenAI, local models
-- Config-driven role mapping: each agent persona can be mapped to a specific provider/model
-- Failover: when a provider hits its limit, the system checkpoints agent state (Vivre Card), migrates to fallback providers, or parks non-critical agents
-- No work is lost — ever
+- Provider-agnostic: Anthropic, OpenAI, Ollama (local models)
+- Config-driven role mapping: each agent persona mapped to a provider/model via DialConfig JSONB
+- Adapter pattern: `ProviderAdapter` ABC with `complete()`, `stream()`, `check_rate_limit()`
+- Adapter factory: `create_adapter()` + `build_router_from_config()` — no global instances, created per-request
+- Failover: `DialSystemRouter` checks rate limits, tries primary, falls back through chain on `ProviderError`
+- Failover applies to both `route()` (sync completion) and `stream()` (SSE streaming)
+- Rate limiter: Redis sliding-window sorted sets tracking tokens + requests per provider
+- SSE streaming: `POST /completions/stream` returns `text/event-stream` with `data: {token}\n\n` format
+- `ProviderSwitchedEvent` published via Den Den Mushi on failover
 
 ## Agent Execution
 - Agents work in **real git repos** with **per-agent branches**
@@ -138,7 +143,14 @@ Users can intervene at any point — pause an agent, redirect work, inject conte
 - Never lose work — Vivre Card checkpointing is mandatory for provider failover
 
 ## Current state
-Starting from scratch — project scaffolded with PDD structure, no application code yet.
+Phases 1-6 complete. The backend is functional with:
+- **Phase 1-2**: Docker infrastructure, PostgreSQL + Redis, SQLAlchemy models (Voyage, VoyagePlan, Poneglyph, VivreCard, CrewAction, DialConfig)
+- **Phase 3**: Pydantic schemas for all models, DialConfig with JSONB role_mapping/fallback_chain
+- **Phase 4**: JWT auth (register, login, refresh, logout) with default-deny middleware
+- **Phase 5**: Den Den Mushi message bus (Redis Streams) with consumer groups, dead-letter handling, xautoclaim stale recovery
+- **Phase 6**: Dial System LLM gateway — provider adapters (Anthropic, OpenAI, Ollama), adapter factory, role-based routing with failover, Redis sliding-window rate limiter, SSE streaming endpoint
+
+163 unit tests passing, mypy clean, ruff clean. Frontend not yet started.
 
 ## Source directory structure
 All application artifacts live under `src/`:

--- a/pdd/evals/dial-system-eval.md
+++ b/pdd/evals/dial-system-eval.md
@@ -1,0 +1,94 @@
+# Eval: Dial System (LLM Gateway)
+
+**Prompt**: `pdd/prompts/features/dial-system/grandline-06-llm-gateway.md`
+**Level**: 1 (Checklist)
+**Created**: 2026-04-05
+
+## Criteria
+
+### C1: Provider Adapter ABC
+- [x] `ProviderAdapter` ABC exists with `complete()`, `stream()`, `check_rate_limit()`
+- [x] `ProviderError` exception defined in `base.py`
+
+### C2: Anthropic Adapter
+- [x] Catches `RateLimitError` → sets `_rate_limited`, re-raises as `ProviderError`
+- [x] Catches `APIError` → re-raises as `ProviderError`
+- [x] `complete()` returns `CompletionResult` with `TokenUsage`
+- [x] `stream()` yields text tokens from streaming events
+- [x] `check_rate_limit()` returns `RateLimitStatus`
+
+### C3: OpenAI Adapter
+- [x] Same error handling pattern as Anthropic (RateLimitError, APIError)
+- [x] `complete()` returns `CompletionResult` with `TokenUsage`
+- [x] `stream()` yields text tokens from streaming chunks
+- [x] `check_rate_limit()` returns `RateLimitStatus`
+
+### C4: Ollama Adapter
+- [x] Uses `httpx` for HTTP calls (no extra SDK)
+- [x] Raises `ProviderError` on non-200 HTTP status
+- [x] Catches `httpx.HTTPError` for connection errors
+- [x] `check_rate_limit()` always returns `is_limited=False`
+- [x] `stream()` parses NDJSON lines
+
+### C5: Rate Limiter
+- [x] Redis sliding window using sorted sets
+- [x] `record_usage(provider, tokens)` stores entries
+- [x] `check(provider)` returns `RateLimitStatus` with token/request counts
+- [x] `cleanup(provider)` removes expired entries
+
+### C6: Adapter Factory
+- [x] `create_adapter()` creates correct adapter for each provider string
+- [x] Raises `ValueError` for unknown provider
+- [x] `build_router_from_config()` reads JSONB config and wires router
+- [x] Handles missing `provider`/`model` keys with `ValueError`
+- [x] Handles `None` fallback chain gracefully
+
+### C7: Router — route()
+- [x] Checks rate limit before calling primary
+- [x] On `ProviderError`, tries fallback chain
+- [x] Calls `record_usage()` after success (when rate_limiter provided)
+- [x] Publishes `ProviderSwitchedEvent` on failover
+- [x] Raises `RuntimeError("All providers exhausted")` when all fail
+- [x] No event published when primary succeeds
+
+### C8: Router — stream()
+- [x] Same failover logic as `route()` (rate limit check → primary → fallbacks)
+- [x] Publishes `ProviderSwitchedEvent` on failover
+- [x] Yields tokens from successful provider
+
+### C9: Schemas
+- [x] `CompletionRequest` has `messages`, `role`, `voyage_id`, `max_tokens`, `temperature`, `extra`
+- [x] `CompletionResult` has `content`, `provider`, `model`, `usage`
+- [x] `TokenUsage` has `prompt_tokens`, `completion_tokens`, `total_tokens`
+- [x] `RateLimitStatus` has `is_limited`, `remaining_tokens`, `remaining_requests`, `reset_at`
+- [x] `ProviderConfig` has `provider`, `model`, `max_tokens`
+
+### C10: REST API
+- [x] `GET /{voyage_id}/dial-config` returns config
+- [x] `PUT /{voyage_id}/dial-config` updates config
+- [x] `POST /{voyage_id}/completions` runs completion
+- [x] `POST /{voyage_id}/completions/stream` returns SSE with `text/event-stream`
+- [x] SSE format: `data: {token}\n\n`
+
+### C11: FastAPI Integration
+- [x] `get_dial_router` dependency fetches config, creates rate limiter, builds router
+- [x] 404 when no config found
+- [x] Settings has `anthropic_api_key`, `openai_api_key`, `ollama_base_url`
+- [x] Dial router registered in `v1_router`
+
+### C12: Constraints
+- [x] `anthropic>=0.40.0` and `openai>=1.50.0` in requirements.txt
+- [x] API keys in env, never in DB
+- [x] Failover in both `route()` and `stream()`
+- [x] No global adapter instances
+
+### C13: Quality Gates
+- [x] All tests pass (pytest) — 37/37 dial system tests, 163/163 total
+- [x] Type-safe (mypy clean) — 0 errors in 46 files
+- [x] Lint-clean (ruff) — all checks passed
+
+## Run Log
+
+| Run | Date | Pass | Fail | Notes |
+|-----|------|------|------|-------|
+| 1   | 2026-04-05 | 48/48 | 0 | All criteria pass. 37 dial tests, mypy clean, ruff clean. |

--- a/pdd/prompts/features/dial-system/grandline-06-llm-gateway.md
+++ b/pdd/prompts/features/dial-system/grandline-06-llm-gateway.md
@@ -2,6 +2,7 @@
 
 **File**: pdd/prompts/features/dial-system/grandline-06-llm-gateway.md
 **Created**: 2026-04-05
+**Updated**: 2026-04-05
 **Depends on**: Phase 3 (DialConfig model + schema), Phase 5 (Den Den Mushi events)
 **Project type**: Backend (FastAPI + LLM SDKs)
 
@@ -16,37 +17,80 @@ In One Piece, Dials are shell-shaped devices from Skypiea that store and release
 Implement a provider-agnostic LLM gateway with config-driven routing per crew role:
 
 1. **Provider Adapters** (`app/dial_system/adapters/`):
-   - `base.py` — `ProviderAdapter` ABC with `complete(messages, **kwargs) -> CompletionResult`, `stream(messages, **kwargs) -> AsyncIterator[str]`, `check_rate_limit() -> RateLimitStatus`
+   - `base.py` — `ProviderAdapter` ABC with:
+     - `complete(request: CompletionRequest) -> CompletionResult`
+     - `stream(request: CompletionRequest) -> AsyncIterator[str]`
+     - `check_rate_limit() -> RateLimitStatus`
    - `anthropic.py` — Anthropic adapter using `anthropic` SDK
+     - Catch `anthropic.RateLimitError` and return `RateLimitStatus(is_limited=True)` from `check_rate_limit()`
+     - Catch `anthropic.APIError` in `complete()` and re-raise as a common `ProviderError`
    - `openai.py` — OpenAI adapter using `openai` SDK
+     - Catch `openai.RateLimitError` and return `RateLimitStatus(is_limited=True)` from `check_rate_limit()`
+     - Catch `openai.APIError` in `complete()` and re-raise as a common `ProviderError`
    - `ollama.py` — Ollama adapter using HTTP calls to local Ollama server
+     - Check HTTP response status codes — raise `ProviderError` on non-2xx responses
+     - `check_rate_limit()` always returns `is_limited=False` (local, no limits)
    - All adapters return a unified `CompletionResult` response shape
+   - `ProviderError` custom exception defined in `base.py` for uniform error handling
 
 2. **Rate Limit Tracker** (`app/dial_system/rate_limiter.py`):
    - Track token counts and request counts per provider using Redis
    - `RateLimitStatus` with `is_limited`, `remaining_tokens`, `remaining_requests`, `reset_at`
    - Sliding window counter using Redis sorted sets
+   - `record_usage(provider, tokens)` — called by the router after each successful completion
+   - `check(provider) -> RateLimitStatus` — called by the router before attempting a provider
+   - `cleanup(provider)` — remove expired window entries
 
-3. **DialSystemRouter** (`app/dial_system/router.py`):
-   - `route(role, messages, **kwargs)` — look up provider for role from config, call adapter
-   - `stream(role, messages, **kwargs)` — same but returns SSE token stream
-   - Config-driven mapping: reads from `DialConfig` DB model per voyage
-   - Failover chain: primary -> fallback -> park (raises if all exhausted)
-   - Publishes `ProviderSwitchedEvent` via Den Den Mushi on failover
+3. **Adapter Factory** (`app/dial_system/factory.py`):
+   - `create_adapter(provider: str, model: str, settings: Settings) -> ProviderAdapter`
+     - `"anthropic"` → `AnthropicAdapter(AsyncAnthropic(api_key=settings.anthropic_api_key), model)`
+     - `"openai"` → `OpenAIAdapter(AsyncOpenAI(api_key=settings.openai_api_key), model)`
+     - `"ollama"` → `OllamaAdapter(httpx.AsyncClient(), model, settings.ollama_base_url)`
+     - Raise `ValueError` for unknown provider names
+   - `build_router_from_config(config: DialConfig, settings: Settings, mushi: DenDenMushi, rate_limiter: RateLimiter) -> DialSystemRouter`
+     - Read `config.role_mapping` JSONB → create primary adapter per role
+     - Read `config.fallback_chain` JSONB → create fallback adapter lists per role
+     - Return a fully wired `DialSystemRouter`
+   - No global adapter instances — adapters are created per-request from config
 
-4. **Schemas** (`app/schemas/dial_system.py`):
-   - `CompletionRequest` — messages, role, voyage_id, model overrides
-   - `CompletionResult` — content, provider, model, usage (tokens)
-   - `RateLimitStatus` — is_limited, remaining_tokens, remaining_requests, reset_at
-   - `ProviderConfig` — provider name, model, api_key reference, max_tokens
+4. **DialSystemRouter** (`app/dial_system/router.py`):
+   - `route(role, request) -> CompletionResult`:
+     - Check rate limiter before calling primary provider
+     - On rate limit or `ProviderError`, try fallback chain in order
+     - After each successful completion, call `rate_limiter.record_usage()`
+     - Publish `ProviderSwitchedEvent` via Den Den Mushi when failover occurs
+     - Raise `RuntimeError("All providers exhausted")` if all fail
+   - `stream(role, request) -> AsyncIterator[str]`:
+     - Same failover logic as `route()` — check rate limit, try primary, then fallbacks
+     - On rate limit or `ProviderError` from primary, failover to next provider's `stream()`
+     - Publish `ProviderSwitchedEvent` on failover
+   - Constructor takes `role_mapping`, `fallback_chains`, `mushi`, `voyage_id`, `rate_limiter`
 
-5. **REST API** (`app/api/v1/dial.py`):
+5. **Schemas** (`app/schemas/dial_system.py`):
+   - `CompletionRequest` — `messages`, `role` (CrewRole), `voyage_id` (UUID), `max_tokens`, `temperature`, `extra`
+   - `CompletionResult` — `content`, `provider`, `model`, `usage` (TokenUsage)
+   - `TokenUsage` — `prompt_tokens`, `completion_tokens`, `total_tokens`
+   - `RateLimitStatus` — `is_limited`, `remaining_tokens`, `remaining_requests`, `reset_at`
+   - `ProviderConfig` — `provider` name, `model`, `max_tokens`
+
+6. **REST API** (`app/api/v1/dial.py`):
    - `GET /api/v1/voyages/{voyage_id}/dial-config` — get current config
    - `PUT /api/v1/voyages/{voyage_id}/dial-config` — update config (takes effect on next call)
+   - `POST /api/v1/voyages/{voyage_id}/completions` — run a completion through the dial system
+     - Request body: `CompletionRequest` (messages, role, max_tokens, temperature)
+     - Returns: `CompletionResult`
+   - `POST /api/v1/voyages/{voyage_id}/completions/stream` — SSE streaming endpoint
+     - Request body: same as completions
+     - Returns: `StreamingResponse` with `media_type="text/event-stream"`
+     - Each token sent as `data: {token}\n\n`
 
-6. **FastAPI Integration**:
-   - Add `get_dial_router` dependency in `dependencies.py`
-   - Provider API keys via Settings (GRANDLINE_ANTHROPIC_API_KEY, GRANDLINE_OPENAI_API_KEY, GRANDLINE_OLLAMA_BASE_URL)
+7. **FastAPI Integration**:
+   - `get_dial_router(voyage_id, session, mushi, redis)` dependency in `dependencies.py`:
+     - Fetch `DialConfig` from DB by `voyage_id`
+     - Create `RateLimiter` from Redis
+     - Call `build_router_from_config()` to construct the fully wired router
+     - Raise 404 if no config found
+   - Provider API keys via Settings: `GRANDLINE_ANTHROPIC_API_KEY`, `GRANDLINE_OPENAI_API_KEY`, `GRANDLINE_OLLAMA_BASE_URL`
 
 ## Input
 
@@ -73,8 +117,25 @@ Implement a provider-agnostic LLM gateway with config-driven routing per crew ro
 - `role_mapping` JSONB shape: `{"captain": {"provider": "anthropic", "model": "claude-sonnet-4-20250514"}, ...}`
 - `fallback_chain` JSONB shape: `{"captain": ["openai", "ollama"], ...}`
 - Rate limits tracked in Redis with TTL-based sliding windows
-- SSE streaming uses `text/event-stream` content type
+- SSE streaming uses `text/event-stream` content type with `data: {token}\n\n` format
 - All providers must return the same `CompletionResult` shape
 - Failover is transparent to the caller — same interface, different backend
+- Failover applies to BOTH `route()` and `stream()` — not just route
 - Integration tests marked with `@pytest.mark.integration`
-- No global adapter instances — adapters created per-request from config
+- No global adapter instances — adapters created per-request from config via factory
+- Ollama adapter must check HTTP status codes and raise on errors
+- Provider SDK errors (RateLimitError, APIError) must be caught and handled uniformly
+
+## Edge Cases
+
+- Unknown provider name in `role_mapping` → `ValueError` from factory
+- Empty `role_mapping` for a voyage → `ValueError` when routing
+- Provider returns empty content → return empty string, don't crash
+- Provider SDK raises `RateLimitError` mid-request → catch, mark rate-limited, failover
+- All providers in fallback chain rate-limited → `RuntimeError("All providers exhausted")`
+- `fallback_chain` is `None` or missing for a role → no fallback, fail immediately after primary
+- Ollama server unreachable → `ProviderError`, triggers failover
+- Malformed `role_mapping` JSONB (missing "provider" or "model" keys) → `ValueError` from factory
+- Config updated via PUT while a request is in-flight → safe, next request picks up new config
+- SSE stream client disconnects mid-stream → generator cleanup, no crash
+- `CompletionRequest` with empty messages list → let provider SDK handle validation

--- a/pdd/prompts/features/dial-system/grandline-06-llm-gateway.md
+++ b/pdd/prompts/features/dial-system/grandline-06-llm-gateway.md
@@ -1,0 +1,80 @@
+# Prompt: Dial System (LLM Gateway)
+
+**File**: pdd/prompts/features/dial-system/grandline-06-llm-gateway.md
+**Created**: 2026-04-05
+**Depends on**: Phase 3 (DialConfig model + schema), Phase 5 (Den Den Mushi events)
+**Project type**: Backend (FastAPI + LLM SDKs)
+
+## Context
+
+GrandLine is a One Piece-themed multi-agent orchestration platform. Phases 1-5 delivered Docker infrastructure, database models, JWT auth, and the Den Den Mushi message bus. The `DialConfig` model stores per-voyage provider/model mappings as JSONB. The `ProviderSwitchedEvent` is already defined in the Den Den Mushi event system.
+
+In One Piece, Dials are shell-shaped devices from Skypiea that store and release different types of energy. Here, the Dial System is the LLM gateway that routes, buffers, and relays AI provider calls — each crew role can be configured to use a different provider/model combination, with automatic failover when limits are hit.
+
+## Task
+
+Implement a provider-agnostic LLM gateway with config-driven routing per crew role:
+
+1. **Provider Adapters** (`app/dial_system/adapters/`):
+   - `base.py` — `ProviderAdapter` ABC with `complete(messages, **kwargs) -> CompletionResult`, `stream(messages, **kwargs) -> AsyncIterator[str]`, `check_rate_limit() -> RateLimitStatus`
+   - `anthropic.py` — Anthropic adapter using `anthropic` SDK
+   - `openai.py` — OpenAI adapter using `openai` SDK
+   - `ollama.py` — Ollama adapter using HTTP calls to local Ollama server
+   - All adapters return a unified `CompletionResult` response shape
+
+2. **Rate Limit Tracker** (`app/dial_system/rate_limiter.py`):
+   - Track token counts and request counts per provider using Redis
+   - `RateLimitStatus` with `is_limited`, `remaining_tokens`, `remaining_requests`, `reset_at`
+   - Sliding window counter using Redis sorted sets
+
+3. **DialSystemRouter** (`app/dial_system/router.py`):
+   - `route(role, messages, **kwargs)` — look up provider for role from config, call adapter
+   - `stream(role, messages, **kwargs)` — same but returns SSE token stream
+   - Config-driven mapping: reads from `DialConfig` DB model per voyage
+   - Failover chain: primary -> fallback -> park (raises if all exhausted)
+   - Publishes `ProviderSwitchedEvent` via Den Den Mushi on failover
+
+4. **Schemas** (`app/schemas/dial_system.py`):
+   - `CompletionRequest` — messages, role, voyage_id, model overrides
+   - `CompletionResult` — content, provider, model, usage (tokens)
+   - `RateLimitStatus` — is_limited, remaining_tokens, remaining_requests, reset_at
+   - `ProviderConfig` — provider name, model, api_key reference, max_tokens
+
+5. **REST API** (`app/api/v1/dial.py`):
+   - `GET /api/v1/voyages/{voyage_id}/dial-config` — get current config
+   - `PUT /api/v1/voyages/{voyage_id}/dial-config` — update config (takes effect on next call)
+
+6. **FastAPI Integration**:
+   - Add `get_dial_router` dependency in `dependencies.py`
+   - Provider API keys via Settings (GRANDLINE_ANTHROPIC_API_KEY, GRANDLINE_OPENAI_API_KEY, GRANDLINE_OLLAMA_BASE_URL)
+
+## Input
+
+- Existing `DialConfig` model at `src/backend/app/models/dial_config.py` (JSONB role_mapping + fallback_chain)
+- Existing `DialConfigCreate/Update/Read` schemas at `src/backend/app/schemas/dial_config.py`
+- Existing `ProviderSwitchedEvent` at `src/backend/app/den_den_mushi/events.py`
+- Existing `DenDenMushi` class at `src/backend/app/den_den_mushi/mushi.py`
+- Existing `CrewRole` enum: captain, navigator, doctor, shipwright, helmsman
+- Existing `Settings` at `src/backend/app/core/config.py` (pydantic-settings, GRANDLINE_ prefix)
+
+## Output format
+
+- Python files following existing conventions (async, type-annotated, Pydantic v2)
+- New `dial_system/` package under `src/backend/app/`
+- Adapters under `dial_system/adapters/` subpackage
+- Unit tests with mocked provider SDKs (AsyncMock) + integration tests with real Ollama (if available)
+- All new files under `src/backend/app/` and `src/backend/tests/`
+
+## Constraints
+
+- Add `anthropic>=0.40.0` and `openai>=1.50.0` to requirements.txt
+- Ollama adapter uses `httpx` (already a dependency) — no extra SDK needed
+- Provider API keys stored in environment, never in DB or code
+- `role_mapping` JSONB shape: `{"captain": {"provider": "anthropic", "model": "claude-sonnet-4-20250514"}, ...}`
+- `fallback_chain` JSONB shape: `{"captain": ["openai", "ollama"], ...}`
+- Rate limits tracked in Redis with TTL-based sliding windows
+- SSE streaming uses `text/event-stream` content type
+- All providers must return the same `CompletionResult` shape
+- Failover is transparent to the caller — same interface, different backend
+- Integration tests marked with `@pytest.mark.integration`
+- No global adapter instances — adapters created per-request from config

--- a/src/backend/app/api/v1/dependencies.py
+++ b/src/backend/app/api/v1/dependencies.py
@@ -12,7 +12,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.config import settings
 from app.core.security import JWTError, decode_token
 from app.den_den_mushi.mushi import DenDenMushi
+from app.dial_system.factory import build_router_from_config
+from app.dial_system.rate_limiter import RateLimiter
+from app.dial_system.router import DialSystemRouter
 from app.models import get_db
+from app.models.dial_config import DialConfig
 from app.models.user import User
 
 bearer_scheme = HTTPBearer(auto_error=False)
@@ -76,3 +80,20 @@ async def get_current_user(
         )
 
     return user
+
+
+async def get_dial_router(
+    voyage_id: uuid.UUID,
+    session: AsyncSession = Depends(get_db),
+    mushi: DenDenMushi = Depends(get_den_den_mushi),
+    redis: Redis = Depends(get_redis),
+) -> DialSystemRouter:
+    result = await session.execute(select(DialConfig).where(DialConfig.voyage_id == voyage_id))
+    config = result.scalar_one_or_none()
+    if config is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Dial config not found for this voyage",
+        )
+    rate_limiter = RateLimiter(redis)
+    return build_router_from_config(config, settings, mushi, rate_limiter)

--- a/src/backend/app/api/v1/dependencies.py
+++ b/src/backend/app/api/v1/dependencies.py
@@ -18,6 +18,7 @@ from app.dial_system.router import DialSystemRouter
 from app.models import get_db
 from app.models.dial_config import DialConfig
 from app.models.user import User
+from app.models.voyage import Voyage
 
 bearer_scheme = HTTPBearer(auto_error=False)
 
@@ -82,12 +83,30 @@ async def get_current_user(
     return user
 
 
+async def get_authorized_voyage(
+    voyage_id: uuid.UUID,
+    session: AsyncSession = Depends(get_db),
+    user: User = Depends(get_current_user),
+) -> Voyage:
+    result = await session.execute(
+        select(Voyage).where(Voyage.id == voyage_id, Voyage.user_id == user.id)
+    )
+    voyage = result.scalar_one_or_none()
+    if voyage is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Voyage not found",
+        )
+    return voyage
+
+
 async def get_dial_router(
     voyage_id: uuid.UUID,
     session: AsyncSession = Depends(get_db),
+    _voyage: Voyage = Depends(get_authorized_voyage),
     mushi: DenDenMushi = Depends(get_den_den_mushi),
     redis: Redis = Depends(get_redis),
-) -> DialSystemRouter:
+) -> AsyncGenerator[DialSystemRouter, None]:
     result = await session.execute(select(DialConfig).where(DialConfig.voyage_id == voyage_id))
     config = result.scalar_one_or_none()
     if config is None:
@@ -96,4 +115,8 @@ async def get_dial_router(
             detail="Dial config not found for this voyage",
         )
     rate_limiter = RateLimiter(redis)
-    return build_router_from_config(config, settings, mushi, rate_limiter)
+    router = build_router_from_config(config, settings, mushi, rate_limiter)
+    try:
+        yield router
+    finally:
+        await router.close()

--- a/src/backend/app/api/v1/dial.py
+++ b/src/backend/app/api/v1/dial.py
@@ -8,11 +8,11 @@ from fastapi.responses import StreamingResponse
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.api.v1.dependencies import get_current_user, get_dial_router
+from app.api.v1.dependencies import get_authorized_voyage, get_dial_router
 from app.dial_system.router import DialSystemRouter
 from app.models import get_db
 from app.models.dial_config import DialConfig
-from app.models.user import User
+from app.models.voyage import Voyage
 from app.schemas.dial_config import DialConfigRead, DialConfigUpdate
 from app.schemas.dial_system import CompletionRequest, CompletionResult
 
@@ -23,7 +23,7 @@ router = APIRouter(prefix="/voyages", tags=["dial-system"])
 async def get_dial_config(
     voyage_id: uuid.UUID,
     session: AsyncSession = Depends(get_db),
-    _user: User = Depends(get_current_user),
+    _voyage: Voyage = Depends(get_authorized_voyage),
 ) -> DialConfig:
     result = await session.execute(select(DialConfig).where(DialConfig.voyage_id == voyage_id))
     config = result.scalar_one_or_none()
@@ -37,7 +37,7 @@ async def update_dial_config(
     voyage_id: uuid.UUID,
     body: DialConfigUpdate,
     session: AsyncSession = Depends(get_db),
-    _user: User = Depends(get_current_user),
+    _voyage: Voyage = Depends(get_authorized_voyage),
 ) -> DialConfig:
     result = await session.execute(select(DialConfig).where(DialConfig.voyage_id == voyage_id))
     config = result.scalar_one_or_none()
@@ -62,7 +62,6 @@ async def create_completion(
     voyage_id: uuid.UUID,
     body: CompletionRequest,
     dial_router: DialSystemRouter = Depends(get_dial_router),
-    _user: User = Depends(get_current_user),
 ) -> CompletionResult:
     return await dial_router.route(body.role, body)
 
@@ -72,7 +71,6 @@ async def create_completion_stream(
     voyage_id: uuid.UUID,
     body: CompletionRequest,
     dial_router: DialSystemRouter = Depends(get_dial_router),
-    _user: User = Depends(get_current_user),
 ) -> StreamingResponse:
     async def generate() -> AsyncIterator[str]:
         async for token in dial_router.stream(body.role, body):

--- a/src/backend/app/api/v1/dial.py
+++ b/src/backend/app/api/v1/dial.py
@@ -1,16 +1,20 @@
 from __future__ import annotations
 
 import uuid
+from collections.abc import AsyncIterator
 
 from fastapi import APIRouter, Depends, HTTPException
+from fastapi.responses import StreamingResponse
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.api.v1.dependencies import get_current_user
+from app.api.v1.dependencies import get_current_user, get_dial_router
+from app.dial_system.router import DialSystemRouter
 from app.models import get_db
 from app.models.dial_config import DialConfig
 from app.models.user import User
 from app.schemas.dial_config import DialConfigRead, DialConfigUpdate
+from app.schemas.dial_system import CompletionRequest, CompletionResult
 
 router = APIRouter(prefix="/voyages", tags=["dial-system"])
 
@@ -48,3 +52,30 @@ async def update_dial_config(
     await session.commit()
     await session.refresh(config)
     return config
+
+
+@router.post(
+    "/{voyage_id}/completions",
+    response_model=CompletionResult,
+)
+async def create_completion(
+    voyage_id: uuid.UUID,
+    body: CompletionRequest,
+    dial_router: DialSystemRouter = Depends(get_dial_router),
+    _user: User = Depends(get_current_user),
+) -> CompletionResult:
+    return await dial_router.route(body.role, body)
+
+
+@router.post("/{voyage_id}/completions/stream")
+async def create_completion_stream(
+    voyage_id: uuid.UUID,
+    body: CompletionRequest,
+    dial_router: DialSystemRouter = Depends(get_dial_router),
+    _user: User = Depends(get_current_user),
+) -> StreamingResponse:
+    async def generate() -> AsyncIterator[str]:
+        async for token in dial_router.stream(body.role, body):
+            yield f"data: {token}\n\n"
+
+    return StreamingResponse(generate(), media_type="text/event-stream")

--- a/src/backend/app/api/v1/dial.py
+++ b/src/backend/app/api/v1/dial.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.v1.dependencies import get_current_user
+from app.models import get_db
+from app.models.dial_config import DialConfig
+from app.models.user import User
+from app.schemas.dial_config import DialConfigRead, DialConfigUpdate
+
+router = APIRouter(prefix="/voyages", tags=["dial-system"])
+
+
+@router.get("/{voyage_id}/dial-config", response_model=DialConfigRead)
+async def get_dial_config(
+    voyage_id: uuid.UUID,
+    session: AsyncSession = Depends(get_db),
+    _user: User = Depends(get_current_user),
+) -> DialConfig:
+    result = await session.execute(select(DialConfig).where(DialConfig.voyage_id == voyage_id))
+    config = result.scalar_one_or_none()
+    if config is None:
+        raise HTTPException(status_code=404, detail="Dial config not found for this voyage")
+    return config
+
+
+@router.put("/{voyage_id}/dial-config", response_model=DialConfigRead)
+async def update_dial_config(
+    voyage_id: uuid.UUID,
+    body: DialConfigUpdate,
+    session: AsyncSession = Depends(get_db),
+    _user: User = Depends(get_current_user),
+) -> DialConfig:
+    result = await session.execute(select(DialConfig).where(DialConfig.voyage_id == voyage_id))
+    config = result.scalar_one_or_none()
+    if config is None:
+        raise HTTPException(status_code=404, detail="Dial config not found for this voyage")
+
+    if body.role_mapping is not None:
+        config.role_mapping = body.role_mapping
+    if body.fallback_chain is not None:
+        config.fallback_chain = body.fallback_chain
+
+    await session.commit()
+    await session.refresh(config)
+    return config

--- a/src/backend/app/api/v1/router.py
+++ b/src/backend/app/api/v1/router.py
@@ -1,8 +1,10 @@
 from fastapi import APIRouter
 
 from app.api.v1.auth import router as auth_router
+from app.api.v1.dial import router as dial_router
 from app.api.v1.health import router as health_router
 
 v1_router = APIRouter(prefix="/api/v1")
 v1_router.include_router(health_router, tags=["health"])
 v1_router.include_router(auth_router)
+v1_router.include_router(dial_router)

--- a/src/backend/app/core/config.py
+++ b/src/backend/app/core/config.py
@@ -18,6 +18,11 @@ class Settings(BaseSettings):
     access_token_expire_minutes: int = 30
     refresh_token_expire_minutes: int = 10080  # 7 days
 
+    # LLM Providers (Dial System)
+    anthropic_api_key: str = ""
+    openai_api_key: str = ""
+    ollama_base_url: str = "http://localhost:11434"
+
     # CORS
     cors_origins: list[str] = ["http://localhost:3000"]
 

--- a/src/backend/app/dial_system/adapters/anthropic.py
+++ b/src/backend/app/dial_system/adapters/anthropic.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
+import logging
 from collections.abc import AsyncIterator
 from typing import Any, cast
 
-from anthropic import AsyncAnthropic
+from anthropic import APIError, AsyncAnthropic, RateLimitError
 
-from app.dial_system.adapters.base import ProviderAdapter
+from app.dial_system.adapters.base import ProviderAdapter, ProviderError
 from app.schemas.dial_system import (
     CompletionRequest,
     CompletionResult,
@@ -13,19 +14,29 @@ from app.schemas.dial_system import (
     TokenUsage,
 )
 
+logger = logging.getLogger(__name__)
+
 
 class AnthropicAdapter(ProviderAdapter):
     def __init__(self, client: AsyncAnthropic, model: str) -> None:
         self._client = client
         self._model = model
+        self._rate_limited = False
 
     async def complete(self, request: CompletionRequest) -> CompletionResult:
-        response = await self._client.messages.create(
-            model=self._model,
-            messages=cast(Any, request.messages),
-            max_tokens=request.max_tokens,
-            temperature=request.temperature,
-        )
+        try:
+            response = await self._client.messages.create(
+                model=self._model,
+                messages=cast(Any, request.messages),
+                max_tokens=request.max_tokens,
+                temperature=request.temperature,
+            )
+        except RateLimitError as exc:
+            self._rate_limited = True
+            raise ProviderError(f"Anthropic rate limited: {exc}") from exc
+        except APIError as exc:
+            raise ProviderError(f"Anthropic API error: {exc}") from exc
+
         text_block = response.content[0]
         content: str = text_block.text  # type: ignore[union-attr]
         usage = response.usage
@@ -41,15 +52,21 @@ class AnthropicAdapter(ProviderAdapter):
         )
 
     async def stream(self, request: CompletionRequest) -> AsyncIterator[str]:
-        async with self._client.messages.stream(
-            model=self._model,
-            messages=cast(Any, request.messages),
-            max_tokens=request.max_tokens,
-            temperature=request.temperature,
-        ) as s:
-            async for event in s:
-                if event.type == "content_block_delta" and event.delta.type == "text_delta":
-                    yield event.delta.text
+        try:
+            async with self._client.messages.stream(
+                model=self._model,
+                messages=cast(Any, request.messages),
+                max_tokens=request.max_tokens,
+                temperature=request.temperature,
+            ) as s:
+                async for event in s:
+                    if event.type == "content_block_delta" and event.delta.type == "text_delta":
+                        yield event.delta.text
+        except RateLimitError as exc:
+            self._rate_limited = True
+            raise ProviderError(f"Anthropic rate limited: {exc}") from exc
+        except APIError as exc:
+            raise ProviderError(f"Anthropic API error: {exc}") from exc
 
     def check_rate_limit(self) -> RateLimitStatus:
-        return RateLimitStatus(is_limited=False)
+        return RateLimitStatus(is_limited=self._rate_limited)

--- a/src/backend/app/dial_system/adapters/anthropic.py
+++ b/src/backend/app/dial_system/adapters/anthropic.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any, cast
+
+from anthropic import AsyncAnthropic
+
+from app.dial_system.adapters.base import ProviderAdapter
+from app.schemas.dial_system import (
+    CompletionRequest,
+    CompletionResult,
+    RateLimitStatus,
+    TokenUsage,
+)
+
+
+class AnthropicAdapter(ProviderAdapter):
+    def __init__(self, client: AsyncAnthropic, model: str) -> None:
+        self._client = client
+        self._model = model
+
+    async def complete(self, request: CompletionRequest) -> CompletionResult:
+        response = await self._client.messages.create(
+            model=self._model,
+            messages=cast(Any, request.messages),
+            max_tokens=request.max_tokens,
+            temperature=request.temperature,
+        )
+        text_block = response.content[0]
+        content: str = text_block.text  # type: ignore[union-attr]
+        usage = response.usage
+        return CompletionResult(
+            content=content,
+            provider="anthropic",
+            model=response.model,
+            usage=TokenUsage(
+                prompt_tokens=usage.input_tokens,
+                completion_tokens=usage.output_tokens,
+                total_tokens=usage.input_tokens + usage.output_tokens,
+            ),
+        )
+
+    async def stream(self, request: CompletionRequest) -> AsyncIterator[str]:
+        async with self._client.messages.stream(
+            model=self._model,
+            messages=cast(Any, request.messages),
+            max_tokens=request.max_tokens,
+            temperature=request.temperature,
+        ) as s:
+            async for event in s:
+                if event.type == "content_block_delta" and event.delta.type == "text_delta":
+                    yield event.delta.text
+
+    def check_rate_limit(self) -> RateLimitStatus:
+        return RateLimitStatus(is_limited=False)

--- a/src/backend/app/dial_system/adapters/base.py
+++ b/src/backend/app/dial_system/adapters/base.py
@@ -6,6 +6,10 @@ from collections.abc import AsyncIterator
 from app.schemas.dial_system import CompletionRequest, CompletionResult, RateLimitStatus
 
 
+class ProviderError(Exception):
+    """Raised when a provider fails in a way that should trigger failover."""
+
+
 class ProviderAdapter(ABC):
     @abstractmethod
     async def complete(self, request: CompletionRequest) -> CompletionResult: ...

--- a/src/backend/app/dial_system/adapters/base.py
+++ b/src/backend/app/dial_system/adapters/base.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import AsyncIterator
+
+from app.schemas.dial_system import CompletionRequest, CompletionResult, RateLimitStatus
+
+
+class ProviderAdapter(ABC):
+    @abstractmethod
+    async def complete(self, request: CompletionRequest) -> CompletionResult: ...
+
+    @abstractmethod
+    def stream(self, request: CompletionRequest) -> AsyncIterator[str]: ...
+
+    @abstractmethod
+    def check_rate_limit(self) -> RateLimitStatus: ...

--- a/src/backend/app/dial_system/adapters/ollama.py
+++ b/src/backend/app/dial_system/adapters/ollama.py
@@ -1,17 +1,20 @@
 from __future__ import annotations
 
 import json
+import logging
 from collections.abc import AsyncIterator
 
 import httpx
 
-from app.dial_system.adapters.base import ProviderAdapter
+from app.dial_system.adapters.base import ProviderAdapter, ProviderError
 from app.schemas.dial_system import (
     CompletionRequest,
     CompletionResult,
     RateLimitStatus,
     TokenUsage,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class OllamaAdapter(ProviderAdapter):
@@ -21,18 +24,25 @@ class OllamaAdapter(ProviderAdapter):
         self._base_url = base_url
 
     async def complete(self, request: CompletionRequest) -> CompletionResult:
-        response = await self._client.post(
-            f"{self._base_url}/api/chat",
-            json={
-                "model": self._model,
-                "messages": request.messages,
-                "stream": False,
-                "options": {
-                    "num_predict": request.max_tokens,
-                    "temperature": request.temperature,
+        try:
+            response = await self._client.post(
+                f"{self._base_url}/api/chat",
+                json={
+                    "model": self._model,
+                    "messages": request.messages,
+                    "stream": False,
+                    "options": {
+                        "num_predict": request.max_tokens,
+                        "temperature": request.temperature,
+                    },
                 },
-            },
-        )
+            )
+        except httpx.HTTPError as exc:
+            raise ProviderError(f"Ollama connection error: {exc}") from exc
+
+        if response.status_code != 200:
+            raise ProviderError(f"Ollama returned HTTP {response.status_code}: {response.text}")
+
         data = response.json()
         prompt_tokens = data.get("prompt_eval_count", 0)
         completion_tokens = data.get("eval_count", 0)
@@ -48,26 +58,34 @@ class OllamaAdapter(ProviderAdapter):
         )
 
     async def stream(self, request: CompletionRequest) -> AsyncIterator[str]:
-        async with self._client.stream(
-            "POST",
-            f"{self._base_url}/api/chat",
-            json={
-                "model": self._model,
-                "messages": request.messages,
-                "stream": True,
-                "options": {
-                    "num_predict": request.max_tokens,
-                    "temperature": request.temperature,
+        try:
+            async with self._client.stream(
+                "POST",
+                f"{self._base_url}/api/chat",
+                json={
+                    "model": self._model,
+                    "messages": request.messages,
+                    "stream": True,
+                    "options": {
+                        "num_predict": request.max_tokens,
+                        "temperature": request.temperature,
+                    },
                 },
-            },
-        ) as response:
-            async for line in response.aiter_lines():
-                chunk = json.loads(line)
-                if chunk.get("done"):
-                    break
-                content = chunk.get("message", {}).get("content", "")
-                if content:
-                    yield content
+            ) as response:
+                if response.status_code != 200:
+                    body = await response.aread()
+                    raise ProviderError(
+                        f"Ollama returned HTTP {response.status_code}: {body.decode()}"
+                    )
+                async for line in response.aiter_lines():
+                    chunk = json.loads(line)
+                    if chunk.get("done"):
+                        break
+                    content = chunk.get("message", {}).get("content", "")
+                    if content:
+                        yield content
+        except httpx.HTTPError as exc:
+            raise ProviderError(f"Ollama connection error: {exc}") from exc
 
     def check_rate_limit(self) -> RateLimitStatus:
         return RateLimitStatus(is_limited=False)

--- a/src/backend/app/dial_system/adapters/ollama.py
+++ b/src/backend/app/dial_system/adapters/ollama.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator
+
+import httpx
+
+from app.dial_system.adapters.base import ProviderAdapter
+from app.schemas.dial_system import (
+    CompletionRequest,
+    CompletionResult,
+    RateLimitStatus,
+    TokenUsage,
+)
+
+
+class OllamaAdapter(ProviderAdapter):
+    def __init__(self, client: httpx.AsyncClient, model: str, base_url: str) -> None:
+        self._client = client
+        self._model = model
+        self._base_url = base_url
+
+    async def complete(self, request: CompletionRequest) -> CompletionResult:
+        response = await self._client.post(
+            f"{self._base_url}/api/chat",
+            json={
+                "model": self._model,
+                "messages": request.messages,
+                "stream": False,
+                "options": {
+                    "num_predict": request.max_tokens,
+                    "temperature": request.temperature,
+                },
+            },
+        )
+        data = response.json()
+        prompt_tokens = data.get("prompt_eval_count", 0)
+        completion_tokens = data.get("eval_count", 0)
+        return CompletionResult(
+            content=data["message"]["content"],
+            provider="ollama",
+            model=data["model"],
+            usage=TokenUsage(
+                prompt_tokens=prompt_tokens,
+                completion_tokens=completion_tokens,
+                total_tokens=prompt_tokens + completion_tokens,
+            ),
+        )
+
+    async def stream(self, request: CompletionRequest) -> AsyncIterator[str]:
+        async with self._client.stream(
+            "POST",
+            f"{self._base_url}/api/chat",
+            json={
+                "model": self._model,
+                "messages": request.messages,
+                "stream": True,
+                "options": {
+                    "num_predict": request.max_tokens,
+                    "temperature": request.temperature,
+                },
+            },
+        ) as response:
+            async for line in response.aiter_lines():
+                chunk = json.loads(line)
+                if chunk.get("done"):
+                    break
+                content = chunk.get("message", {}).get("content", "")
+                if content:
+                    yield content
+
+    def check_rate_limit(self) -> RateLimitStatus:
+        return RateLimitStatus(is_limited=False)

--- a/src/backend/app/dial_system/adapters/openai.py
+++ b/src/backend/app/dial_system/adapters/openai.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
+import logging
 from collections.abc import AsyncIterator
 from typing import Any, cast
 
-from openai import AsyncOpenAI
+from openai import APIError, AsyncOpenAI, RateLimitError
 
-from app.dial_system.adapters.base import ProviderAdapter
+from app.dial_system.adapters.base import ProviderAdapter, ProviderError
 from app.schemas.dial_system import (
     CompletionRequest,
     CompletionResult,
@@ -13,19 +14,29 @@ from app.schemas.dial_system import (
     TokenUsage,
 )
 
+logger = logging.getLogger(__name__)
+
 
 class OpenAIAdapter(ProviderAdapter):
     def __init__(self, client: AsyncOpenAI, model: str) -> None:
         self._client = client
         self._model = model
+        self._rate_limited = False
 
     async def complete(self, request: CompletionRequest) -> CompletionResult:
-        response = await self._client.chat.completions.create(
-            model=self._model,
-            messages=cast(Any, request.messages),
-            max_tokens=request.max_tokens,
-            temperature=request.temperature,
-        )
+        try:
+            response = await self._client.chat.completions.create(
+                model=self._model,
+                messages=cast(Any, request.messages),
+                max_tokens=request.max_tokens,
+                temperature=request.temperature,
+            )
+        except RateLimitError as exc:
+            self._rate_limited = True
+            raise ProviderError(f"OpenAI rate limited: {exc}") from exc
+        except APIError as exc:
+            raise ProviderError(f"OpenAI API error: {exc}") from exc
+
         content = response.choices[0].message.content or ""
         usage = response.usage
         return CompletionResult(
@@ -40,17 +51,23 @@ class OpenAIAdapter(ProviderAdapter):
         )
 
     async def stream(self, request: CompletionRequest) -> AsyncIterator[str]:
-        response = await self._client.chat.completions.create(
-            model=self._model,
-            messages=cast(Any, request.messages),
-            max_tokens=request.max_tokens,
-            temperature=request.temperature,
-            stream=True,
-        )
-        async for chunk in response:
-            delta = chunk.choices[0].delta
-            if delta.content is not None:
-                yield delta.content
+        try:
+            response = await self._client.chat.completions.create(
+                model=self._model,
+                messages=cast(Any, request.messages),
+                max_tokens=request.max_tokens,
+                temperature=request.temperature,
+                stream=True,
+            )
+            async for chunk in response:
+                delta = chunk.choices[0].delta
+                if delta.content is not None:
+                    yield delta.content
+        except RateLimitError as exc:
+            self._rate_limited = True
+            raise ProviderError(f"OpenAI rate limited: {exc}") from exc
+        except APIError as exc:
+            raise ProviderError(f"OpenAI API error: {exc}") from exc
 
     def check_rate_limit(self) -> RateLimitStatus:
-        return RateLimitStatus(is_limited=False)
+        return RateLimitStatus(is_limited=self._rate_limited)

--- a/src/backend/app/dial_system/adapters/openai.py
+++ b/src/backend/app/dial_system/adapters/openai.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any, cast
+
+from openai import AsyncOpenAI
+
+from app.dial_system.adapters.base import ProviderAdapter
+from app.schemas.dial_system import (
+    CompletionRequest,
+    CompletionResult,
+    RateLimitStatus,
+    TokenUsage,
+)
+
+
+class OpenAIAdapter(ProviderAdapter):
+    def __init__(self, client: AsyncOpenAI, model: str) -> None:
+        self._client = client
+        self._model = model
+
+    async def complete(self, request: CompletionRequest) -> CompletionResult:
+        response = await self._client.chat.completions.create(
+            model=self._model,
+            messages=cast(Any, request.messages),
+            max_tokens=request.max_tokens,
+            temperature=request.temperature,
+        )
+        content = response.choices[0].message.content or ""
+        usage = response.usage
+        return CompletionResult(
+            content=content,
+            provider="openai",
+            model=response.model,
+            usage=TokenUsage(
+                prompt_tokens=usage.prompt_tokens if usage else 0,
+                completion_tokens=usage.completion_tokens if usage else 0,
+                total_tokens=usage.total_tokens if usage else 0,
+            ),
+        )
+
+    async def stream(self, request: CompletionRequest) -> AsyncIterator[str]:
+        response = await self._client.chat.completions.create(
+            model=self._model,
+            messages=cast(Any, request.messages),
+            max_tokens=request.max_tokens,
+            temperature=request.temperature,
+            stream=True,
+        )
+        async for chunk in response:
+            delta = chunk.choices[0].delta
+            if delta.content is not None:
+                yield delta.content
+
+    def check_rate_limit(self) -> RateLimitStatus:
+        return RateLimitStatus(is_limited=False)

--- a/src/backend/app/dial_system/factory.py
+++ b/src/backend/app/dial_system/factory.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+from anthropic import AsyncAnthropic
+from openai import AsyncOpenAI
+
+from app.core.config import Settings
+from app.den_den_mushi.mushi import DenDenMushi
+from app.dial_system.adapters.anthropic import AnthropicAdapter
+from app.dial_system.adapters.base import ProviderAdapter
+from app.dial_system.adapters.ollama import OllamaAdapter
+from app.dial_system.adapters.openai import OpenAIAdapter
+from app.dial_system.rate_limiter import RateLimiter
+from app.dial_system.router import DialSystemRouter
+from app.models.dial_config import DialConfig
+from app.models.enums import CrewRole
+
+
+def create_adapter(provider: str, model: str, settings: Settings) -> ProviderAdapter:
+    if provider == "anthropic":
+        return AnthropicAdapter(
+            client=AsyncAnthropic(api_key=settings.anthropic_api_key), model=model
+        )
+    elif provider == "openai":
+        return OpenAIAdapter(client=AsyncOpenAI(api_key=settings.openai_api_key), model=model)
+    elif provider == "ollama":
+        return OllamaAdapter(
+            client=httpx.AsyncClient(),
+            model=model,
+            base_url=settings.ollama_base_url,
+        )
+    else:
+        raise ValueError(f"Unknown provider: {provider!r}")
+
+
+def build_router_from_config(
+    config: DialConfig,
+    settings: Settings,
+    mushi: DenDenMushi,
+    rate_limiter: RateLimiter,
+) -> DialSystemRouter:
+    role_mapping: dict[CrewRole, ProviderAdapter] = {}
+    fallback_chains: dict[CrewRole, list[ProviderAdapter]] = {}
+
+    mapping: dict[str, Any] = config.role_mapping or {}
+    for role_str, provider_cfg in mapping.items():
+        role = CrewRole(role_str)
+        if not isinstance(provider_cfg, dict):
+            raise ValueError(f"Invalid config for role {role_str}: expected dict")
+        provider = provider_cfg.get("provider")
+        model = provider_cfg.get("model")
+        if not provider or not model:
+            raise ValueError(f"Missing 'provider' or 'model' in config for role {role_str}")
+        role_mapping[role] = create_adapter(provider, model, settings)
+
+    chains: dict[str, Any] = config.fallback_chain or {}
+    for role_str, fallback_providers in chains.items():
+        role = CrewRole(role_str)
+        adapters: list[ProviderAdapter] = []
+        default_model = mapping.get(role_str, {}).get("model", "default")
+        for fb_provider in fallback_providers:
+            adapters.append(create_adapter(fb_provider, default_model, settings))
+        fallback_chains[role] = adapters
+
+    return DialSystemRouter(
+        role_mapping=role_mapping,
+        fallback_chains=fallback_chains,
+        mushi=mushi,
+        voyage_id=config.voyage_id,
+        rate_limiter=rate_limiter,
+    )

--- a/src/backend/app/dial_system/rate_limiter.py
+++ b/src/backend/app/dial_system/rate_limiter.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import time
+
+from redis.asyncio import Redis
+
+from app.schemas.dial_system import RateLimitStatus
+
+WINDOW_SECONDS = 60
+KEY_PREFIX = "grandline:ratelimit"
+
+
+class RateLimiter:
+    def __init__(
+        self,
+        redis: Redis,
+        max_tokens_per_minute: int = 100_000,
+        max_requests_per_minute: int = 100,
+    ) -> None:
+        self._redis = redis
+        self._max_tokens = max_tokens_per_minute
+        self._max_requests = max_requests_per_minute
+
+    def _key(self, provider: str) -> str:
+        return f"{KEY_PREFIX}:{provider}"
+
+    async def record_usage(self, provider: str, tokens: int) -> None:
+        key = self._key(provider)
+        now = time.time()
+        member = f"{now}:{tokens}"
+        await self._redis.zadd(key, {member: now})
+        await self._redis.expire(key, WINDOW_SECONDS * 2)
+
+    async def check(self, provider: str) -> RateLimitStatus:
+        key = self._key(provider)
+        now = time.time()
+        window_start = now - WINDOW_SECONDS
+
+        # Get entries within the sliding window
+        entries = await self._redis.zrangebyscore(key, window_start, now, withscores=True)
+        request_count = await self._redis.zcount(key, window_start, now)
+
+        # Sum tokens from member names (format: "timestamp:tokens")
+        total_tokens = 0
+        for member, _score in entries:
+            parts = member.split(":")
+            if len(parts) >= 2:
+                try:
+                    total_tokens += int(parts[-1])
+                except ValueError:
+                    pass
+
+        tokens_limited = total_tokens >= self._max_tokens
+        requests_limited = request_count >= self._max_requests
+
+        return RateLimitStatus(
+            is_limited=tokens_limited or requests_limited,
+            remaining_tokens=max(0, self._max_tokens - total_tokens),
+            remaining_requests=max(0, self._max_requests - request_count),
+        )
+
+    async def cleanup(self, provider: str) -> int:
+        key = self._key(provider)
+        now = time.time()
+        window_start = now - WINDOW_SECONDS
+        removed: int = await self._redis.zremrangebyscore(key, 0, window_start)
+        return removed

--- a/src/backend/app/dial_system/router.py
+++ b/src/backend/app/dial_system/router.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import logging
+import uuid
+from collections.abc import AsyncIterator
+
+from app.den_den_mushi.constants import stream_key
+from app.den_den_mushi.events import ProviderSwitchedEvent
+from app.den_den_mushi.mushi import DenDenMushi
+from app.dial_system.adapters.base import ProviderAdapter
+from app.models.enums import CrewRole
+from app.schemas.dial_system import CompletionRequest, CompletionResult
+
+logger = logging.getLogger(__name__)
+
+
+class DialSystemRouter:
+    def __init__(
+        self,
+        role_mapping: dict[CrewRole, ProviderAdapter],
+        fallback_chains: dict[CrewRole, list[ProviderAdapter]],
+        mushi: DenDenMushi,
+        voyage_id: uuid.UUID,
+    ) -> None:
+        self._role_mapping = role_mapping
+        self._fallback_chains = fallback_chains
+        self._mushi = mushi
+        self._voyage_id = voyage_id
+
+    async def route(self, role: CrewRole, request: CompletionRequest) -> CompletionResult:
+        if role not in self._role_mapping:
+            raise ValueError(f"No provider configured for role {role.value}")
+
+        primary = self._role_mapping[role]
+
+        # Try primary adapter
+        if not primary.check_rate_limit().is_limited:
+            try:
+                return await primary.complete(request)
+            except Exception as exc:
+                logger.warning("Primary provider failed for %s: %s", role.value, exc)
+
+        # Failover to fallback chain
+        fallbacks = self._fallback_chains.get(role, [])
+        for fallback in fallbacks:
+            if fallback.check_rate_limit().is_limited:
+                continue
+            try:
+                result = await fallback.complete(request)
+                await self._publish_switch_event(role, result.provider)
+                return result
+            except Exception as exc:
+                logger.warning("Fallback provider failed for %s: %s", role.value, exc)
+
+        raise RuntimeError(f"All providers exhausted for role {role.value}")
+
+    async def stream(self, role: CrewRole, request: CompletionRequest) -> AsyncIterator[str]:
+        if role not in self._role_mapping:
+            raise ValueError(f"No provider configured for role {role.value}")
+
+        adapter = self._role_mapping[role]
+        async for token in adapter.stream(request):
+            yield token
+
+    async def _publish_switch_event(self, role: CrewRole, new_provider: str) -> None:
+        event = ProviderSwitchedEvent(
+            voyage_id=self._voyage_id,
+            source_role=role,
+            payload={"new_provider": new_provider},
+        )
+        stream = stream_key(self._voyage_id)
+        await self._mushi.publish(stream, event)

--- a/src/backend/app/dial_system/router.py
+++ b/src/backend/app/dial_system/router.py
@@ -30,6 +30,28 @@ class DialSystemRouter:
         self._voyage_id = voyage_id
         self._rate_limiter = rate_limiter
 
+    async def _is_rate_limited(self, adapter: ProviderAdapter) -> bool:
+        """Check both adapter-level and Redis-level rate limits."""
+        if adapter.check_rate_limit().is_limited:
+            return True
+        if self._rate_limiter:
+            provider_name = self._get_provider_name(adapter)
+            redis_status = await self._rate_limiter.check(provider_name)
+            if redis_status.is_limited:
+                return True
+        return False
+
+    def _get_provider_name(self, adapter: ProviderAdapter) -> str:
+        """Extract provider name from adapter class."""
+        cls_name = type(adapter).__name__.lower()
+        if "anthropic" in cls_name:
+            return "anthropic"
+        if "openai" in cls_name:
+            return "openai"
+        if "ollama" in cls_name:
+            return "ollama"
+        return "unknown"
+
     async def route(self, role: CrewRole, request: CompletionRequest) -> CompletionResult:
         if role not in self._role_mapping:
             raise ValueError(f"No provider configured for role {role.value}")
@@ -37,7 +59,7 @@ class DialSystemRouter:
         primary = self._role_mapping[role]
 
         # Try primary adapter
-        if not primary.check_rate_limit().is_limited:
+        if not await self._is_rate_limited(primary):
             try:
                 result = await primary.complete(request)
                 if self._rate_limiter:
@@ -51,7 +73,7 @@ class DialSystemRouter:
         # Failover to fallback chain
         fallbacks = self._fallback_chains.get(role, [])
         for fallback in fallbacks:
-            if fallback.check_rate_limit().is_limited:
+            if await self._is_rate_limited(fallback):
                 continue
             try:
                 result = await fallback.complete(request)
@@ -73,7 +95,7 @@ class DialSystemRouter:
         primary = self._role_mapping[role]
 
         # Try primary adapter
-        if not primary.check_rate_limit().is_limited:
+        if not await self._is_rate_limited(primary):
             try:
                 async for token in primary.stream(request):
                     yield token
@@ -84,7 +106,7 @@ class DialSystemRouter:
         # Failover to fallback chain
         fallbacks = self._fallback_chains.get(role, [])
         for fallback in fallbacks:
-            if fallback.check_rate_limit().is_limited:
+            if await self._is_rate_limited(fallback):
                 continue
             try:
                 await self._publish_switch_event(role, "fallback")
@@ -95,6 +117,18 @@ class DialSystemRouter:
                 logger.warning("Fallback stream failed for %s: %s", role.value, exc)
 
         raise RuntimeError(f"All providers exhausted for role {role.value}")
+
+    async def close(self) -> None:
+        """Close all adapter clients to prevent resource leaks."""
+        adapters = list(self._role_mapping.values())
+        for chain in self._fallback_chains.values():
+            adapters.extend(chain)
+        for adapter in adapters:
+            client = getattr(adapter, "_client", None)
+            if client is not None and hasattr(client, "close"):
+                await client.close()
+            elif client is not None and hasattr(client, "aclose"):
+                await client.aclose()
 
     async def _publish_switch_event(self, role: CrewRole, new_provider: str) -> None:
         event = ProviderSwitchedEvent(

--- a/src/backend/app/dial_system/router.py
+++ b/src/backend/app/dial_system/router.py
@@ -7,7 +7,8 @@ from collections.abc import AsyncIterator
 from app.den_den_mushi.constants import stream_key
 from app.den_den_mushi.events import ProviderSwitchedEvent
 from app.den_den_mushi.mushi import DenDenMushi
-from app.dial_system.adapters.base import ProviderAdapter
+from app.dial_system.adapters.base import ProviderAdapter, ProviderError
+from app.dial_system.rate_limiter import RateLimiter
 from app.models.enums import CrewRole
 from app.schemas.dial_system import CompletionRequest, CompletionResult
 
@@ -21,11 +22,13 @@ class DialSystemRouter:
         fallback_chains: dict[CrewRole, list[ProviderAdapter]],
         mushi: DenDenMushi,
         voyage_id: uuid.UUID,
+        rate_limiter: RateLimiter | None = None,
     ) -> None:
         self._role_mapping = role_mapping
         self._fallback_chains = fallback_chains
         self._mushi = mushi
         self._voyage_id = voyage_id
+        self._rate_limiter = rate_limiter
 
     async def route(self, role: CrewRole, request: CompletionRequest) -> CompletionResult:
         if role not in self._role_mapping:
@@ -36,8 +39,13 @@ class DialSystemRouter:
         # Try primary adapter
         if not primary.check_rate_limit().is_limited:
             try:
-                return await primary.complete(request)
-            except Exception as exc:
+                result = await primary.complete(request)
+                if self._rate_limiter:
+                    await self._rate_limiter.record_usage(
+                        result.provider, result.usage.total_tokens
+                    )
+                return result
+            except ProviderError as exc:
                 logger.warning("Primary provider failed for %s: %s", role.value, exc)
 
         # Failover to fallback chain
@@ -47,9 +55,13 @@ class DialSystemRouter:
                 continue
             try:
                 result = await fallback.complete(request)
+                if self._rate_limiter:
+                    await self._rate_limiter.record_usage(
+                        result.provider, result.usage.total_tokens
+                    )
                 await self._publish_switch_event(role, result.provider)
                 return result
-            except Exception as exc:
+            except ProviderError as exc:
                 logger.warning("Fallback provider failed for %s: %s", role.value, exc)
 
         raise RuntimeError(f"All providers exhausted for role {role.value}")
@@ -58,9 +70,31 @@ class DialSystemRouter:
         if role not in self._role_mapping:
             raise ValueError(f"No provider configured for role {role.value}")
 
-        adapter = self._role_mapping[role]
-        async for token in adapter.stream(request):
-            yield token
+        primary = self._role_mapping[role]
+
+        # Try primary adapter
+        if not primary.check_rate_limit().is_limited:
+            try:
+                async for token in primary.stream(request):
+                    yield token
+                return
+            except ProviderError as exc:
+                logger.warning("Primary stream failed for %s: %s", role.value, exc)
+
+        # Failover to fallback chain
+        fallbacks = self._fallback_chains.get(role, [])
+        for fallback in fallbacks:
+            if fallback.check_rate_limit().is_limited:
+                continue
+            try:
+                await self._publish_switch_event(role, "fallback")
+                async for token in fallback.stream(request):
+                    yield token
+                return
+            except ProviderError as exc:
+                logger.warning("Fallback stream failed for %s: %s", role.value, exc)
+
+        raise RuntimeError(f"All providers exhausted for role {role.value}")
 
     async def _publish_switch_event(self, role: CrewRole, new_provider: str) -> None:
         event = ProviderSwitchedEvent(

--- a/src/backend/app/schemas/dial_system.py
+++ b/src/backend/app/schemas/dial_system.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class ProviderConfig(BaseModel):
+    provider: str
+    model: str
+    max_tokens: int = 4096
+
+
+class CompletionRequest(BaseModel):
+    messages: list[dict[str, str]]
+    max_tokens: int = 4096
+    temperature: float = 1.0
+    extra: dict[str, Any] = Field(default_factory=dict)
+
+
+class TokenUsage(BaseModel):
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    total_tokens: int = 0
+
+
+class CompletionResult(BaseModel):
+    content: str
+    provider: str
+    model: str
+    usage: TokenUsage = Field(default_factory=TokenUsage)
+
+
+class RateLimitStatus(BaseModel):
+    is_limited: bool = False
+    remaining_tokens: int | None = None
+    remaining_requests: int | None = None
+    reset_at: datetime | None = None

--- a/src/backend/app/schemas/dial_system.py
+++ b/src/backend/app/schemas/dial_system.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import uuid
 from datetime import datetime
 from typing import Any
 
 from pydantic import BaseModel, Field
+
+from app.models.enums import CrewRole
 
 
 class ProviderConfig(BaseModel):
@@ -14,6 +17,8 @@ class ProviderConfig(BaseModel):
 
 class CompletionRequest(BaseModel):
     messages: list[dict[str, str]]
+    role: CrewRole
+    voyage_id: uuid.UUID | None = None
     max_tokens: int = 4096
     temperature: float = 1.0
     extra: dict[str, Any] = Field(default_factory=dict)

--- a/src/backend/requirements.txt
+++ b/src/backend/requirements.txt
@@ -16,6 +16,10 @@ email-validator==2.2.0
 # Redis
 redis==5.1.1
 
+# LLM Providers
+anthropic>=0.40.0
+openai>=1.50.0
+
 # Testing
 pytest==8.3.3
 pytest-asyncio==0.24.0

--- a/src/backend/tests/test_dial_adapters.py
+++ b/src/backend/tests/test_dial_adapters.py
@@ -5,17 +5,24 @@ from __future__ import annotations
 import json
 from unittest.mock import AsyncMock, MagicMock
 
+import httpx
 import pytest
+from anthropic import APIError as AnthropicAPIError
+from anthropic import RateLimitError as AnthropicRateLimitError
+from openai import RateLimitError as OpenAIRateLimitError
 
 from app.dial_system.adapters.anthropic import AnthropicAdapter
+from app.dial_system.adapters.base import ProviderError
 from app.dial_system.adapters.ollama import OllamaAdapter
 from app.dial_system.adapters.openai import OpenAIAdapter
+from app.models.enums import CrewRole
 from app.schemas.dial_system import CompletionRequest, CompletionResult
 
 
 def _make_request() -> CompletionRequest:
     return CompletionRequest(
         messages=[{"role": "user", "content": "Hello"}],
+        role=CrewRole.CAPTAIN,
         max_tokens=100,
         temperature=0.7,
     )
@@ -255,3 +262,92 @@ class TestOllamaAdapter:
         )
         status = adapter.check_rate_limit()
         assert status.is_limited is False
+
+    @pytest.mark.asyncio
+    async def test_complete_raises_provider_error_on_non_200(self) -> None:
+        mock_client = AsyncMock()
+        mock_response = MagicMock()
+        mock_response.status_code = 500
+        mock_response.text = "Internal Server Error"
+        mock_client.post.return_value = mock_response
+
+        adapter = OllamaAdapter(
+            client=mock_client, model="llama3", base_url="http://localhost:11434"
+        )
+
+        with pytest.raises(ProviderError, match="HTTP 500"):
+            await adapter.complete(_make_request())
+
+    @pytest.mark.asyncio
+    async def test_complete_raises_provider_error_on_connection_error(
+        self,
+    ) -> None:
+        mock_client = AsyncMock()
+        mock_client.post.side_effect = httpx.ConnectError("Connection refused")
+
+        adapter = OllamaAdapter(
+            client=mock_client, model="llama3", base_url="http://localhost:11434"
+        )
+
+        with pytest.raises(ProviderError, match="connection error"):
+            await adapter.complete(_make_request())
+
+
+class TestAnthropicErrorHandling:
+    @pytest.mark.asyncio
+    async def test_rate_limit_error_raises_provider_error(self) -> None:
+        mock_client = AsyncMock()
+        mock_response = MagicMock()
+        mock_response.status_code = 429
+        mock_response.headers = {}
+        mock_client.messages.create.side_effect = AnthropicRateLimitError(
+            message="Rate limited",
+            response=mock_response,
+            body=None,
+        )
+
+        adapter = AnthropicAdapter(client=mock_client, model="claude-sonnet-4-20250514")
+
+        with pytest.raises(ProviderError, match="rate limited"):
+            await adapter.complete(_make_request())
+
+        assert adapter.check_rate_limit().is_limited is True
+
+    @pytest.mark.asyncio
+    async def test_api_error_raises_provider_error(self) -> None:
+        mock_client = AsyncMock()
+        mock_response = MagicMock()
+        mock_response.status_code = 500
+        mock_response.headers = {}
+        mock_client.messages.create.side_effect = AnthropicAPIError(
+            message="Server error",
+            request=MagicMock(),
+            body=None,
+        )
+
+        adapter = AnthropicAdapter(client=mock_client, model="claude-sonnet-4-20250514")
+
+        with pytest.raises(ProviderError, match="API error"):
+            await adapter.complete(_make_request())
+
+
+class TestOpenAIErrorHandling:
+    @pytest.mark.asyncio
+    async def test_rate_limit_error_raises_provider_error(self) -> None:
+        mock_client = AsyncMock()
+        mock_response = MagicMock()
+        mock_response.status_code = 429
+        mock_response.headers = {}
+        mock_response.json.return_value = {"error": {"message": "Rate limited"}}
+        mock_client.chat.completions.create.side_effect = OpenAIRateLimitError(
+            message="Rate limited",
+            response=mock_response,
+            body={"error": {"message": "Rate limited"}},
+        )
+
+        adapter = OpenAIAdapter(client=mock_client, model="gpt-4o")
+
+        with pytest.raises(ProviderError, match="rate limited"):
+            await adapter.complete(_make_request())
+
+        assert adapter.check_rate_limit().is_limited is True

--- a/src/backend/tests/test_dial_adapters.py
+++ b/src/backend/tests/test_dial_adapters.py
@@ -1,0 +1,257 @@
+"""Tests for Dial System provider adapters with mocked SDKs."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.dial_system.adapters.anthropic import AnthropicAdapter
+from app.dial_system.adapters.ollama import OllamaAdapter
+from app.dial_system.adapters.openai import OpenAIAdapter
+from app.schemas.dial_system import CompletionRequest, CompletionResult
+
+
+def _make_request() -> CompletionRequest:
+    return CompletionRequest(
+        messages=[{"role": "user", "content": "Hello"}],
+        max_tokens=100,
+        temperature=0.7,
+    )
+
+
+class TestAnthropicAdapter:
+    @pytest.mark.asyncio
+    async def test_complete_returns_completion_result(self) -> None:
+        mock_client = AsyncMock()
+        mock_client.messages.create.return_value = MagicMock(
+            content=[MagicMock(text="Hello from Claude!")],
+            model="claude-sonnet-4-20250514",
+            usage=MagicMock(input_tokens=10, output_tokens=5),
+        )
+
+        adapter = AnthropicAdapter(client=mock_client, model="claude-sonnet-4-20250514")
+        result = await adapter.complete(_make_request())
+
+        assert isinstance(result, CompletionResult)
+        assert result.content == "Hello from Claude!"
+        assert result.provider == "anthropic"
+        assert result.model == "claude-sonnet-4-20250514"
+        assert result.usage.prompt_tokens == 10
+        assert result.usage.completion_tokens == 5
+        assert result.usage.total_tokens == 15
+
+    @pytest.mark.asyncio
+    async def test_complete_calls_sdk_with_correct_params(self) -> None:
+        mock_client = AsyncMock()
+        mock_client.messages.create.return_value = MagicMock(
+            content=[MagicMock(text="response")],
+            model="claude-sonnet-4-20250514",
+            usage=MagicMock(input_tokens=5, output_tokens=3),
+        )
+
+        adapter = AnthropicAdapter(client=mock_client, model="claude-sonnet-4-20250514")
+        request = _make_request()
+        await adapter.complete(request)
+
+        mock_client.messages.create.assert_awaited_once_with(
+            model="claude-sonnet-4-20250514",
+            messages=request.messages,
+            max_tokens=request.max_tokens,
+            temperature=request.temperature,
+        )
+
+    @pytest.mark.asyncio
+    async def test_stream_yields_tokens(self) -> None:
+        mock_client = AsyncMock()
+
+        # Simulate streaming events
+        events = [
+            MagicMock(type="content_block_delta", delta=MagicMock(type="text_delta", text="Hello")),
+            MagicMock(
+                type="content_block_delta", delta=MagicMock(type="text_delta", text=" world")
+            ),
+            MagicMock(type="message_stop"),
+        ]
+
+        # messages.stream() returns a context manager (not a coroutine)
+        stream_cm = MagicMock()
+
+        async def _aiter(self_inner):
+            for e in events:
+                yield e
+
+        stream_cm.__aenter__ = AsyncMock(return_value=stream_cm)
+        stream_cm.__aexit__ = AsyncMock(return_value=False)
+        stream_cm.__aiter__ = _aiter
+        # Override messages.stream to be a regular MagicMock returning the context manager
+        mock_client.messages.stream = MagicMock(return_value=stream_cm)
+
+        adapter = AnthropicAdapter(client=mock_client, model="claude-sonnet-4-20250514")
+        tokens = [t async for t in adapter.stream(_make_request())]
+
+        assert tokens == ["Hello", " world"]
+
+    def test_check_rate_limit_not_limited(self) -> None:
+        adapter = AnthropicAdapter(client=AsyncMock(), model="claude-sonnet-4-20250514")
+        status = adapter.check_rate_limit()
+        assert status.is_limited is False
+
+
+class TestOpenAIAdapter:
+    @pytest.mark.asyncio
+    async def test_complete_returns_completion_result(self) -> None:
+        mock_client = AsyncMock()
+        mock_client.chat.completions.create.return_value = MagicMock(
+            choices=[MagicMock(message=MagicMock(content="Hello from GPT!"))],
+            model="gpt-4o",
+            usage=MagicMock(prompt_tokens=8, completion_tokens=4, total_tokens=12),
+        )
+
+        adapter = OpenAIAdapter(client=mock_client, model="gpt-4o")
+        result = await adapter.complete(_make_request())
+
+        assert isinstance(result, CompletionResult)
+        assert result.content == "Hello from GPT!"
+        assert result.provider == "openai"
+        assert result.model == "gpt-4o"
+        assert result.usage.prompt_tokens == 8
+        assert result.usage.completion_tokens == 4
+        assert result.usage.total_tokens == 12
+
+    @pytest.mark.asyncio
+    async def test_complete_calls_sdk_with_correct_params(self) -> None:
+        mock_client = AsyncMock()
+        mock_client.chat.completions.create.return_value = MagicMock(
+            choices=[MagicMock(message=MagicMock(content="ok"))],
+            model="gpt-4o",
+            usage=MagicMock(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+        )
+
+        adapter = OpenAIAdapter(client=mock_client, model="gpt-4o")
+        request = _make_request()
+        await adapter.complete(request)
+
+        mock_client.chat.completions.create.assert_awaited_once_with(
+            model="gpt-4o",
+            messages=request.messages,
+            max_tokens=request.max_tokens,
+            temperature=request.temperature,
+        )
+
+    @pytest.mark.asyncio
+    async def test_stream_yields_tokens(self) -> None:
+        mock_client = AsyncMock()
+
+        chunks = [
+            MagicMock(choices=[MagicMock(delta=MagicMock(content="Hello"))]),
+            MagicMock(choices=[MagicMock(delta=MagicMock(content=" world"))]),
+            MagicMock(choices=[MagicMock(delta=MagicMock(content=None))]),
+        ]
+
+        async def mock_create(*args, **kwargs):
+            for chunk in chunks:
+                yield chunk
+
+        mock_client.chat.completions.create.return_value = mock_create()
+
+        adapter = OpenAIAdapter(client=mock_client, model="gpt-4o")
+        tokens = [t async for t in adapter.stream(_make_request())]
+
+        assert tokens == ["Hello", " world"]
+
+    def test_check_rate_limit_not_limited(self) -> None:
+        adapter = OpenAIAdapter(client=AsyncMock(), model="gpt-4o")
+        status = adapter.check_rate_limit()
+        assert status.is_limited is False
+
+
+class TestOllamaAdapter:
+    @pytest.mark.asyncio
+    async def test_complete_returns_completion_result(self) -> None:
+        mock_client = AsyncMock()
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "message": {"content": "Hello from Ollama!"},
+            "model": "llama3",
+            "prompt_eval_count": 12,
+            "eval_count": 6,
+        }
+        mock_client.post.return_value = mock_response
+
+        adapter = OllamaAdapter(
+            client=mock_client, model="llama3", base_url="http://localhost:11434"
+        )
+        result = await adapter.complete(_make_request())
+
+        assert isinstance(result, CompletionResult)
+        assert result.content == "Hello from Ollama!"
+        assert result.provider == "ollama"
+        assert result.model == "llama3"
+        assert result.usage.prompt_tokens == 12
+        assert result.usage.completion_tokens == 6
+        assert result.usage.total_tokens == 18
+
+    @pytest.mark.asyncio
+    async def test_complete_calls_correct_endpoint(self) -> None:
+        mock_client = AsyncMock()
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "message": {"content": "ok"},
+            "model": "llama3",
+            "prompt_eval_count": 1,
+            "eval_count": 1,
+        }
+        mock_client.post.return_value = mock_response
+
+        adapter = OllamaAdapter(
+            client=mock_client, model="llama3", base_url="http://localhost:11434"
+        )
+        request = _make_request()
+        await adapter.complete(request)
+
+        mock_client.post.assert_awaited_once()
+        call_args = mock_client.post.call_args
+        assert call_args[0][0] == "http://localhost:11434/api/chat"
+
+    @pytest.mark.asyncio
+    async def test_stream_yields_tokens(self) -> None:
+        mock_client = MagicMock()
+
+        lines = [
+            json.dumps({"message": {"content": "Hello"}, "done": False}),
+            json.dumps({"message": {"content": " world"}, "done": False}),
+            json.dumps({"message": {"content": ""}, "done": True}),
+        ]
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+
+        async def mock_aiter_lines():
+            for line in lines:
+                yield line
+
+        mock_response.aiter_lines = mock_aiter_lines
+
+        # client.stream() returns a sync context manager
+        stream_cm = MagicMock()
+        stream_cm.__aenter__ = AsyncMock(return_value=mock_response)
+        stream_cm.__aexit__ = AsyncMock(return_value=False)
+        mock_client.stream.return_value = stream_cm
+
+        adapter = OllamaAdapter(
+            client=mock_client, model="llama3", base_url="http://localhost:11434"
+        )
+        tokens = [t async for t in adapter.stream(_make_request())]
+
+        assert tokens == ["Hello", " world"]
+
+    def test_check_rate_limit_never_limited(self) -> None:
+        adapter = OllamaAdapter(
+            client=AsyncMock(), model="llama3", base_url="http://localhost:11434"
+        )
+        status = adapter.check_rate_limit()
+        assert status.is_limited is False

--- a/src/backend/tests/test_dial_api.py
+++ b/src/backend/tests/test_dial_api.py
@@ -1,0 +1,103 @@
+"""Tests for Dial System REST API endpoints."""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.dial_config import DialConfig
+from app.schemas.dial_config import DialConfigUpdate
+
+VOYAGE_ID = uuid.uuid4()
+CONFIG_ID = uuid.uuid4()
+
+ROLE_MAPPING = {
+    "captain": {"provider": "anthropic", "model": "claude-sonnet-4-20250514"},
+    "navigator": {"provider": "openai", "model": "gpt-4o"},
+}
+
+FALLBACK_CHAIN = {
+    "captain": ["openai", "ollama"],
+}
+
+
+def _mock_session_with_config(config: DialConfig | None) -> AsyncMock:
+    session = AsyncMock(spec=AsyncSession)
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = config
+    session.execute.return_value = mock_result
+    return session
+
+
+class TestGetDialConfig:
+    @pytest.mark.asyncio
+    async def test_get_dial_config_returns_config(self) -> None:
+        from app.api.v1.dial import get_dial_config
+
+        config = DialConfig(
+            id=CONFIG_ID,
+            voyage_id=VOYAGE_ID,
+            role_mapping=ROLE_MAPPING,
+            fallback_chain=FALLBACK_CHAIN,
+        )
+        session = _mock_session_with_config(config)
+        user = MagicMock()
+
+        result = await get_dial_config(VOYAGE_ID, session, user)
+
+        assert result.voyage_id == VOYAGE_ID
+        assert result.role_mapping == ROLE_MAPPING
+
+    @pytest.mark.asyncio
+    async def test_get_dial_config_not_found_raises_404(self) -> None:
+        from app.api.v1.dial import get_dial_config
+
+        session = _mock_session_with_config(None)
+        user = MagicMock()
+
+        with pytest.raises(HTTPException) as exc_info:
+            await get_dial_config(VOYAGE_ID, session, user)
+
+        assert exc_info.value.status_code == 404
+
+
+class TestUpdateDialConfig:
+    @pytest.mark.asyncio
+    async def test_update_dial_config_updates_fields(self) -> None:
+        from app.api.v1.dial import update_dial_config
+
+        config = DialConfig(
+            id=CONFIG_ID,
+            voyage_id=VOYAGE_ID,
+            role_mapping=ROLE_MAPPING,
+            fallback_chain=FALLBACK_CHAIN,
+        )
+        session = _mock_session_with_config(config)
+        user = MagicMock()
+
+        new_mapping = {
+            "captain": {"provider": "openai", "model": "gpt-4o"},
+        }
+        update = DialConfigUpdate(role_mapping=new_mapping)
+
+        result = await update_dial_config(VOYAGE_ID, update, session, user)
+
+        assert result.role_mapping == new_mapping
+        session.commit.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_update_dial_config_not_found_raises_404(self) -> None:
+        from app.api.v1.dial import update_dial_config
+
+        session = _mock_session_with_config(None)
+        user = MagicMock()
+        update = DialConfigUpdate(role_mapping=ROLE_MAPPING)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await update_dial_config(VOYAGE_ID, update, session, user)
+
+        assert exc_info.value.status_code == 404

--- a/src/backend/tests/test_dial_factory.py
+++ b/src/backend/tests/test_dial_factory.py
@@ -1,0 +1,116 @@
+"""Tests for Dial System adapter factory."""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.core.config import Settings
+from app.dial_system.adapters.anthropic import AnthropicAdapter
+from app.dial_system.adapters.ollama import OllamaAdapter
+from app.dial_system.adapters.openai import OpenAIAdapter
+from app.dial_system.factory import build_router_from_config, create_adapter
+from app.models.dial_config import DialConfig
+
+VOYAGE_ID = uuid.uuid4()
+
+
+def _make_settings() -> Settings:
+    return Settings(
+        anthropic_api_key="test-key",
+        openai_api_key="test-key",
+        ollama_base_url="http://localhost:11434",
+    )
+
+
+class TestCreateAdapter:
+    def test_creates_anthropic_adapter(self) -> None:
+        adapter = create_adapter("anthropic", "claude-sonnet-4-20250514", _make_settings())
+        assert isinstance(adapter, AnthropicAdapter)
+
+    def test_creates_openai_adapter(self) -> None:
+        adapter = create_adapter("openai", "gpt-4o", _make_settings())
+        assert isinstance(adapter, OpenAIAdapter)
+
+    def test_creates_ollama_adapter(self) -> None:
+        adapter = create_adapter("ollama", "llama3", _make_settings())
+        assert isinstance(adapter, OllamaAdapter)
+
+    def test_raises_for_unknown_provider(self) -> None:
+        with pytest.raises(ValueError, match="Unknown provider"):
+            create_adapter("gemini", "gemini-pro", _make_settings())
+
+
+class TestBuildRouterFromConfig:
+    def test_builds_router_from_valid_config(self) -> None:
+        config = DialConfig(
+            id=uuid.uuid4(),
+            voyage_id=VOYAGE_ID,
+            role_mapping={
+                "captain": {
+                    "provider": "anthropic",
+                    "model": "claude-sonnet-4-20250514",
+                },
+                "navigator": {"provider": "openai", "model": "gpt-4o"},
+            },
+            fallback_chain={"captain": ["openai", "ollama"]},
+        )
+        mushi = MagicMock()
+        rate_limiter = MagicMock()
+
+        router = build_router_from_config(config, _make_settings(), mushi, rate_limiter)
+
+        assert router is not None
+
+    def test_raises_for_missing_provider_key(self) -> None:
+        config = DialConfig(
+            id=uuid.uuid4(),
+            voyage_id=VOYAGE_ID,
+            role_mapping={"captain": {"model": "claude-sonnet-4-20250514"}},
+            fallback_chain=None,
+        )
+
+        with pytest.raises(ValueError, match="Missing 'provider' or 'model'"):
+            build_router_from_config(config, _make_settings(), MagicMock(), MagicMock())
+
+    def test_raises_for_missing_model_key(self) -> None:
+        config = DialConfig(
+            id=uuid.uuid4(),
+            voyage_id=VOYAGE_ID,
+            role_mapping={"captain": {"provider": "anthropic"}},
+            fallback_chain=None,
+        )
+
+        with pytest.raises(ValueError, match="Missing 'provider' or 'model'"):
+            build_router_from_config(config, _make_settings(), MagicMock(), MagicMock())
+
+    def test_raises_for_unknown_provider_in_mapping(self) -> None:
+        config = DialConfig(
+            id=uuid.uuid4(),
+            voyage_id=VOYAGE_ID,
+            role_mapping={
+                "captain": {"provider": "gemini", "model": "gemini-pro"},
+            },
+            fallback_chain=None,
+        )
+
+        with pytest.raises(ValueError, match="Unknown provider"):
+            build_router_from_config(config, _make_settings(), MagicMock(), MagicMock())
+
+    def test_handles_none_fallback_chain(self) -> None:
+        config = DialConfig(
+            id=uuid.uuid4(),
+            voyage_id=VOYAGE_ID,
+            role_mapping={
+                "captain": {
+                    "provider": "anthropic",
+                    "model": "claude-sonnet-4-20250514",
+                },
+            },
+            fallback_chain=None,
+        )
+
+        router = build_router_from_config(config, _make_settings(), MagicMock(), MagicMock())
+        assert router is not None

--- a/src/backend/tests/test_dial_rate_limiter.py
+++ b/src/backend/tests/test_dial_rate_limiter.py
@@ -1,0 +1,68 @@
+"""Tests for Dial System rate limiter with mocked Redis."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.dial_system.rate_limiter import RateLimiter
+
+
+class TestRateLimiter:
+    @pytest.mark.asyncio
+    async def test_record_usage_stores_in_redis(self) -> None:
+        redis = AsyncMock()
+        redis.zadd.return_value = 1
+        redis.expire.return_value = True
+        limiter = RateLimiter(redis)
+
+        await limiter.record_usage("anthropic", tokens=100)
+
+        redis.zadd.assert_awaited()
+        redis.expire.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_check_returns_not_limited_under_threshold(self) -> None:
+        redis = AsyncMock()
+        redis.zrangebyscore.return_value = []
+        redis.zcount.return_value = 0
+        limiter = RateLimiter(redis, max_tokens_per_minute=100_000, max_requests_per_minute=100)
+
+        status = await limiter.check("anthropic")
+
+        assert status.is_limited is False
+
+    @pytest.mark.asyncio
+    async def test_check_returns_limited_when_tokens_exceeded(self) -> None:
+        redis = AsyncMock()
+        # Member format is "timestamp:tokens" — sum of tokens exceeds limit
+        redis.zrangebyscore.return_value = [("1234.5:60000", 1234.5), ("1234.6:50000", 1234.6)]
+        redis.zcount.return_value = 2
+        limiter = RateLimiter(redis, max_tokens_per_minute=100_000, max_requests_per_minute=100)
+
+        status = await limiter.check("anthropic")
+
+        assert status.is_limited is True
+
+    @pytest.mark.asyncio
+    async def test_check_returns_limited_when_requests_exceeded(self) -> None:
+        redis = AsyncMock()
+        redis.zrangebyscore.return_value = []
+        redis.zcount.return_value = 150
+        limiter = RateLimiter(redis, max_tokens_per_minute=100_000, max_requests_per_minute=100)
+
+        status = await limiter.check("anthropic")
+
+        assert status.is_limited is True
+
+    @pytest.mark.asyncio
+    async def test_cleanup_removes_old_entries(self) -> None:
+        redis = AsyncMock()
+        redis.zremrangebyscore.return_value = 5
+        limiter = RateLimiter(redis)
+
+        removed = await limiter.cleanup("anthropic")
+
+        assert removed == 5
+        redis.zremrangebyscore.assert_awaited_once()

--- a/src/backend/tests/test_dial_router.py
+++ b/src/backend/tests/test_dial_router.py
@@ -8,7 +8,8 @@ from unittest.mock import AsyncMock
 import pytest
 
 from app.den_den_mushi.mushi import DenDenMushi
-from app.dial_system.adapters.base import ProviderAdapter
+from app.dial_system.adapters.base import ProviderAdapter, ProviderError
+from app.dial_system.rate_limiter import RateLimiter
 from app.dial_system.router import DialSystemRouter
 from app.models.enums import CrewRole
 from app.schemas.dial_system import (
@@ -24,6 +25,7 @@ VOYAGE_ID = uuid.uuid4()
 def _make_request() -> CompletionRequest:
     return CompletionRequest(
         messages=[{"role": "user", "content": "Plan the voyage"}],
+        role=CrewRole.CAPTAIN,
         max_tokens=200,
     )
 
@@ -125,10 +127,10 @@ class TestFailover:
         fallback.complete.assert_awaited_once()
 
     @pytest.mark.asyncio
-    async def test_failover_to_fallback_on_exception(self) -> None:
+    async def test_failover_to_fallback_on_provider_error(self) -> None:
         primary = _make_adapter()
         primary.check_rate_limit.return_value = RateLimitStatus(is_limited=False)
-        primary.complete.side_effect = Exception("Provider down")
+        primary.complete.side_effect = ProviderError("Provider down")
 
         fallback = _make_adapter(result=_make_result(provider="openai", model="gpt-4o"))
 
@@ -209,3 +211,84 @@ class TestFailover:
         await router.route(CrewRole.CAPTAIN, _make_request())
 
         mushi.publish.assert_not_awaited()
+
+
+class TestStreamFailover:
+    @pytest.mark.asyncio
+    async def test_stream_fails_over_on_provider_error(self) -> None:
+        primary = AsyncMock(spec=ProviderAdapter)
+        primary.check_rate_limit.return_value = RateLimitStatus(is_limited=False)
+
+        async def failing_stream(req):
+            raise ProviderError("Stream failed")
+            yield  # make it an async generator  # noqa: E501
+
+        primary.stream = failing_stream
+
+        fallback = AsyncMock(spec=ProviderAdapter)
+        fallback.check_rate_limit.return_value = RateLimitStatus(is_limited=False)
+
+        async def fallback_stream(req):
+            yield "fallback"
+            yield " response"
+
+        fallback.stream = fallback_stream
+
+        mushi = AsyncMock(spec=DenDenMushi)
+
+        router = DialSystemRouter(
+            role_mapping={CrewRole.CAPTAIN: primary},
+            fallback_chains={CrewRole.CAPTAIN: [fallback]},
+            mushi=mushi,
+            voyage_id=VOYAGE_ID,
+        )
+
+        tokens = [t async for t in router.stream(CrewRole.CAPTAIN, _make_request())]
+
+        assert tokens == ["fallback", " response"]
+        mushi.publish.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_stream_skips_rate_limited_primary(self) -> None:
+        primary = AsyncMock(spec=ProviderAdapter)
+        primary.check_rate_limit.return_value = RateLimitStatus(is_limited=True)
+
+        fallback = AsyncMock(spec=ProviderAdapter)
+        fallback.check_rate_limit.return_value = RateLimitStatus(is_limited=False)
+
+        async def fallback_stream(req):
+            yield "ok"
+
+        fallback.stream = fallback_stream
+
+        mushi = AsyncMock(spec=DenDenMushi)
+
+        router = DialSystemRouter(
+            role_mapping={CrewRole.CAPTAIN: primary},
+            fallback_chains={CrewRole.CAPTAIN: [fallback]},
+            mushi=mushi,
+            voyage_id=VOYAGE_ID,
+        )
+
+        tokens = [t async for t in router.stream(CrewRole.CAPTAIN, _make_request())]
+
+        assert tokens == ["ok"]
+
+
+class TestRateLimiterIntegration:
+    @pytest.mark.asyncio
+    async def test_records_usage_after_successful_completion(self) -> None:
+        adapter = _make_adapter()
+        rate_limiter = AsyncMock(spec=RateLimiter)
+
+        router = DialSystemRouter(
+            role_mapping={CrewRole.CAPTAIN: adapter},
+            fallback_chains={},
+            mushi=AsyncMock(spec=DenDenMushi),
+            voyage_id=VOYAGE_ID,
+            rate_limiter=rate_limiter,
+        )
+
+        await router.route(CrewRole.CAPTAIN, _make_request())
+
+        rate_limiter.record_usage.assert_awaited_once_with("anthropic", 15)

--- a/src/backend/tests/test_dial_router.py
+++ b/src/backend/tests/test_dial_router.py
@@ -1,0 +1,211 @@
+"""Tests for DialSystemRouter — role-based routing, failover, and Den Den Mushi events."""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.den_den_mushi.mushi import DenDenMushi
+from app.dial_system.adapters.base import ProviderAdapter
+from app.dial_system.router import DialSystemRouter
+from app.models.enums import CrewRole
+from app.schemas.dial_system import (
+    CompletionRequest,
+    CompletionResult,
+    RateLimitStatus,
+    TokenUsage,
+)
+
+VOYAGE_ID = uuid.uuid4()
+
+
+def _make_request() -> CompletionRequest:
+    return CompletionRequest(
+        messages=[{"role": "user", "content": "Plan the voyage"}],
+        max_tokens=200,
+    )
+
+
+def _make_result(
+    provider: str = "anthropic", model: str = "claude-sonnet-4-20250514"
+) -> CompletionResult:
+    return CompletionResult(
+        content="Aye aye, captain!",
+        provider=provider,
+        model=model,
+        usage=TokenUsage(prompt_tokens=10, completion_tokens=5, total_tokens=15),
+    )
+
+
+def _make_adapter(result: CompletionResult | None = None, limited: bool = False) -> ProviderAdapter:
+    adapter = AsyncMock(spec=ProviderAdapter)
+    adapter.complete.return_value = result or _make_result()
+    adapter.check_rate_limit.return_value = RateLimitStatus(is_limited=limited)
+    return adapter
+
+
+class TestRouting:
+    @pytest.mark.asyncio
+    async def test_routes_to_correct_provider_for_role(self) -> None:
+        adapter = _make_adapter()
+        role_mapping = {CrewRole.CAPTAIN: adapter}
+
+        router = DialSystemRouter(
+            role_mapping=role_mapping,
+            fallback_chains={},
+            mushi=AsyncMock(spec=DenDenMushi),
+            voyage_id=VOYAGE_ID,
+        )
+
+        result = await router.route(CrewRole.CAPTAIN, _make_request())
+
+        assert result.content == "Aye aye, captain!"
+        adapter.complete.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_raises_for_unmapped_role(self) -> None:
+        router = DialSystemRouter(
+            role_mapping={},
+            fallback_chains={},
+            mushi=AsyncMock(spec=DenDenMushi),
+            voyage_id=VOYAGE_ID,
+        )
+
+        with pytest.raises(ValueError, match="No provider configured"):
+            await router.route(CrewRole.CAPTAIN, _make_request())
+
+    @pytest.mark.asyncio
+    async def test_stream_routes_to_correct_provider(self) -> None:
+        adapter = AsyncMock(spec=ProviderAdapter)
+        adapter.check_rate_limit.return_value = RateLimitStatus(is_limited=False)
+
+        async def mock_stream(req):
+            yield "Hello"
+            yield " captain"
+
+        adapter.stream = mock_stream
+
+        role_mapping = {CrewRole.CAPTAIN: adapter}
+        router = DialSystemRouter(
+            role_mapping=role_mapping,
+            fallback_chains={},
+            mushi=AsyncMock(spec=DenDenMushi),
+            voyage_id=VOYAGE_ID,
+        )
+
+        tokens = [t async for t in router.stream(CrewRole.CAPTAIN, _make_request())]
+
+        assert tokens == ["Hello", " captain"]
+
+
+class TestFailover:
+    @pytest.mark.asyncio
+    async def test_failover_to_fallback_on_rate_limit(self) -> None:
+        primary = _make_adapter(limited=True)
+        fallback = _make_adapter(result=_make_result(provider="openai", model="gpt-4o"))
+
+        role_mapping = {CrewRole.CAPTAIN: primary}
+        fallback_chains = {CrewRole.CAPTAIN: [fallback]}
+
+        mushi = AsyncMock(spec=DenDenMushi)
+
+        router = DialSystemRouter(
+            role_mapping=role_mapping,
+            fallback_chains=fallback_chains,
+            mushi=mushi,
+            voyage_id=VOYAGE_ID,
+        )
+
+        result = await router.route(CrewRole.CAPTAIN, _make_request())
+
+        assert result.provider == "openai"
+        primary.complete.assert_not_awaited()
+        fallback.complete.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_failover_to_fallback_on_exception(self) -> None:
+        primary = _make_adapter()
+        primary.check_rate_limit.return_value = RateLimitStatus(is_limited=False)
+        primary.complete.side_effect = Exception("Provider down")
+
+        fallback = _make_adapter(result=_make_result(provider="openai", model="gpt-4o"))
+
+        role_mapping = {CrewRole.CAPTAIN: primary}
+        fallback_chains = {CrewRole.CAPTAIN: [fallback]}
+
+        mushi = AsyncMock(spec=DenDenMushi)
+
+        router = DialSystemRouter(
+            role_mapping=role_mapping,
+            fallback_chains=fallback_chains,
+            mushi=mushi,
+            voyage_id=VOYAGE_ID,
+        )
+
+        result = await router.route(CrewRole.CAPTAIN, _make_request())
+
+        assert result.provider == "openai"
+
+    @pytest.mark.asyncio
+    async def test_raises_when_all_providers_exhausted(self) -> None:
+        primary = _make_adapter(limited=True)
+        fallback = _make_adapter(limited=True)
+
+        role_mapping = {CrewRole.CAPTAIN: primary}
+        fallback_chains = {CrewRole.CAPTAIN: [fallback]}
+
+        router = DialSystemRouter(
+            role_mapping=role_mapping,
+            fallback_chains=fallback_chains,
+            mushi=AsyncMock(spec=DenDenMushi),
+            voyage_id=VOYAGE_ID,
+        )
+
+        with pytest.raises(RuntimeError, match="All providers exhausted"):
+            await router.route(CrewRole.CAPTAIN, _make_request())
+
+    @pytest.mark.asyncio
+    async def test_publishes_provider_switched_event_on_failover(self) -> None:
+        primary = _make_adapter(limited=True)
+        fallback = _make_adapter(result=_make_result(provider="openai", model="gpt-4o"))
+
+        role_mapping = {CrewRole.CAPTAIN: primary}
+        fallback_chains = {CrewRole.CAPTAIN: [fallback]}
+
+        mushi = AsyncMock(spec=DenDenMushi)
+
+        router = DialSystemRouter(
+            role_mapping=role_mapping,
+            fallback_chains=fallback_chains,
+            mushi=mushi,
+            voyage_id=VOYAGE_ID,
+        )
+
+        await router.route(CrewRole.CAPTAIN, _make_request())
+
+        mushi.publish.assert_awaited_once()
+        event = mushi.publish.call_args[0][1]
+        assert event.event_type == "provider_switched"
+        assert event.voyage_id == VOYAGE_ID
+        assert event.source_role == CrewRole.CAPTAIN
+
+    @pytest.mark.asyncio
+    async def test_no_event_when_primary_succeeds(self) -> None:
+        primary = _make_adapter()
+
+        role_mapping = {CrewRole.CAPTAIN: primary}
+
+        mushi = AsyncMock(spec=DenDenMushi)
+
+        router = DialSystemRouter(
+            role_mapping=role_mapping,
+            fallback_chains={},
+            mushi=mushi,
+            voyage_id=VOYAGE_ID,
+        )
+
+        await router.route(CrewRole.CAPTAIN, _make_request())
+
+        mushi.publish.assert_not_awaited()

--- a/src/backend/tests/test_dial_router.py
+++ b/src/backend/tests/test_dial_router.py
@@ -280,6 +280,7 @@ class TestRateLimiterIntegration:
     async def test_records_usage_after_successful_completion(self) -> None:
         adapter = _make_adapter()
         rate_limiter = AsyncMock(spec=RateLimiter)
+        rate_limiter.check.return_value = RateLimitStatus(is_limited=False)
 
         router = DialSystemRouter(
             role_mapping={CrewRole.CAPTAIN: adapter},
@@ -292,3 +293,59 @@ class TestRateLimiterIntegration:
         await router.route(CrewRole.CAPTAIN, _make_request())
 
         rate_limiter.record_usage.assert_awaited_once_with("anthropic", 15)
+
+    @pytest.mark.asyncio
+    async def test_redis_rate_limiter_triggers_failover(self) -> None:
+        """When Redis rate limiter says provider is limited, skip to fallback."""
+        primary = _make_adapter()
+        fallback = _make_adapter(result=_make_result(provider="openai", model="gpt-4o"))
+
+        rate_limiter = AsyncMock(spec=RateLimiter)
+        # Primary adapter says not limited, but Redis says limited for unknown
+        # (mock adapters resolve to "unknown"), not limited for "openai"
+        call_count = 0
+
+        async def mock_check(provider: str) -> RateLimitStatus:
+            nonlocal call_count
+            call_count += 1
+            # First call is for primary (unknown), second is for fallback (unknown)
+            # We want primary limited, fallback not limited
+            if call_count == 1:
+                return RateLimitStatus(is_limited=True)
+            return RateLimitStatus(is_limited=False)
+
+        rate_limiter.check = mock_check
+
+        mushi = AsyncMock(spec=DenDenMushi)
+
+        router = DialSystemRouter(
+            role_mapping={CrewRole.CAPTAIN: primary},
+            fallback_chains={CrewRole.CAPTAIN: [fallback]},
+            mushi=mushi,
+            voyage_id=VOYAGE_ID,
+            rate_limiter=rate_limiter,
+        )
+
+        result = await router.route(CrewRole.CAPTAIN, _make_request())
+
+        assert result.provider == "openai"
+        primary.complete.assert_not_awaited()
+        fallback.complete.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_redis_check_called_with_provider_name(self) -> None:
+        adapter = _make_adapter()
+        rate_limiter = AsyncMock(spec=RateLimiter)
+        rate_limiter.check.return_value = RateLimitStatus(is_limited=False)
+
+        router = DialSystemRouter(
+            role_mapping={CrewRole.CAPTAIN: adapter},
+            fallback_chains={},
+            mushi=AsyncMock(spec=DenDenMushi),
+            voyage_id=VOYAGE_ID,
+            rate_limiter=rate_limiter,
+        )
+
+        await router.route(CrewRole.CAPTAIN, _make_request())
+
+        rate_limiter.check.assert_awaited()


### PR DESCRIPTION
## Summary
- Provider-agnostic LLM gateway with adapters for **Anthropic**, **OpenAI**, and **Ollama** — all returning a unified `CompletionResult` shape
- `ProviderAdapter` ABC with `complete()`, `stream()`, `check_rate_limit()` — uniform error handling via `ProviderError`
- **Adapter factory** (`factory.py`): `create_adapter()` + `build_router_from_config()` — no global instances, created per-request from DialConfig JSONB
- **DialSystemRouter** with config-driven role-based routing and automatic failover chain (primary → fallbacks → RuntimeError)
- Failover applies to **both** `route()` (completions) and `stream()` (SSE streaming) — identical logic
- **Redis-based sliding window rate limiter** tracking tokens and requests per provider per minute
- **SSE streaming endpoint**: `POST /completions/stream` returns `text/event-stream` with `data: {token}\n\n` format
- **FastAPI integration**: `get_dial_router` dependency fetches config from DB, wires router via factory
- REST API: `GET/PUT /dial-config` for runtime config, `POST /completions` and `POST /completions/stream`
- Publishes `ProviderSwitchedEvent` via Den Den Mushi on failover
- PDD prompt, eval (48/48 pass), and updated context files included

## Test plan
- [x] 37 dial system unit tests: adapters (14), router + failover + stream (10), factory (8), rate limiter (5)
- [x] Full suite: **163 passed**, 0 failed (non-integration)
- [x] mypy clean — 0 errors in 46 files
- [x] ruff + ruff-format pass
- [x] PDD review: all prompt requirements verified against code
- [x] PDD eval: 48/48 criteria pass (Level 1 checklist)
- [ ] Integration tests with real providers (manual, requires API keys)