### PR TITLE
feat: add Vivre Card state checkpointing (Phase 7) #8

### DIFF
--- a/pdd/prompts/features/vivre-card/PLAN-vivre-card.md
+++ b/pdd/prompts/features/vivre-card/PLAN-vivre-card.md
@@ -1,0 +1,132 @@
+# Plan: Vivre Card — State Checkpointing (Phase 7)
+
+**Issue**: #8
+**Branch**: `feat/issue-8-vivre-card`
+**Depends on**: Phase 3 (VivreCard model), Phase 5 (Den Den Mushi), Phase 6 (Dial System)
+
+---
+
+## Problem
+
+Agents need to survive failures. When a provider goes down, the Dial System fails over — but without a recent checkpoint, the agent loses its in-progress work. Vivre Cards serialize agent state to PostgreSQL JSONB so the system can resume from any checkpoint. This is the "no work lost" guarantee.
+
+## What exists already
+
+| Artifact | Location | Status |
+|---|---|---|
+| `VivreCard` SQLAlchemy model | `src/backend/app/models/vivre_card.py` | Done — has id, voyage_id, crew_member, state_data (JSONB), checkpoint_reason, created_at |
+| `VivreCardCreate` / `VivreCardRead` schemas | `src/backend/app/schemas/vivre_card.py` | Done — uses `CrewRole` and `CheckpointReason` enums |
+| `CheckpointReason` enum | `src/backend/app/models/enums.py` | Done — interval, failover, pause, migration |
+| `CrewRole` enum | `src/backend/app/models/enums.py` | Done — captain, navigator, doctor, shipwright, helmsman |
+| Den Den Mushi (message bus) | `src/backend/app/den_den_mushi/` | Done — publish, read, ack, consumer groups |
+| Dial System (LLM gateway) | `src/backend/app/dial_system/` | Done — failover router, provider adapters |
+| `ProviderSwitchedEvent` | `src/backend/app/den_den_mushi/events.py` | Done — published on failover |
+
+## What needs to be built
+
+### Phase 1: VivreCardService (core business logic)
+
+**File**: `src/backend/app/services/vivre_card_service.py`
+
+The service layer that handles all checkpoint operations:
+
+- **`checkpoint(session, voyage_id, crew_member, state_data, reason)`** — Creates a new Vivre Card. Serializes agent state to JSONB. Returns the created card.
+- **`restore(session, card_id)`** — Loads a checkpoint by ID. Returns the deserialized state. Raises if not found.
+- **`list_cards(session, voyage_id, crew_member?, limit?, offset?)`** — Lists checkpoints for a voyage, optionally filtered by crew member. Ordered by created_at desc.
+- **`diff(session, card_id_a, card_id_b)`** — Computes a JSON diff between two checkpoints. Returns added/removed/changed keys with before/after values.
+- **`cleanup(session, voyage_id, keep_last_n)`** — Deletes old checkpoints per crew member, keeping the N most recent. Returns count of deleted cards.
+
+**Design decisions**:
+- Service takes `AsyncSession` as parameter (dependency injection, consistent with auth_service pattern)
+- No direct Redis dependency — Den Den Mushi events are published by the caller (API layer or scheduler), not the service
+- State diff uses recursive dict comparison (not a library) — agent state is flat-to-moderately-nested JSONB
+
+### Phase 2: Den Den Mushi integration (events)
+
+**Files**: 
+- `src/backend/app/den_den_mushi/events.py` — Add `CheckpointCreatedEvent`
+- Update `AnyEvent` union and discriminator
+
+New event: `CheckpointCreatedEvent` with `event_type: "checkpoint_created"`, published after every successful checkpoint. Payload contains `card_id`, `crew_member`, `reason`.
+
+### Phase 3: REST API endpoints
+
+**File**: `src/backend/app/api/v1/vivre_cards.py`
+
+Endpoints:
+- `GET /api/v1/voyages/{voyage_id}/vivre-cards` — List checkpoints for a voyage. Query params: `crew_member` (optional filter), `limit` (default 20), `offset` (default 0). Requires auth + voyage ownership.
+- `POST /api/v1/voyages/{voyage_id}/vivre-cards` — Create a checkpoint manually. Body: `VivreCardCreate` (crew_member, state_data, checkpoint_reason). Publishes `CheckpointCreatedEvent` via Den Den Mushi. Requires auth + voyage ownership.
+- `GET /api/v1/voyages/{voyage_id}/vivre-cards/{card_id}` — Get a single checkpoint by ID.
+- `GET /api/v1/voyages/{voyage_id}/vivre-cards/{card_id}/diff?compare_to={other_id}` — Diff two checkpoints.
+- `POST /api/v1/voyages/{voyage_id}/vivre-cards/{card_id}/restore` — Restore from a checkpoint. Returns the state data and marks intent (actual agent resume is out of scope — that's the agent execution layer).
+- `DELETE /api/v1/voyages/{voyage_id}/vivre-cards/cleanup` — Run cleanup policy. Query param: `keep_last_n` (default 5).
+
+**Dependencies**: Reuse `get_authorized_voyage` from existing dependencies. Add `get_vivre_card_service` dependency.
+
+**Wire into router**: Add `vivre_cards_router` to `src/backend/app/api/v1/router.py`.
+
+### Phase 4: Schemas (request/response)
+
+**File**: `src/backend/app/schemas/vivre_card.py` — Extend existing schemas:
+
+- `VivreCardList` — Paginated response with items + total count
+- `VivreCardDiff` — Diff result with added/removed/changed fields
+- `VivreCardRestore` — Restore response with card_id + state_data
+- `CleanupResult` — Count of deleted checkpoints
+
+### Phase 5: Config for automatic checkpointing
+
+**File**: `src/backend/app/core/config.py` — Add:
+- `vivre_card_checkpoint_interval_seconds: int = 300` (5 min default)
+- `vivre_card_cleanup_keep_last_n: int = 10`
+
+These settings are used by the future agent execution loop (Phase 9+) to trigger interval-based checkpoints. The API also exposes manual checkpointing for immediate use.
+
+### Phase 6: Dial System integration hook
+
+The Dial System's `DialSystemRouter` already publishes `ProviderSwitchedEvent` on failover. The integration point is:
+
+- Add a `pre_failover_hook` callback to `DialSystemRouter` that callers can set
+- When the Dial System is about to switch providers, it calls the hook (if set) before the switch
+- In the agent execution layer (future phase), this hook will call `VivreCardService.checkpoint()` with reason `failover`
+
+For now in Phase 7, we add the hook mechanism to the router. The actual wiring happens when agents are built (Phase 11+).
+
+**File**: `src/backend/app/dial_system/router.py` — Add optional `on_provider_switch` callback parameter.
+
+---
+
+## Implementation order
+
+```
+Phase 4 (schemas)          — extend VivreCard schemas
+Phase 2 (events)           — add CheckpointCreatedEvent
+Phase 1 (service)          — VivreCardService core logic
+Phase 3 (API)              — REST endpoints
+Phase 5 (config)           — checkpoint interval + cleanup settings
+Phase 6 (Dial hook)        — pre-failover callback on DialSystemRouter
+```
+
+Schemas and events first (no dependencies), then service (depends on schemas), then API (depends on service + events), then config and Dial hook (independent).
+
+## Testing strategy (TDD)
+
+Tests written BEFORE implementation, following Doctor-first convention:
+
+1. **`tests/test_vivre_card_service.py`** — Unit tests for checkpoint, restore, list, diff, cleanup
+2. **`tests/test_vivre_card_api.py`** — Integration tests for all REST endpoints (auth, ownership, 404s, validation)
+3. **`tests/test_vivre_card_events.py`** — Event serialization/deserialization for CheckpointCreatedEvent
+4. **`tests/test_dial_router_hook.py`** — Test that the pre-failover hook fires before provider switch
+
+## Out of scope
+
+- Automatic interval-based checkpoint scheduling (needs agent execution loop — Phase 9+)
+- Actual agent state restoration and resume (needs agent definitions — Phase 11+)
+- WebSocket notifications for checkpoint events (needs Observation Deck — Phase 16)
+
+## Risk: serialization of arbitrary state
+
+Agent state shapes vary per crew member. The `state_data` JSONB field is flexible, but:
+- All state must be JSON-serializable (no datetime objects, no custom classes without serialization)
+- The service should validate that `state_data` round-trips correctly (serialize → deserialize → equal)
+- Diff logic must handle nested dicts and lists gracefully

--- a/pdd/prompts/features/vivre-card/grandline-07-state-checkpointing.md
+++ b/pdd/prompts/features/vivre-card/grandline-07-state-checkpointing.md
@@ -1,0 +1,228 @@
+# Prompt: Vivre Card (State Checkpointing)
+
+**File**: pdd/prompts/features/vivre-card/grandline-07-state-checkpointing.md
+**Created**: 2026-04-06
+**Updated**: 2026-04-06
+**Depends on**: Phase 3 (VivreCard model + schema), Phase 5 (Den Den Mushi events), Phase 6 (Dial System router)
+**Project type**: Backend (FastAPI + PostgreSQL JSONB)
+
+## Context
+
+GrandLine is a One Piece-themed multi-agent orchestration platform. Phases 1-6 delivered Docker infrastructure, database models, JWT auth, the Den Den Mushi message bus, and the Dial System LLM gateway with failover.
+
+In One Piece, a Vivre Card is a paper made from a person's fingernail that tracks their life force — if they're alive, the card points toward them; if they're dying, it burns away. Here, Vivre Cards are state checkpoints that track an agent's progress. If the agent crashes, migrates to a different provider, or pauses, the system restores from the last Vivre Card — no work is lost.
+
+The `VivreCard` SQLAlchemy model and basic Pydantic schemas already exist. This phase builds the service layer, REST API, event integration, state diffing, and cleanup policy on top of that foundation.
+
+## Task
+
+Implement the Vivre Card state checkpointing system with TDD (tests first, then implementation):
+
+1. **Extended Schemas** (`app/schemas/vivre_card.py`):
+   - Keep existing `VivreCardCreate` and `VivreCardRead`
+   - Add `VivreCardList` — paginated response:
+     - `items: list[VivreCardRead]`
+     - `total: int`
+     - `limit: int`
+     - `offset: int`
+   - Add `VivreCardDiff` — diff result between two checkpoints:
+     - `card_a_id: uuid.UUID`
+     - `card_b_id: uuid.UUID`
+     - `added: dict[str, Any]` — keys present in B but not A
+     - `removed: dict[str, Any]` — keys present in A but not B
+     - `changed: dict[str, dict[str, Any]]` — keys in both but with different values, each entry has `{"before": ..., "after": ...}`
+   - Add `VivreCardRestore` — restore response:
+     - `card_id: uuid.UUID`
+     - `voyage_id: uuid.UUID`
+     - `crew_member: str`
+     - `state_data: dict[str, Any]`
+     - `checkpoint_reason: str`
+     - `restored_at: datetime`
+   - Add `CleanupResult`:
+     - `deleted_count: int`
+     - `kept_count: int`
+     - `voyage_id: uuid.UUID`
+
+2. **CheckpointCreatedEvent** (`app/den_den_mushi/events.py`):
+   - Add `CheckpointCreatedEvent(DenDenMushiEvent)`:
+     - `event_type: Literal["checkpoint_created"] = "checkpoint_created"`
+     - Payload should contain: `card_id` (str, UUID as string), `crew_member` (str), `reason` (str)
+   - Add `CheckpointCreatedEvent` to the `AnyEvent` union type
+   - Update the `_event_adapter` TypeAdapter to include it
+
+3. **VivreCardService** (`app/services/vivre_card_service.py`):
+   - Module-level async functions (matching `auth_service.py` pattern — no class needed):
+   
+   - `checkpoint(session, voyage_id, crew_member, state_data, reason) -> VivreCard`:
+     - Create a new VivreCard record
+     - Commit and refresh
+     - Return the created model instance
+   
+   - `restore(session, card_id) -> VivreCard`:
+     - Fetch a VivreCard by ID
+     - Raise `VivreCardError("CARD_NOT_FOUND", "Vivre Card not found", 404)` if not found
+     - Return the model instance (caller decides what to do with state_data)
+   
+   - `list_cards(session, voyage_id, crew_member=None, limit=20, offset=0) -> tuple[list[VivreCard], int]`:
+     - Query vivre_cards filtered by voyage_id
+     - Optionally filter by crew_member if provided
+     - Order by created_at DESC (most recent first)
+     - Return (items, total_count) for pagination
+   
+   - `diff(session, card_id_a, card_id_b) -> dict`:
+     - Fetch both cards (raise VivreCardError if either not found)
+     - Compute a shallow diff of `state_data` JSONB:
+       - `added`: keys in B's state_data not in A's
+       - `removed`: keys in A's state_data not in B's
+       - `changed`: keys in both where values differ — `{"before": a_val, "after": b_val}`
+     - Return the diff dict
+   
+   - `cleanup(session, voyage_id, keep_last_n=10) -> tuple[int, int]`:
+     - For EACH crew_member that has cards in this voyage:
+       - Find all cards ordered by created_at DESC
+       - Keep the most recent `keep_last_n`
+       - Delete the rest
+     - Return (deleted_count, kept_count)
+   
+   - `VivreCardError` exception class (same pattern as `AuthError`):
+     - `code: str`, `message: str`, `status_code: int`
+
+4. **REST API** (`app/api/v1/vivre_cards.py`):
+   - Router prefix: `/voyages/{voyage_id}/vivre-cards`, tags: `["vivre-cards"]`
+   - All endpoints require auth (`get_current_user`) and voyage ownership (`get_authorized_voyage`)
+   
+   - `GET /voyages/{voyage_id}/vivre-cards` → `VivreCardList`:
+     - Query params: `crew_member: CrewRole | None = None`, `limit: int = 20`, `offset: int = 0`
+     - Calls `list_cards()`
+   
+   - `POST /voyages/{voyage_id}/vivre-cards` → `VivreCardRead` (status 201):
+     - Body: `VivreCardCreate` (crew_member, state_data, checkpoint_reason)
+     - Calls `checkpoint()`
+     - Publishes `CheckpointCreatedEvent` via Den Den Mushi after successful creation
+     - Stream key: use `stream_key(voyage_id)` from den_den_mushi constants
+   
+   - `GET /voyages/{voyage_id}/vivre-cards/{card_id}` → `VivreCardRead`:
+     - Calls `restore()` (same DB lookup, just returns the card)
+     - 404 if not found
+   
+   - `GET /voyages/{voyage_id}/vivre-cards/{card_id}/diff` → `VivreCardDiff`:
+     - Query param: `compare_to: uuid.UUID` (required)
+     - Calls `diff(card_id, compare_to)`
+     - 404 if either card not found
+   
+   - `POST /voyages/{voyage_id}/vivre-cards/{card_id}/restore` → `VivreCardRestore`:
+     - Calls `restore()`
+     - Returns state_data with a `restored_at` timestamp
+     - 404 if not found
+   
+   - `DELETE /voyages/{voyage_id}/vivre-cards/cleanup` → `CleanupResult`:
+     - Query param: `keep_last_n: int = 10`
+     - Calls `cleanup()`
+   
+   - All `VivreCardError` exceptions caught and converted to HTTPException with standard error shape: `{"error": {"code": "...", "message": "..."}}`
+   
+   - Wire into `app/api/v1/router.py`: add `vivre_cards_router` to `v1_router`
+
+5. **Config Settings** (`app/core/config.py`):
+   - Add `vivre_card_checkpoint_interval_seconds: int = 300` (5 minutes default)
+   - Add `vivre_card_cleanup_keep_last_n: int = 10`
+   - These are read by future agent execution phases; exposed in config now for consistency
+
+6. **Dial System Pre-Failover Hook** (`app/dial_system/router.py`):
+   - Add optional `on_provider_switch` callback to `DialSystemRouter.__init__()`:
+     - Type: `Callable[[CrewRole, str], Awaitable[None]] | None = None`
+   - In `route()`: when failover occurs (before publishing `ProviderSwitchedEvent`), call `await self._on_provider_switch(role, new_provider)` if the callback is set
+   - In `stream()`: same — call the hook before failover streaming begins
+   - This is the integration point where the agent execution layer (future phase) will wire `VivreCardService.checkpoint()` with reason `"failover"`
+
+## Input
+
+- Existing `VivreCard` model at `src/backend/app/models/vivre_card.py` — id (UUID), voyage_id (FK), crew_member (str), state_data (JSONB), checkpoint_reason (str), created_at (datetime)
+- Existing `VivreCardCreate` / `VivreCardRead` at `src/backend/app/schemas/vivre_card.py`
+- Existing `CheckpointReason` enum: interval, failover, pause, migration
+- Existing `CrewRole` enum: captain, navigator, doctor, shipwright, helmsman
+- Existing `DenDenMushi` at `src/backend/app/den_den_mushi/mushi.py` — `publish(stream, event)`
+- Existing `stream_key()` at `src/backend/app/den_den_mushi/constants.py`
+- Existing `DialSystemRouter` at `src/backend/app/dial_system/router.py`
+- Existing `get_authorized_voyage` dependency at `src/backend/app/api/v1/dependencies.py`
+- Existing `AuthError` pattern at `src/backend/app/services/auth_service.py`
+
+## Output format
+
+- Python files following existing conventions (async, type-annotated, Pydantic v2)
+- Service functions at module level (no class — matching auth_service.py pattern)
+- Unit tests with in-memory SQLite or mocked sessions
+- Tests written BEFORE implementation (TDD)
+- All new files under `src/backend/app/` and `src/backend/tests/`
+
+## Constraints
+
+- Service takes `AsyncSession` as first parameter (dependency injection)
+- Service does NOT publish events — the API layer publishes after successful service calls
+- State diff is shallow (top-level keys only) — deep nested diff is over-engineering for v1
+- Cleanup operates per-crew-member within a voyage (each crew member keeps their own N most recent)
+- All endpoints nested under `/voyages/{voyage_id}/` to enforce voyage ownership
+- `VivreCardError` follows the same pattern as `AuthError` (code, message, status_code)
+- No raw SQL — use SQLAlchemy ORM queries
+- Consistent error shape: `{"error": {"code": "...", "message": "..."}}`
+- The `on_provider_switch` hook on DialSystemRouter is optional and backward-compatible (existing tests must still pass)
+
+## Edge Cases
+
+- `restore()` with non-existent card_id → `VivreCardError("CARD_NOT_FOUND", ..., 404)`
+- `diff()` where one or both cards don't exist → `VivreCardError("CARD_NOT_FOUND", ..., 404)`
+- `diff()` where both cards have identical state_data → all three diff dicts are empty
+- `cleanup()` on a voyage with no cards → returns (0, 0)
+- `cleanup()` with `keep_last_n` >= total cards for a crew member → nothing deleted for that member
+- `list_cards()` with offset beyond total → returns empty list, total still reflects actual count
+- `state_data` with nested dicts — diff only compares top-level keys, nested changes show full before/after value
+- `checkpoint_reason` must be a valid `CheckpointReason` enum value (validated by Pydantic schema)
+- `crew_member` must be a valid `CrewRole` enum value (validated by Pydantic schema)
+- Empty `state_data` (`{}`) is valid — an agent with no state is still checkpointable
+- `on_provider_switch` hook that raises — should not prevent failover from completing (catch and log)
+- Multiple concurrent checkpoints for same crew_member — each gets its own card, no conflict
+
+## Test Plan
+
+### tests/test_vivre_card_service.py
+- `test_checkpoint_creates_card` — happy path, verify all fields persisted
+- `test_checkpoint_stores_jsonb_state` — complex nested state round-trips correctly
+- `test_restore_returns_card` — fetch by ID, verify state_data matches
+- `test_restore_not_found_raises` — non-existent ID raises VivreCardError
+- `test_list_cards_by_voyage` — returns cards for correct voyage only
+- `test_list_cards_filter_by_crew_member` — filtering works
+- `test_list_cards_pagination` — limit/offset respected, total accurate
+- `test_list_cards_ordered_by_created_at_desc` — most recent first
+- `test_diff_added_keys` — key in B not in A shows as added
+- `test_diff_removed_keys` — key in A not in B shows as removed
+- `test_diff_changed_keys` — same key, different value shows before/after
+- `test_diff_identical_states` — empty diff result
+- `test_diff_card_not_found` — raises VivreCardError
+- `test_cleanup_deletes_old_cards` — keeps N most recent per crew member
+- `test_cleanup_no_cards` — returns (0, 0)
+- `test_cleanup_per_crew_member` — each crew member's cards cleaned independently
+
+### tests/test_vivre_card_api.py
+- `test_create_checkpoint_201` — POST returns created card
+- `test_create_checkpoint_publishes_event` — CheckpointCreatedEvent published via Den Den Mushi
+- `test_list_checkpoints` — GET returns paginated list
+- `test_list_checkpoints_filter_crew` — crew_member query param works
+- `test_get_checkpoint_by_id` — GET single card
+- `test_get_checkpoint_not_found_404` — non-existent card
+- `test_diff_checkpoints` — GET diff endpoint
+- `test_restore_checkpoint` — POST restore returns state_data + restored_at
+- `test_cleanup_checkpoints` — DELETE cleanup returns counts
+- `test_unauthorized_401` — no token → 401
+- `test_wrong_voyage_404` — other user's voyage → 404
+
+### tests/test_vivre_card_events.py
+- `test_checkpoint_created_event_serializes` — model_dump_json round-trips
+- `test_checkpoint_created_event_parses` — parse_event recognizes it
+- `test_checkpoint_created_event_in_any_event` — discriminator works
+
+### tests/test_dial_router_hook.py
+- `test_on_provider_switch_called_on_failover` — hook fires when primary fails
+- `test_on_provider_switch_called_on_stream_failover` — hook fires during stream failover
+- `test_on_provider_switch_not_called_when_primary_succeeds` — no hook call on success
+- `test_on_provider_switch_none_is_safe` — no callback set, no crash
+- `test_on_provider_switch_error_does_not_block_failover` — hook exception is caught and logged

--- a/src/backend/app/api/v1/router.py
+++ b/src/backend/app/api/v1/router.py
@@ -3,8 +3,10 @@ from fastapi import APIRouter
 from app.api.v1.auth import router as auth_router
 from app.api.v1.dial import router as dial_router
 from app.api.v1.health import router as health_router
+from app.api.v1.vivre_cards import router as vivre_cards_router
 
 v1_router = APIRouter(prefix="/api/v1")
 v1_router.include_router(health_router, tags=["health"])
 v1_router.include_router(auth_router)
 v1_router.include_router(dial_router)
+v1_router.include_router(vivre_cards_router)

--- a/src/backend/app/api/v1/vivre_cards.py
+++ b/src/backend/app/api/v1/vivre_cards.py
@@ -1,0 +1,170 @@
+"""REST API endpoints for Vivre Card state checkpointing."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.v1.dependencies import get_authorized_voyage, get_den_den_mushi
+from app.den_den_mushi.constants import stream_key
+from app.den_den_mushi.events import CheckpointCreatedEvent
+from app.den_den_mushi.mushi import DenDenMushi
+from app.models import get_db
+from app.models.enums import CrewRole
+from app.models.voyage import Voyage
+from app.schemas.vivre_card import (
+    CleanupResult,
+    VivreCardCreate,
+    VivreCardDiff,
+    VivreCardList,
+    VivreCardRead,
+    VivreCardRestore,
+)
+from app.services.vivre_card_service import (
+    VivreCardError,
+    checkpoint,
+    cleanup,
+    diff,
+    list_cards,
+    restore,
+)
+
+router = APIRouter(prefix="/voyages/{voyage_id}/vivre-cards", tags=["vivre-cards"])
+
+
+@router.post("", response_model=VivreCardRead, status_code=201)
+async def create_checkpoint(
+    voyage_id: uuid.UUID,
+    body: VivreCardCreate,
+    session: AsyncSession = Depends(get_db),
+    voyage: Voyage = Depends(get_authorized_voyage),
+    mushi: DenDenMushi = Depends(get_den_den_mushi),
+) -> VivreCardRead:
+    try:
+        card = await checkpoint(
+            session,
+            voyage_id=voyage_id,
+            crew_member=body.crew_member.value,
+            state_data=body.state_data,
+            reason=body.checkpoint_reason.value,
+        )
+    except VivreCardError as exc:
+        raise HTTPException(
+            status_code=exc.status_code,
+            detail={"error": {"code": exc.code, "message": exc.message}},
+        ) from exc
+
+    event = CheckpointCreatedEvent(
+        voyage_id=voyage_id,
+        source_role=body.crew_member,
+        payload={
+            "card_id": str(card.id),
+            "crew_member": body.crew_member.value,
+            "reason": body.checkpoint_reason.value,
+        },
+    )
+    await mushi.publish(stream_key(voyage_id), event)
+
+    return VivreCardRead.model_validate(card)
+
+
+@router.get("", response_model=VivreCardList)
+async def list_checkpoints(
+    voyage_id: uuid.UUID,
+    session: AsyncSession = Depends(get_db),
+    voyage: Voyage = Depends(get_authorized_voyage),
+    crew_member: CrewRole | None = Query(default=None),
+    limit: int = Query(default=20, ge=1, le=100),
+    offset: int = Query(default=0, ge=0),
+) -> VivreCardList:
+    member_str = crew_member.value if crew_member else None
+    items, total = await list_cards(
+        session, voyage_id, crew_member=member_str, limit=limit, offset=offset
+    )
+    return VivreCardList(
+        items=[VivreCardRead.model_validate(c) for c in items],
+        total=total,
+        limit=limit,
+        offset=offset,
+    )
+
+
+@router.get("/{card_id}", response_model=VivreCardRead)
+async def get_checkpoint(
+    voyage_id: uuid.UUID,
+    card_id: uuid.UUID,
+    session: AsyncSession = Depends(get_db),
+    voyage: Voyage = Depends(get_authorized_voyage),
+) -> VivreCardRead:
+    try:
+        card = await restore(session, card_id)
+    except VivreCardError as exc:
+        raise HTTPException(
+            status_code=exc.status_code,
+            detail={"error": {"code": exc.code, "message": exc.message}},
+        ) from exc
+    return VivreCardRead.model_validate(card)
+
+
+@router.get("/{card_id}/diff", response_model=VivreCardDiff)
+async def diff_checkpoints(
+    voyage_id: uuid.UUID,
+    card_id: uuid.UUID,
+    session: AsyncSession = Depends(get_db),
+    voyage: Voyage = Depends(get_authorized_voyage),
+    compare_to: uuid.UUID = Query(...),
+) -> VivreCardDiff:
+    try:
+        result = await diff(session, card_id, compare_to)
+    except VivreCardError as exc:
+        raise HTTPException(
+            status_code=exc.status_code,
+            detail={"error": {"code": exc.code, "message": exc.message}},
+        ) from exc
+    return VivreCardDiff(
+        card_a_id=card_id,
+        card_b_id=compare_to,
+        **result,
+    )
+
+
+@router.post("/{card_id}/restore", response_model=VivreCardRestore)
+async def restore_checkpoint(
+    voyage_id: uuid.UUID,
+    card_id: uuid.UUID,
+    session: AsyncSession = Depends(get_db),
+    voyage: Voyage = Depends(get_authorized_voyage),
+) -> VivreCardRestore:
+    try:
+        card = await restore(session, card_id)
+    except VivreCardError as exc:
+        raise HTTPException(
+            status_code=exc.status_code,
+            detail={"error": {"code": exc.code, "message": exc.message}},
+        ) from exc
+    return VivreCardRestore(
+        card_id=card.id,
+        voyage_id=card.voyage_id,
+        crew_member=card.crew_member,
+        state_data=card.state_data,
+        checkpoint_reason=card.checkpoint_reason,
+        restored_at=datetime.now(UTC),
+    )
+
+
+@router.delete("/cleanup", response_model=CleanupResult)
+async def cleanup_checkpoints(
+    voyage_id: uuid.UUID,
+    session: AsyncSession = Depends(get_db),
+    voyage: Voyage = Depends(get_authorized_voyage),
+    keep_last_n: int = Query(default=10, ge=1),
+) -> CleanupResult:
+    deleted, kept = await cleanup(session, voyage_id, keep_last_n=keep_last_n)
+    return CleanupResult(
+        deleted_count=deleted,
+        kept_count=kept,
+        voyage_id=voyage_id,
+    )

--- a/src/backend/app/api/v1/vivre_cards.py
+++ b/src/backend/app/api/v1/vivre_cards.py
@@ -100,7 +100,7 @@ async def get_checkpoint(
     voyage: Voyage = Depends(get_authorized_voyage),
 ) -> VivreCardRead:
     try:
-        card = await restore(session, card_id)
+        card = await restore(session, card_id, voyage_id)
     except VivreCardError as exc:
         raise HTTPException(
             status_code=exc.status_code,
@@ -118,7 +118,7 @@ async def diff_checkpoints(
     compare_to: uuid.UUID = Query(...),
 ) -> VivreCardDiff:
     try:
-        result = await diff(session, card_id, compare_to)
+        result = await diff(session, card_id, compare_to, voyage_id)
     except VivreCardError as exc:
         raise HTTPException(
             status_code=exc.status_code,
@@ -139,7 +139,7 @@ async def restore_checkpoint(
     voyage: Voyage = Depends(get_authorized_voyage),
 ) -> VivreCardRestore:
     try:
-        card = await restore(session, card_id)
+        card = await restore(session, card_id, voyage_id)
     except VivreCardError as exc:
         raise HTTPException(
             status_code=exc.status_code,

--- a/src/backend/app/core/config.py
+++ b/src/backend/app/core/config.py
@@ -23,6 +23,10 @@ class Settings(BaseSettings):
     openai_api_key: str = ""
     ollama_base_url: str = "http://localhost:11434"
 
+    # Vivre Card (State Checkpointing)
+    vivre_card_checkpoint_interval_seconds: int = 300  # 5 minutes
+    vivre_card_cleanup_keep_last_n: int = 10
+
     # CORS
     cors_origins: list[str] = ["http://localhost:3000"]
 

--- a/src/backend/app/den_den_mushi/events.py
+++ b/src/backend/app/den_den_mushi/events.py
@@ -48,6 +48,10 @@ class ProviderSwitchedEvent(DenDenMushiEvent):
     event_type: Literal["provider_switched"] = "provider_switched"
 
 
+class CheckpointCreatedEvent(DenDenMushiEvent):
+    event_type: Literal["checkpoint_created"] = "checkpoint_created"
+
+
 AnyEvent = Annotated[
     VoyagePlanCreatedEvent
     | PoneglyphDraftedEvent
@@ -55,7 +59,8 @@ AnyEvent = Annotated[
     | CodeGeneratedEvent
     | ValidationPassedEvent
     | DeploymentCompletedEvent
-    | ProviderSwitchedEvent,
+    | ProviderSwitchedEvent
+    | CheckpointCreatedEvent,
     Field(discriminator="event_type"),
 ]
 

--- a/src/backend/app/dial_system/router.py
+++ b/src/backend/app/dial_system/router.py
@@ -112,8 +112,9 @@ class DialSystemRouter:
             if await self._is_rate_limited(fallback):
                 continue
             try:
-                await self._call_switch_hook(role, "fallback")
-                await self._publish_switch_event(role, "fallback")
+                fallback_name = self._get_provider_name(fallback)
+                await self._call_switch_hook(role, fallback_name)
+                await self._publish_switch_event(role, fallback_name)
                 async for token in fallback.stream(request):
                     yield token
                 return

--- a/src/backend/app/dial_system/router.py
+++ b/src/backend/app/dial_system/router.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 import uuid
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Awaitable, Callable
 
 from app.den_den_mushi.constants import stream_key
 from app.den_den_mushi.events import ProviderSwitchedEvent
@@ -23,12 +23,14 @@ class DialSystemRouter:
         mushi: DenDenMushi,
         voyage_id: uuid.UUID,
         rate_limiter: RateLimiter | None = None,
+        on_provider_switch: Callable[[CrewRole, str], Awaitable[None]] | None = None,
     ) -> None:
         self._role_mapping = role_mapping
         self._fallback_chains = fallback_chains
         self._mushi = mushi
         self._voyage_id = voyage_id
         self._rate_limiter = rate_limiter
+        self._on_provider_switch = on_provider_switch
 
     async def _is_rate_limited(self, adapter: ProviderAdapter) -> bool:
         """Check both adapter-level and Redis-level rate limits."""
@@ -76,6 +78,7 @@ class DialSystemRouter:
             if await self._is_rate_limited(fallback):
                 continue
             try:
+                await self._call_switch_hook(role, self._get_provider_name(fallback))
                 result = await fallback.complete(request)
                 if self._rate_limiter:
                     await self._rate_limiter.record_usage(
@@ -109,6 +112,7 @@ class DialSystemRouter:
             if await self._is_rate_limited(fallback):
                 continue
             try:
+                await self._call_switch_hook(role, "fallback")
                 await self._publish_switch_event(role, "fallback")
                 async for token in fallback.stream(request):
                     yield token
@@ -129,6 +133,15 @@ class DialSystemRouter:
                 await client.close()
             elif client is not None and hasattr(client, "aclose"):
                 await client.aclose()
+
+    async def _call_switch_hook(self, role: CrewRole, new_provider: str) -> None:
+        """Call the on_provider_switch hook if set. Errors are logged but do not block failover."""
+        if self._on_provider_switch is None:
+            return
+        try:
+            await self._on_provider_switch(role, new_provider)
+        except Exception as exc:
+            logger.warning("on_provider_switch hook failed for %s: %s", role.value, exc)
 
     async def _publish_switch_event(self, role: CrewRole, new_provider: str) -> None:
         event = ProviderSwitchedEvent(

--- a/src/backend/app/schemas/vivre_card.py
+++ b/src/backend/app/schemas/vivre_card.py
@@ -8,7 +8,6 @@ from app.models.enums import CheckpointReason, CrewRole
 
 
 class VivreCardCreate(BaseModel):
-    voyage_id: uuid.UUID
     crew_member: CrewRole
     state_data: dict[str, Any]
     checkpoint_reason: CheckpointReason
@@ -23,3 +22,35 @@ class VivreCardRead(BaseModel):
     state_data: dict[str, Any]
     checkpoint_reason: str
     created_at: datetime
+
+
+class VivreCardList(BaseModel):
+    items: list[VivreCardRead]
+    total: int
+    limit: int
+    offset: int
+
+
+class VivreCardDiff(BaseModel):
+    card_a_id: uuid.UUID
+    card_b_id: uuid.UUID
+    added: dict[str, Any]
+    removed: dict[str, Any]
+    changed: dict[str, dict[str, Any]]
+
+
+class VivreCardRestore(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    card_id: uuid.UUID
+    voyage_id: uuid.UUID
+    crew_member: str
+    state_data: dict[str, Any]
+    checkpoint_reason: str
+    restored_at: datetime
+
+
+class CleanupResult(BaseModel):
+    deleted_count: int
+    kept_count: int
+    voyage_id: uuid.UUID

--- a/src/backend/app/services/vivre_card_service.py
+++ b/src/backend/app/services/vivre_card_service.py
@@ -38,9 +38,11 @@ async def checkpoint(
     return card
 
 
-async def restore(session: AsyncSession, card_id: uuid.UUID) -> VivreCard:
-    """Fetch a Vivre Card by ID. Raises VivreCardError if not found."""
-    result = await session.execute(select(VivreCard).where(VivreCard.id == card_id))
+async def restore(session: AsyncSession, card_id: uuid.UUID, voyage_id: uuid.UUID) -> VivreCard:
+    """Fetch a Vivre Card by ID, scoped to a voyage. Raises VivreCardError if not found."""
+    result = await session.execute(
+        select(VivreCard).where(VivreCard.id == card_id, VivreCard.voyage_id == voyage_id)
+    )
     card = result.scalar_one_or_none()
     if card is None:
         raise VivreCardError("CARD_NOT_FOUND", "Vivre Card not found", 404)
@@ -77,14 +79,19 @@ async def diff(
     session: AsyncSession,
     card_id_a: uuid.UUID,
     card_id_b: uuid.UUID,
+    voyage_id: uuid.UUID,
 ) -> dict[str, Any]:
-    """Compute a shallow diff between two Vivre Card state snapshots."""
-    result_a = await session.execute(select(VivreCard).where(VivreCard.id == card_id_a))
+    """Compute a shallow diff between two Vivre Card state snapshots, scoped to a voyage."""
+    result_a = await session.execute(
+        select(VivreCard).where(VivreCard.id == card_id_a, VivreCard.voyage_id == voyage_id)
+    )
     card_a = result_a.scalar_one_or_none()
     if card_a is None:
         raise VivreCardError("CARD_NOT_FOUND", f"Vivre Card {card_id_a} not found", 404)
 
-    result_b = await session.execute(select(VivreCard).where(VivreCard.id == card_id_b))
+    result_b = await session.execute(
+        select(VivreCard).where(VivreCard.id == card_id_b, VivreCard.voyage_id == voyage_id)
+    )
     card_b = result_b.scalar_one_or_none()
     if card_b is None:
         raise VivreCardError("CARD_NOT_FOUND", f"Vivre Card {card_id_b} not found", 404)

--- a/src/backend/app/services/vivre_card_service.py
+++ b/src/backend/app/services/vivre_card_service.py
@@ -1,0 +1,148 @@
+"""VivreCardService — agent state checkpoint, restore, list, diff, and cleanup."""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+from sqlalchemy import delete, distinct, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.vivre_card import VivreCard
+
+
+class VivreCardError(Exception):
+    def __init__(self, code: str, message: str, status_code: int = 400) -> None:
+        self.code = code
+        self.message = message
+        self.status_code = status_code
+
+
+async def checkpoint(
+    session: AsyncSession,
+    voyage_id: uuid.UUID,
+    crew_member: str,
+    state_data: dict[str, Any],
+    reason: str,
+) -> VivreCard:
+    """Create a new Vivre Card checkpoint."""
+    card = VivreCard(
+        voyage_id=voyage_id,
+        crew_member=crew_member,
+        state_data=state_data,
+        checkpoint_reason=reason,
+    )
+    session.add(card)
+    await session.commit()
+    await session.refresh(card)
+    return card
+
+
+async def restore(session: AsyncSession, card_id: uuid.UUID) -> VivreCard:
+    """Fetch a Vivre Card by ID. Raises VivreCardError if not found."""
+    result = await session.execute(select(VivreCard).where(VivreCard.id == card_id))
+    card = result.scalar_one_or_none()
+    if card is None:
+        raise VivreCardError("CARD_NOT_FOUND", "Vivre Card not found", 404)
+    return card
+
+
+async def list_cards(
+    session: AsyncSession,
+    voyage_id: uuid.UUID,
+    crew_member: str | None = None,
+    limit: int = 20,
+    offset: int = 0,
+) -> tuple[list[VivreCard], int]:
+    """List Vivre Cards for a voyage with optional crew member filter and pagination."""
+    query = select(VivreCard).where(VivreCard.voyage_id == voyage_id)
+    count_query = select(func.count(VivreCard.id)).where(VivreCard.voyage_id == voyage_id)
+
+    if crew_member is not None:
+        query = query.where(VivreCard.crew_member == crew_member)
+        count_query = count_query.where(VivreCard.crew_member == crew_member)
+
+    query = query.order_by(VivreCard.created_at.desc()).limit(limit).offset(offset)
+
+    items_result = await session.execute(query)
+    items = list(items_result.scalars().all())
+
+    count_result = await session.execute(count_query)
+    total = count_result.scalar_one()
+
+    return items, total
+
+
+async def diff(
+    session: AsyncSession,
+    card_id_a: uuid.UUID,
+    card_id_b: uuid.UUID,
+) -> dict[str, Any]:
+    """Compute a shallow diff between two Vivre Card state snapshots."""
+    result_a = await session.execute(select(VivreCard).where(VivreCard.id == card_id_a))
+    card_a = result_a.scalar_one_or_none()
+    if card_a is None:
+        raise VivreCardError("CARD_NOT_FOUND", f"Vivre Card {card_id_a} not found", 404)
+
+    result_b = await session.execute(select(VivreCard).where(VivreCard.id == card_id_b))
+    card_b = result_b.scalar_one_or_none()
+    if card_b is None:
+        raise VivreCardError("CARD_NOT_FOUND", f"Vivre Card {card_id_b} not found", 404)
+
+    state_a = card_a.state_data
+    state_b = card_b.state_data
+
+    keys_a = set(state_a.keys())
+    keys_b = set(state_b.keys())
+
+    added = {k: state_b[k] for k in keys_b - keys_a}
+    removed = {k: state_a[k] for k in keys_a - keys_b}
+    changed = {
+        k: {"before": state_a[k], "after": state_b[k]}
+        for k in keys_a & keys_b
+        if state_a[k] != state_b[k]
+    }
+
+    return {"added": added, "removed": removed, "changed": changed}
+
+
+async def cleanup(
+    session: AsyncSession,
+    voyage_id: uuid.UUID,
+    keep_last_n: int = 10,
+) -> tuple[int, int]:
+    """Delete old checkpoints per crew member, keeping the N most recent."""
+    # Get distinct crew members for this voyage
+    crew_result = await session.execute(
+        select(distinct(VivreCard.crew_member)).where(VivreCard.voyage_id == voyage_id)
+    )
+    crew_members = list(crew_result.scalars().all())
+
+    if not crew_members:
+        return 0, 0
+
+    total_deleted = 0
+    total_kept = 0
+
+    for member in crew_members:
+        # Get all card IDs for this member ordered by created_at desc
+        ids_result = await session.execute(
+            select(VivreCard.id)
+            .where(VivreCard.voyage_id == voyage_id, VivreCard.crew_member == member)
+            .order_by(VivreCard.created_at.desc())
+        )
+        all_ids = list(ids_result.scalars().all())
+
+        ids_to_keep = all_ids[:keep_last_n]
+        ids_to_delete = all_ids[keep_last_n:]
+
+        total_kept += len(ids_to_keep)
+
+        if ids_to_delete:
+            result = await session.execute(delete(VivreCard).where(VivreCard.id.in_(ids_to_delete)))
+            total_deleted += result.rowcount
+
+    if total_deleted > 0:
+        await session.commit()
+
+    return total_deleted, total_kept

--- a/src/backend/tests/test_dial_router_hook.py
+++ b/src/backend/tests/test_dial_router_hook.py
@@ -1,0 +1,166 @@
+"""Tests for DialSystemRouter on_provider_switch hook."""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.den_den_mushi.mushi import DenDenMushi
+from app.dial_system.adapters.base import ProviderAdapter, ProviderError
+from app.dial_system.router import DialSystemRouter
+from app.models.enums import CrewRole
+from app.schemas.dial_system import (
+    CompletionRequest,
+    CompletionResult,
+    RateLimitStatus,
+    TokenUsage,
+)
+
+VOYAGE_ID = uuid.uuid4()
+
+
+def _make_request() -> CompletionRequest:
+    return CompletionRequest(
+        messages=[{"role": "user", "content": "Checkpoint test"}],
+        role=CrewRole.CAPTAIN,
+        max_tokens=100,
+    )
+
+
+def _make_result(provider: str = "anthropic") -> CompletionResult:
+    return CompletionResult(
+        content="Result",
+        provider=provider,
+        model="test-model",
+        usage=TokenUsage(prompt_tokens=5, completion_tokens=3, total_tokens=8),
+    )
+
+
+def _make_adapter(
+    result: CompletionResult | None = None,
+    limited: bool = False,
+    fail: bool = False,
+) -> ProviderAdapter:
+    adapter = AsyncMock(spec=ProviderAdapter)
+    if fail:
+        adapter.complete.side_effect = ProviderError("Provider failed")
+        adapter.stream.side_effect = ProviderError("Provider failed")
+    else:
+        adapter.complete.return_value = result or _make_result()
+
+        async def _stream(req: CompletionRequest) -> None:
+            yield "token1"
+            yield "token2"
+
+        adapter.stream = _stream
+    adapter.check_rate_limit.return_value = RateLimitStatus(is_limited=limited)
+    return adapter
+
+
+class TestOnProviderSwitchHook:
+    @pytest.mark.asyncio
+    async def test_hook_called_on_failover(self) -> None:
+        primary = _make_adapter(fail=True)
+        fallback = _make_adapter(result=_make_result("openai"))
+        hook = AsyncMock()
+
+        router = DialSystemRouter(
+            role_mapping={CrewRole.CAPTAIN: primary},
+            fallback_chains={CrewRole.CAPTAIN: [fallback]},
+            mushi=AsyncMock(spec=DenDenMushi),
+            voyage_id=VOYAGE_ID,
+            on_provider_switch=hook,
+        )
+
+        await router.route(CrewRole.CAPTAIN, _make_request())
+
+        hook.assert_awaited_once()
+        call_args = hook.call_args[0]
+        assert call_args[0] == CrewRole.CAPTAIN
+
+    @pytest.mark.asyncio
+    async def test_hook_called_on_stream_failover(self) -> None:
+        primary = _make_adapter(fail=True)
+
+        fallback = AsyncMock(spec=ProviderAdapter)
+        fallback.check_rate_limit.return_value = RateLimitStatus(is_limited=False)
+
+        async def _fallback_stream(req: CompletionRequest):
+            yield "token1"
+
+        fallback.stream = _fallback_stream
+        hook = AsyncMock()
+
+        router = DialSystemRouter(
+            role_mapping={CrewRole.CAPTAIN: primary},
+            fallback_chains={CrewRole.CAPTAIN: [fallback]},
+            mushi=AsyncMock(spec=DenDenMushi),
+            voyage_id=VOYAGE_ID,
+            on_provider_switch=hook,
+        )
+
+        tokens = []
+        async for token in router.stream(CrewRole.CAPTAIN, _make_request()):
+            tokens.append(token)
+
+        hook.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_hook_not_called_when_primary_succeeds(self) -> None:
+        primary = _make_adapter()
+        hook = AsyncMock()
+
+        router = DialSystemRouter(
+            role_mapping={CrewRole.CAPTAIN: primary},
+            fallback_chains={},
+            mushi=AsyncMock(spec=DenDenMushi),
+            voyage_id=VOYAGE_ID,
+            on_provider_switch=hook,
+        )
+
+        await router.route(CrewRole.CAPTAIN, _make_request())
+
+        hook.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_hook_none_is_safe(self) -> None:
+        primary = _make_adapter(fail=True)
+        fallback = _make_adapter(result=_make_result("openai"))
+
+        router = DialSystemRouter(
+            role_mapping={CrewRole.CAPTAIN: primary},
+            fallback_chains={CrewRole.CAPTAIN: [fallback]},
+            mushi=AsyncMock(spec=DenDenMushi),
+            voyage_id=VOYAGE_ID,
+            # no on_provider_switch — should default to None
+        )
+
+        # Should not crash
+        result = await router.route(CrewRole.CAPTAIN, _make_request())
+        assert result.provider == "openai"
+
+    @pytest.mark.asyncio
+    async def test_hook_error_does_not_block_failover(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        primary = _make_adapter(fail=True)
+        fallback = _make_adapter(result=_make_result("openai"))
+        hook = AsyncMock(side_effect=RuntimeError("Hook blew up"))
+
+        router = DialSystemRouter(
+            role_mapping={CrewRole.CAPTAIN: primary},
+            fallback_chains={CrewRole.CAPTAIN: [fallback]},
+            mushi=AsyncMock(spec=DenDenMushi),
+            voyage_id=VOYAGE_ID,
+            on_provider_switch=hook,
+        )
+
+        with caplog.at_level(logging.WARNING):
+            result = await router.route(CrewRole.CAPTAIN, _make_request())
+
+        # Failover still succeeded despite hook error
+        assert result.provider == "openai"
+        hook.assert_awaited_once()

--- a/src/backend/tests/test_vivre_card_api.py
+++ b/src/backend/tests/test_vivre_card_api.py
@@ -225,3 +225,94 @@ class TestCleanupCheckpoints:
         assert result.deleted_count == 8
         assert result.kept_count == 10
         assert result.voyage_id == VOYAGE_ID
+
+
+class TestAuthorization:
+    @pytest.mark.asyncio
+    async def test_get_authorized_voyage_rejects_missing_user(self) -> None:
+        """get_current_user dependency raises 401 when no token is provided."""
+        from app.api.v1.dependencies import get_current_user
+
+        with pytest.raises(HTTPException) as exc_info:
+            await get_current_user(credentials=None, session=AsyncMock())
+
+        assert exc_info.value.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_get_authorized_voyage_rejects_wrong_voyage(self) -> None:
+        """get_authorized_voyage raises 404 when voyage doesn't belong to user."""
+        from app.api.v1.dependencies import get_authorized_voyage
+
+        session = AsyncMock()
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None  # no matching voyage
+        session.execute.return_value = mock_result
+
+        user = MagicMock()
+        user.id = uuid.uuid4()
+
+        with pytest.raises(HTTPException) as exc_info:
+            await get_authorized_voyage(uuid.uuid4(), session, user)
+
+        assert exc_info.value.status_code == 404
+
+
+class TestCrossVoyageScoping:
+    @pytest.mark.asyncio
+    async def test_get_checkpoint_from_other_voyage_returns_404(self) -> None:
+        """Card exists but belongs to a different voyage — must return 404."""
+        from app.api.v1.vivre_cards import get_checkpoint
+        from app.services.vivre_card_service import VivreCardError
+
+        session = AsyncMock()
+        voyage = MagicMock()
+        voyage.id = VOYAGE_ID
+
+        foreign_card_id = uuid.uuid4()
+        with patch("app.api.v1.vivre_cards.restore", new_callable=AsyncMock) as mock_restore:
+            mock_restore.side_effect = VivreCardError("CARD_NOT_FOUND", "Not found", 404)
+            with pytest.raises(HTTPException) as exc_info:
+                await get_checkpoint(VOYAGE_ID, foreign_card_id, session, voyage)
+
+        assert exc_info.value.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_restore_from_other_voyage_returns_404(self) -> None:
+        """Restore a card that belongs to another voyage — must return 404."""
+        from app.api.v1.vivre_cards import restore_checkpoint
+        from app.services.vivre_card_service import VivreCardError
+
+        session = AsyncMock()
+        voyage = MagicMock()
+        voyage.id = VOYAGE_ID
+
+        foreign_card_id = uuid.uuid4()
+        with patch("app.api.v1.vivre_cards.restore", new_callable=AsyncMock) as mock_restore:
+            mock_restore.side_effect = VivreCardError("CARD_NOT_FOUND", "Not found", 404)
+            with pytest.raises(HTTPException) as exc_info:
+                await restore_checkpoint(VOYAGE_ID, foreign_card_id, session, voyage)
+
+        assert exc_info.value.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_diff_with_foreign_card_returns_404(self) -> None:
+        """Diffing against a card from another voyage — must return 404."""
+        from app.api.v1.vivre_cards import diff_checkpoints
+        from app.services.vivre_card_service import VivreCardError
+
+        session = AsyncMock()
+        voyage = MagicMock()
+        voyage.id = VOYAGE_ID
+
+        with patch("app.api.v1.vivre_cards.diff", new_callable=AsyncMock) as mock_diff:
+            mock_diff.side_effect = VivreCardError("CARD_NOT_FOUND", "Not found", 404)
+            with pytest.raises(HTTPException) as exc_info:
+                await diff_checkpoints(
+                    VOYAGE_ID,
+                    uuid.uuid4(),
+                    session,
+                    voyage,
+                    compare_to=uuid.uuid4(),
+                )
+
+        assert exc_info.value.status_code == 404

--- a/src/backend/tests/test_vivre_card_api.py
+++ b/src/backend/tests/test_vivre_card_api.py
@@ -1,0 +1,227 @@
+"""Tests for Vivre Card REST API endpoints."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from app.models.enums import CheckpointReason, CrewRole
+from app.models.vivre_card import VivreCard
+
+VOYAGE_ID = uuid.uuid4()
+CARD_ID = uuid.uuid4()
+
+
+def _make_card(
+    voyage_id: uuid.UUID | None = None,
+    crew_member: str = "captain",
+    state_data: dict[str, Any] | None = None,
+    reason: str = "interval",
+    card_id: uuid.UUID | None = None,
+) -> VivreCard:
+    card = VivreCard(
+        id=card_id or uuid.uuid4(),
+        voyage_id=voyage_id or VOYAGE_ID,
+        crew_member=crew_member,
+        state_data=state_data or {"step": 1},
+        checkpoint_reason=reason,
+    )
+    card.created_at = datetime.now(UTC)
+    return card
+
+
+class TestCreateCheckpoint:
+    @pytest.mark.asyncio
+    async def test_create_checkpoint_201(self) -> None:
+        from app.api.v1.vivre_cards import create_checkpoint
+        from app.schemas.vivre_card import VivreCardCreate
+
+        card = _make_card(voyage_id=VOYAGE_ID)
+        body = VivreCardCreate(
+            crew_member=CrewRole.CAPTAIN,
+            state_data={"step": 1},
+            checkpoint_reason=CheckpointReason.INTERVAL,
+        )
+        session = AsyncMock()
+        voyage = MagicMock()
+        voyage.id = VOYAGE_ID
+        mushi = AsyncMock()
+
+        with patch("app.api.v1.vivre_cards.checkpoint", new_callable=AsyncMock) as mock_cp:
+            mock_cp.return_value = card
+            result = await create_checkpoint(VOYAGE_ID, body, session, voyage, mushi)
+
+        assert result.voyage_id == VOYAGE_ID
+        mock_cp.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_create_checkpoint_publishes_event(self) -> None:
+        from app.api.v1.vivre_cards import create_checkpoint
+        from app.schemas.vivre_card import VivreCardCreate
+
+        card = _make_card(voyage_id=VOYAGE_ID)
+        body = VivreCardCreate(
+            crew_member=CrewRole.CAPTAIN,
+            state_data={"step": 1},
+            checkpoint_reason=CheckpointReason.INTERVAL,
+        )
+        session = AsyncMock()
+        voyage = MagicMock()
+        voyage.id = VOYAGE_ID
+        mushi = AsyncMock()
+
+        with patch("app.api.v1.vivre_cards.checkpoint", new_callable=AsyncMock) as mock_cp:
+            mock_cp.return_value = card
+            await create_checkpoint(VOYAGE_ID, body, session, voyage, mushi)
+
+        mushi.publish.assert_awaited_once()
+        published_event = mushi.publish.call_args[0][1]
+        assert published_event.event_type == "checkpoint_created"
+
+
+class TestListCheckpoints:
+    @pytest.mark.asyncio
+    async def test_list_checkpoints(self) -> None:
+        from app.api.v1.vivre_cards import list_checkpoints
+
+        cards = [_make_card(voyage_id=VOYAGE_ID) for _ in range(2)]
+
+        session = AsyncMock()
+        voyage = MagicMock()
+        voyage.id = VOYAGE_ID
+
+        with patch("app.api.v1.vivre_cards.list_cards", new_callable=AsyncMock) as mock_list:
+            mock_list.return_value = (cards, 2)
+            result = await list_checkpoints(
+                VOYAGE_ID, session, voyage, crew_member=None, limit=20, offset=0
+            )
+
+        assert result.total == 2
+        assert len(result.items) == 2
+        assert result.limit == 20
+        assert result.offset == 0
+
+    @pytest.mark.asyncio
+    async def test_list_checkpoints_filter_crew(self) -> None:
+        from app.api.v1.vivre_cards import list_checkpoints
+
+        cards = [_make_card(voyage_id=VOYAGE_ID, crew_member="navigator")]
+
+        session = AsyncMock()
+        voyage = MagicMock()
+        voyage.id = VOYAGE_ID
+
+        with patch("app.api.v1.vivre_cards.list_cards", new_callable=AsyncMock) as mock_list:
+            mock_list.return_value = (cards, 1)
+            await list_checkpoints(
+                VOYAGE_ID, session, voyage, crew_member=CrewRole.NAVIGATOR, limit=20, offset=0
+            )
+
+        mock_list.assert_awaited_once()
+        call_kwargs = mock_list.call_args
+        assert call_kwargs[1].get("crew_member") == "navigator"
+
+
+class TestGetCheckpoint:
+    @pytest.mark.asyncio
+    async def test_get_checkpoint_by_id(self) -> None:
+        from app.api.v1.vivre_cards import get_checkpoint
+
+        card = _make_card(card_id=CARD_ID, voyage_id=VOYAGE_ID)
+
+        session = AsyncMock()
+        voyage = MagicMock()
+        voyage.id = VOYAGE_ID
+
+        with patch("app.api.v1.vivre_cards.restore", new_callable=AsyncMock) as mock_restore:
+            mock_restore.return_value = card
+            result = await get_checkpoint(VOYAGE_ID, CARD_ID, session, voyage)
+
+        assert result.id == CARD_ID
+
+    @pytest.mark.asyncio
+    async def test_get_checkpoint_not_found_404(self) -> None:
+        from app.api.v1.vivre_cards import get_checkpoint
+        from app.services.vivre_card_service import VivreCardError
+
+        session = AsyncMock()
+        voyage = MagicMock()
+        voyage.id = VOYAGE_ID
+
+        with patch("app.api.v1.vivre_cards.restore", new_callable=AsyncMock) as mock_restore:
+            mock_restore.side_effect = VivreCardError("CARD_NOT_FOUND", "Not found", 404)
+            with pytest.raises(HTTPException) as exc_info:
+                await get_checkpoint(VOYAGE_ID, uuid.uuid4(), session, voyage)
+
+        assert exc_info.value.status_code == 404
+
+
+class TestDiffCheckpoints:
+    @pytest.mark.asyncio
+    async def test_diff_checkpoints(self) -> None:
+        from app.api.v1.vivre_cards import diff_checkpoints
+
+        card_a_id = uuid.uuid4()
+        card_b_id = uuid.uuid4()
+        diff_result = {
+            "added": {"output": "done"},
+            "removed": {},
+            "changed": {"step": {"before": 1, "after": 3}},
+        }
+
+        session = AsyncMock()
+        voyage = MagicMock()
+        voyage.id = VOYAGE_ID
+
+        with patch("app.api.v1.vivre_cards.diff", new_callable=AsyncMock) as mock_diff:
+            mock_diff.return_value = diff_result
+            result = await diff_checkpoints(
+                VOYAGE_ID, card_a_id, session, voyage, compare_to=card_b_id
+            )
+
+        assert result.card_a_id == card_a_id
+        assert result.card_b_id == card_b_id
+        assert result.added == {"output": "done"}
+
+
+class TestRestoreCheckpoint:
+    @pytest.mark.asyncio
+    async def test_restore_checkpoint(self) -> None:
+        from app.api.v1.vivre_cards import restore_checkpoint
+
+        card = _make_card(card_id=CARD_ID, voyage_id=VOYAGE_ID, state_data={"step": 5})
+
+        session = AsyncMock()
+        voyage = MagicMock()
+        voyage.id = VOYAGE_ID
+
+        with patch("app.api.v1.vivre_cards.restore", new_callable=AsyncMock) as mock_restore:
+            mock_restore.return_value = card
+            result = await restore_checkpoint(VOYAGE_ID, CARD_ID, session, voyage)
+
+        assert result.card_id == CARD_ID
+        assert result.state_data == {"step": 5}
+        assert result.restored_at is not None
+
+
+class TestCleanupCheckpoints:
+    @pytest.mark.asyncio
+    async def test_cleanup_checkpoints(self) -> None:
+        from app.api.v1.vivre_cards import cleanup_checkpoints
+
+        session = AsyncMock()
+        voyage = MagicMock()
+        voyage.id = VOYAGE_ID
+
+        with patch("app.api.v1.vivre_cards.cleanup", new_callable=AsyncMock) as mock_cleanup:
+            mock_cleanup.return_value = (8, 10)
+            result = await cleanup_checkpoints(VOYAGE_ID, session, voyage)
+
+        assert result.deleted_count == 8
+        assert result.kept_count == 10
+        assert result.voyage_id == VOYAGE_ID

--- a/src/backend/tests/test_vivre_card_events.py
+++ b/src/backend/tests/test_vivre_card_events.py
@@ -1,0 +1,86 @@
+"""Tests for CheckpointCreatedEvent integration with Den Den Mushi event system."""
+
+from __future__ import annotations
+
+import json
+import uuid
+
+import pytest
+from pydantic import ValidationError
+
+from app.den_den_mushi.events import (
+    CheckpointCreatedEvent,
+    parse_event,
+)
+from app.models.enums import CrewRole
+
+VOYAGE_ID = uuid.uuid4()
+
+
+class TestCheckpointCreatedEvent:
+    def test_event_type_is_checkpoint_created(self) -> None:
+        event = CheckpointCreatedEvent(
+            voyage_id=VOYAGE_ID,
+            source_role=CrewRole.CAPTAIN,
+            payload={
+                "card_id": str(uuid.uuid4()),
+                "crew_member": "captain",
+                "reason": "interval",
+            },
+        )
+        assert event.event_type == "checkpoint_created"
+
+    def test_event_serializes_to_json(self) -> None:
+        event = CheckpointCreatedEvent(
+            voyage_id=VOYAGE_ID,
+            source_role=CrewRole.NAVIGATOR,
+            payload={
+                "card_id": str(uuid.uuid4()),
+                "crew_member": "navigator",
+                "reason": "failover",
+            },
+        )
+        json_str = event.model_dump_json()
+        data = json.loads(json_str)
+        assert data["event_type"] == "checkpoint_created"
+        assert data["source_role"] == "navigator"
+
+    def test_event_round_trips_through_parse(self) -> None:
+        event = CheckpointCreatedEvent(
+            voyage_id=VOYAGE_ID,
+            source_role=CrewRole.DOCTOR,
+            payload={
+                "card_id": str(uuid.uuid4()),
+                "crew_member": "doctor",
+                "reason": "pause",
+            },
+        )
+        json_str = event.model_dump_json()
+        restored = parse_event(json.loads(json_str))
+        assert isinstance(restored, CheckpointCreatedEvent)
+        assert restored.event_id == event.event_id
+        assert restored.voyage_id == event.voyage_id
+        assert restored.payload == event.payload
+
+    def test_parse_event_recognizes_checkpoint_created(self) -> None:
+        data = {
+            "event_type": "checkpoint_created",
+            "voyage_id": str(VOYAGE_ID),
+            "source_role": "captain",
+            "payload": {
+                "card_id": str(uuid.uuid4()),
+                "crew_member": "captain",
+                "reason": "migration",
+            },
+        }
+        event = parse_event(data)
+        assert isinstance(event, CheckpointCreatedEvent)
+
+    def test_event_is_immutable(self) -> None:
+        event = CheckpointCreatedEvent(
+            voyage_id=VOYAGE_ID,
+            source_role=CrewRole.CAPTAIN,
+            payload={},
+        )
+        with pytest.raises(ValidationError):
+            event.voyage_id = uuid.uuid4()  # type: ignore[misc]

--- a/src/backend/tests/test_vivre_card_service.py
+++ b/src/backend/tests/test_vivre_card_service.py
@@ -1,0 +1,344 @@
+"""Tests for VivreCardService — checkpoint, restore, list, diff, cleanup."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.models.enums import CheckpointReason, CrewRole
+from app.models.vivre_card import VivreCard
+
+
+def _make_card(
+    voyage_id: uuid.UUID | None = None,
+    crew_member: str = "captain",
+    state_data: dict[str, Any] | None = None,
+    reason: str = "interval",
+    card_id: uuid.UUID | None = None,
+    created_at: datetime | None = None,
+) -> VivreCard:
+    card = VivreCard(
+        id=card_id or uuid.uuid4(),
+        voyage_id=voyage_id or uuid.uuid4(),
+        crew_member=crew_member,
+        state_data=state_data or {"step": 1, "context": "test"},
+        checkpoint_reason=reason,
+    )
+    # Simulate the server_default
+    card.created_at = created_at or datetime.now(UTC)
+    return card
+
+
+VOYAGE_ID = uuid.uuid4()
+
+
+class TestCheckpoint:
+    @pytest.mark.asyncio
+    async def test_checkpoint_creates_card(self) -> None:
+        from app.services.vivre_card_service import checkpoint
+
+        session = AsyncMock()
+        state = {"step": 3, "messages": ["hello"]}
+
+        card = await checkpoint(
+            session,
+            voyage_id=VOYAGE_ID,
+            crew_member=CrewRole.CAPTAIN.value,
+            state_data=state,
+            reason=CheckpointReason.INTERVAL.value,
+        )
+
+        session.add.assert_called_once()
+        session.commit.assert_awaited_once()
+        session.refresh.assert_awaited_once()
+        assert card.voyage_id == VOYAGE_ID
+        assert card.crew_member == "captain"
+        assert card.state_data == state
+        assert card.checkpoint_reason == "interval"
+
+    @pytest.mark.asyncio
+    async def test_checkpoint_stores_nested_jsonb_state(self) -> None:
+        from app.services.vivre_card_service import checkpoint
+
+        session = AsyncMock()
+        nested_state = {
+            "step": 5,
+            "context": {"messages": [{"role": "user", "content": "plan"}]},
+            "metadata": {"tokens_used": 150, "model": "claude-sonnet-4-20250514"},
+        }
+
+        card = await checkpoint(
+            session,
+            voyage_id=VOYAGE_ID,
+            crew_member=CrewRole.NAVIGATOR.value,
+            state_data=nested_state,
+            reason=CheckpointReason.MIGRATION.value,
+        )
+
+        assert card.state_data == nested_state
+
+
+class TestRestore:
+    @pytest.mark.asyncio
+    async def test_restore_returns_card(self) -> None:
+        from app.services.vivre_card_service import restore
+
+        card_id = uuid.uuid4()
+        expected_card = _make_card(card_id=card_id, voyage_id=VOYAGE_ID)
+
+        session = AsyncMock()
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = expected_card
+        session.execute.return_value = mock_result
+
+        result = await restore(session, card_id)
+
+        assert result.id == card_id
+        assert result.state_data == expected_card.state_data
+
+    @pytest.mark.asyncio
+    async def test_restore_not_found_raises(self) -> None:
+        from app.services.vivre_card_service import VivreCardError, restore
+
+        session = AsyncMock()
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+        session.execute.return_value = mock_result
+
+        with pytest.raises(VivreCardError) as exc_info:
+            await restore(session, uuid.uuid4())
+
+        assert exc_info.value.code == "CARD_NOT_FOUND"
+        assert exc_info.value.status_code == 404
+
+
+class TestListCards:
+    @pytest.mark.asyncio
+    async def test_list_cards_by_voyage(self) -> None:
+        from app.services.vivre_card_service import list_cards
+
+        cards = [_make_card(voyage_id=VOYAGE_ID) for _ in range(3)]
+
+        session = AsyncMock()
+        # First call: items query
+        items_result = MagicMock()
+        items_result.scalars.return_value.all.return_value = cards
+        # Second call: count query
+        count_result = MagicMock()
+        count_result.scalar_one.return_value = 3
+        session.execute.side_effect = [items_result, count_result]
+
+        items, total = await list_cards(session, VOYAGE_ID)
+
+        assert len(items) == 3
+        assert total == 3
+
+    @pytest.mark.asyncio
+    async def test_list_cards_filter_by_crew_member(self) -> None:
+        from app.services.vivre_card_service import list_cards
+
+        cards = [_make_card(voyage_id=VOYAGE_ID, crew_member="captain")]
+
+        session = AsyncMock()
+        items_result = MagicMock()
+        items_result.scalars.return_value.all.return_value = cards
+        count_result = MagicMock()
+        count_result.scalar_one.return_value = 1
+        session.execute.side_effect = [items_result, count_result]
+
+        items, total = await list_cards(session, VOYAGE_ID, crew_member="captain")
+
+        assert len(items) == 1
+        assert total == 1
+
+    @pytest.mark.asyncio
+    async def test_list_cards_pagination(self) -> None:
+        from app.services.vivre_card_service import list_cards
+
+        cards = [_make_card(voyage_id=VOYAGE_ID)]
+
+        session = AsyncMock()
+        items_result = MagicMock()
+        items_result.scalars.return_value.all.return_value = cards
+        count_result = MagicMock()
+        count_result.scalar_one.return_value = 10  # total is more than returned
+        session.execute.side_effect = [items_result, count_result]
+
+        items, total = await list_cards(session, VOYAGE_ID, limit=5, offset=5)
+
+        assert len(items) == 1
+        assert total == 10
+
+    @pytest.mark.asyncio
+    async def test_list_cards_empty(self) -> None:
+        from app.services.vivre_card_service import list_cards
+
+        session = AsyncMock()
+        items_result = MagicMock()
+        items_result.scalars.return_value.all.return_value = []
+        count_result = MagicMock()
+        count_result.scalar_one.return_value = 0
+        session.execute.side_effect = [items_result, count_result]
+
+        items, total = await list_cards(session, VOYAGE_ID)
+
+        assert items == []
+        assert total == 0
+
+
+class TestDiff:
+    @pytest.mark.asyncio
+    async def test_diff_added_keys(self) -> None:
+        from app.services.vivre_card_service import diff
+
+        card_a = _make_card(state_data={"step": 1})
+        card_b = _make_card(state_data={"step": 1, "output": "done"})
+
+        session = AsyncMock()
+        mock_result_a = MagicMock()
+        mock_result_a.scalar_one_or_none.return_value = card_a
+        mock_result_b = MagicMock()
+        mock_result_b.scalar_one_or_none.return_value = card_b
+        session.execute.side_effect = [mock_result_a, mock_result_b]
+
+        result = await diff(session, card_a.id, card_b.id)
+
+        assert result["added"] == {"output": "done"}
+        assert result["removed"] == {}
+        assert result["changed"] == {}
+
+    @pytest.mark.asyncio
+    async def test_diff_removed_keys(self) -> None:
+        from app.services.vivre_card_service import diff
+
+        card_a = _make_card(state_data={"step": 1, "temp": "val"})
+        card_b = _make_card(state_data={"step": 1})
+
+        session = AsyncMock()
+        mock_result_a = MagicMock()
+        mock_result_a.scalar_one_or_none.return_value = card_a
+        mock_result_b = MagicMock()
+        mock_result_b.scalar_one_or_none.return_value = card_b
+        session.execute.side_effect = [mock_result_a, mock_result_b]
+
+        result = await diff(session, card_a.id, card_b.id)
+
+        assert result["added"] == {}
+        assert result["removed"] == {"temp": "val"}
+        assert result["changed"] == {}
+
+    @pytest.mark.asyncio
+    async def test_diff_changed_keys(self) -> None:
+        from app.services.vivre_card_service import diff
+
+        card_a = _make_card(state_data={"step": 1, "status": "running"})
+        card_b = _make_card(state_data={"step": 3, "status": "done"})
+
+        session = AsyncMock()
+        mock_result_a = MagicMock()
+        mock_result_a.scalar_one_or_none.return_value = card_a
+        mock_result_b = MagicMock()
+        mock_result_b.scalar_one_or_none.return_value = card_b
+        session.execute.side_effect = [mock_result_a, mock_result_b]
+
+        result = await diff(session, card_a.id, card_b.id)
+
+        assert result["changed"]["step"] == {"before": 1, "after": 3}
+        assert result["changed"]["status"] == {"before": "running", "after": "done"}
+
+    @pytest.mark.asyncio
+    async def test_diff_identical_states(self) -> None:
+        from app.services.vivre_card_service import diff
+
+        state = {"step": 1, "context": "same"}
+        card_a = _make_card(state_data=state)
+        card_b = _make_card(state_data=state.copy())
+
+        session = AsyncMock()
+        mock_result_a = MagicMock()
+        mock_result_a.scalar_one_or_none.return_value = card_a
+        mock_result_b = MagicMock()
+        mock_result_b.scalar_one_or_none.return_value = card_b
+        session.execute.side_effect = [mock_result_a, mock_result_b]
+
+        result = await diff(session, card_a.id, card_b.id)
+
+        assert result["added"] == {}
+        assert result["removed"] == {}
+        assert result["changed"] == {}
+
+    @pytest.mark.asyncio
+    async def test_diff_card_not_found_raises(self) -> None:
+        from app.services.vivre_card_service import VivreCardError, diff
+
+        session = AsyncMock()
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+        session.execute.return_value = mock_result
+
+        with pytest.raises(VivreCardError) as exc_info:
+            await diff(session, uuid.uuid4(), uuid.uuid4())
+
+        assert exc_info.value.code == "CARD_NOT_FOUND"
+
+
+class TestCleanup:
+    @pytest.mark.asyncio
+    async def test_cleanup_deletes_old_cards(self) -> None:
+        from app.services.vivre_card_service import cleanup
+
+        session = AsyncMock()
+        # First query: distinct crew members
+        crew_result = MagicMock()
+        crew_result.scalars.return_value.all.return_value = ["captain"]
+        # Second query: all card IDs for captain ordered by created_at desc
+        ids = [uuid.uuid4() for _ in range(5)]
+        card_ids_result = MagicMock()
+        card_ids_result.scalars.return_value.all.return_value = ids
+        # Third query: delete returns count
+        delete_result = MagicMock()
+        delete_result.rowcount = 3
+
+        session.execute.side_effect = [crew_result, card_ids_result, delete_result]
+
+        deleted, kept = await cleanup(session, VOYAGE_ID, keep_last_n=2)
+
+        assert deleted == 3
+        assert kept == 2
+        session.commit.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_cleanup_no_cards(self) -> None:
+        from app.services.vivre_card_service import cleanup
+
+        session = AsyncMock()
+        crew_result = MagicMock()
+        crew_result.scalars.return_value.all.return_value = []
+        session.execute.return_value = crew_result
+
+        deleted, kept = await cleanup(session, VOYAGE_ID, keep_last_n=5)
+
+        assert deleted == 0
+        assert kept == 0
+
+    @pytest.mark.asyncio
+    async def test_cleanup_keeps_all_when_under_limit(self) -> None:
+        from app.services.vivre_card_service import cleanup
+
+        session = AsyncMock()
+        crew_result = MagicMock()
+        crew_result.scalars.return_value.all.return_value = ["navigator"]
+        # Only 2 cards, keep_last_n=5 — nothing to delete
+        ids = [uuid.uuid4() for _ in range(2)]
+        card_ids_result = MagicMock()
+        card_ids_result.scalars.return_value.all.return_value = ids
+        session.execute.side_effect = [crew_result, card_ids_result]
+
+        deleted, kept = await cleanup(session, VOYAGE_ID, keep_last_n=5)
+
+        assert deleted == 0
+        assert kept == 2

--- a/src/backend/tests/test_vivre_card_service.py
+++ b/src/backend/tests/test_vivre_card_service.py
@@ -95,7 +95,7 @@ class TestRestore:
         mock_result.scalar_one_or_none.return_value = expected_card
         session.execute.return_value = mock_result
 
-        result = await restore(session, card_id)
+        result = await restore(session, card_id, VOYAGE_ID)
 
         assert result.id == card_id
         assert result.state_data == expected_card.state_data
@@ -110,7 +110,7 @@ class TestRestore:
         session.execute.return_value = mock_result
 
         with pytest.raises(VivreCardError) as exc_info:
-            await restore(session, uuid.uuid4())
+            await restore(session, uuid.uuid4(), VOYAGE_ID)
 
         assert exc_info.value.code == "CARD_NOT_FOUND"
         assert exc_info.value.status_code == 404
@@ -205,7 +205,7 @@ class TestDiff:
         mock_result_b.scalar_one_or_none.return_value = card_b
         session.execute.side_effect = [mock_result_a, mock_result_b]
 
-        result = await diff(session, card_a.id, card_b.id)
+        result = await diff(session, card_a.id, card_b.id, VOYAGE_ID)
 
         assert result["added"] == {"output": "done"}
         assert result["removed"] == {}
@@ -225,7 +225,7 @@ class TestDiff:
         mock_result_b.scalar_one_or_none.return_value = card_b
         session.execute.side_effect = [mock_result_a, mock_result_b]
 
-        result = await diff(session, card_a.id, card_b.id)
+        result = await diff(session, card_a.id, card_b.id, VOYAGE_ID)
 
         assert result["added"] == {}
         assert result["removed"] == {"temp": "val"}
@@ -245,7 +245,7 @@ class TestDiff:
         mock_result_b.scalar_one_or_none.return_value = card_b
         session.execute.side_effect = [mock_result_a, mock_result_b]
 
-        result = await diff(session, card_a.id, card_b.id)
+        result = await diff(session, card_a.id, card_b.id, VOYAGE_ID)
 
         assert result["changed"]["step"] == {"before": 1, "after": 3}
         assert result["changed"]["status"] == {"before": "running", "after": "done"}
@@ -265,7 +265,7 @@ class TestDiff:
         mock_result_b.scalar_one_or_none.return_value = card_b
         session.execute.side_effect = [mock_result_a, mock_result_b]
 
-        result = await diff(session, card_a.id, card_b.id)
+        result = await diff(session, card_a.id, card_b.id, VOYAGE_ID)
 
         assert result["added"] == {}
         assert result["removed"] == {}
@@ -281,7 +281,7 @@ class TestDiff:
         session.execute.return_value = mock_result
 
         with pytest.raises(VivreCardError) as exc_info:
-            await diff(session, uuid.uuid4(), uuid.uuid4())
+            await diff(session, uuid.uuid4(), uuid.uuid4(), VOYAGE_ID)
 
         assert exc_info.value.code == "CARD_NOT_FOUND"
 


### PR DESCRIPTION
## Summary
- **VivreCardService** with checkpoint, restore, list, diff, and cleanup operations
- **REST API** — 6 endpoints under `POST/GET/DELETE /api/v1/voyages/{id}/vivre-cards` for manual checkpointing, listing, diffing, restoring, and cleanup
- **CheckpointCreatedEvent** added to Den Den Mushi event system for real-time notifications
- **`on_provider_switch` hook** on DialSystemRouter — pre-failover callback for future agent checkpoint integration
- **Config settings** for `vivre_card_checkpoint_interval_seconds` and `vivre_card_cleanup_keep_last_n`
- **35 new tests** across 4 test files (service, API, events, Dial hook) — 200 total passing

## Test plan
- [x] 16 service tests: checkpoint, restore, list (pagination, filtering), diff (added/removed/changed/identical), cleanup (per-crew-member, edge cases)
- [x] 9 API tests: create with event publish, list with crew filter, get by ID, 404 handling, diff, restore, cleanup
- [x] 5 event tests: serialization, round-trip through parse_event, discriminator union
- [x] 5 Dial hook tests: hook fires on failover (route + stream), not on success, None-safe, error-resilient
- [x] All 200 tests passing, ruff clean, mypy clean