### PR TITLE
feat: add Execution Service with containerized sandbox and gVisor backend (Phase 8)

### DIFF
--- a/pdd/context/project.md
+++ b/pdd/context/project.md
@@ -1,6 +1,6 @@
 # Project: GrandLine
 
-**Last updated**: 2026-04-05
+**Last updated**: 2026-04-12
 
 ## What we're building
 A web-based multi-agent orchestration platform where a crew of persona-based AI agents voyage together through a structured pipeline to build, test, and deploy software solutions. Themed after One Piece — the crew, the voyage, and the platform vocabulary are all drawn from that world.
@@ -143,14 +143,16 @@ Users can intervene at any point — pause an agent, redirect work, inject conte
 - Never lose work — Vivre Card checkpointing is mandatory for provider failover
 
 ## Current state
-Phases 1-6 complete. The backend is functional with:
+Phases 1-8 complete. The backend is functional with:
 - **Phase 1-2**: Docker infrastructure, PostgreSQL + Redis, SQLAlchemy models (Voyage, VoyagePlan, Poneglyph, VivreCard, CrewAction, DialConfig)
 - **Phase 3**: Pydantic schemas for all models, DialConfig with JSONB role_mapping/fallback_chain
 - **Phase 4**: JWT auth (register, login, refresh, logout) with default-deny middleware
 - **Phase 5**: Den Den Mushi message bus (Redis Streams) with consumer groups, dead-letter handling, xautoclaim stale recovery
 - **Phase 6**: Dial System LLM gateway — provider adapters (Anthropic, OpenAI, Ollama), adapter factory, role-based routing with failover, Redis sliding-window rate limiter, SSE streaming endpoint
+- **Phase 7**: Vivre Card state checkpointing — service, API, and Dial System hook for provider failover
+- **Phase 8**: Execution Service — containerized sandbox with gVisor/Docker backend (aiodocker), swappable ExecutionBackend ABC, per-user sandbox lifecycle, path traversal sanitization, file size limits, app lifespan wiring
 
-163 unit tests passing, mypy clean, ruff clean. Frontend not yet started.
+Frontend not yet started.
 
 ## Source directory structure
 All application artifacts live under `src/`:
@@ -161,6 +163,7 @@ src/
     api/            — Route handlers (REST, SSE, WebSocket)
     crew/           — Agent persona definitions (Captain, Navigator, etc.)
     dial_system/    — LLM gateway, provider routing, failover
+    execution/      — Sandboxed code execution backends (gVisor/Docker)
     services/       — Business logic layer
     models/         — SQLAlchemy models (including Vivre Card state)
   shared/           — Shared types, schemas, constants

--- a/pdd/prompts/features/sandbox/PLAN-execution-service.md
+++ b/pdd/prompts/features/sandbox/PLAN-execution-service.md
@@ -1,0 +1,241 @@
+# Plan: Execution Service — Containerized Sandbox (Phase 8)
+
+**Issue**: #9
+**Branch**: `feat/issue-9-execution-service`
+**Depends on**: Phase 1 (Docker), Phase 3 (models)
+
+---
+
+## Problem
+
+Crew agents (Shipwrights, Doctor, Helmsman) generate and execute untrusted code. This code must never run on the host — it needs a security boundary with resource limits, filesystem isolation, and network restrictions. The Execution Service is that boundary.
+
+The architecture decision mandates a swappable `ExecutionBackend` interface so the sandbox implementation can evolve (gVisor → Firecracker → Wasm) without changing the calling code.
+
+## What exists already
+
+| Artifact | Location | Status |
+|---|---|---|
+| Docker infrastructure | `src/infra/docker/docker-compose.yml` | Done — api, frontend, db, redis |
+| `CrewAction` model | `src/backend/app/models/crew_action.py` | Done — logs agent actions |
+| `CrewRole` enum | `src/backend/app/models/enums.py` | Done — captain, navigator, doctor, shipwright, helmsman |
+| `ProviderAdapter` ABC pattern | `src/backend/app/dial_system/adapters/base.py` | Done — good reference for the `ExecutionBackend` ABC pattern |
+| Settings (pydantic-settings) | `src/backend/app/core/config.py` | Done — GRANDLINE_ prefix |
+
+## What needs to be built
+
+### Phase 1: Data models — ExecutionRequest/Result schemas
+
+**File**: `src/backend/app/schemas/execution.py`
+
+Pydantic schemas for the execution boundary:
+
+- `ExecutionRequest`:
+  - `command: str` — the shell command to execute
+  - `working_dir: str = "/workspace"` — working directory inside the container
+  - `timeout_seconds: int = 30` — max execution time
+  - `environment: dict[str, str] = {}` — environment variables to inject
+  - `files: dict[str, str] = {}` — file path → content to write before execution
+  - `user_id: uuid.UUID` — for per-user isolation
+  - `voyage_id: uuid.UUID` — for tracking
+
+- `ExecutionResult`:
+  - `exit_code: int`
+  - `stdout: str`
+  - `stderr: str`
+  - `timed_out: bool`
+  - `duration_seconds: float`
+  - `sandbox_id: str` — container/sandbox identifier for logging
+
+- `SandboxStatus`:
+  - `sandbox_id: str`
+  - `state: str` — "running", "idle", "destroyed"
+  - `user_id: uuid.UUID`
+  - `created_at: datetime`
+
+### Phase 2: ExecutionBackend ABC
+
+**File**: `src/backend/app/execution/__init__.py` (package)
+**File**: `src/backend/app/execution/backend.py`
+
+Abstract base class defining the sandbox contract:
+
+- `create(user_id: UUID) -> str` — provision a sandbox, return sandbox_id
+- `execute(sandbox_id: str, request: ExecutionRequest) -> ExecutionResult` — run code in sandbox
+- `destroy(sandbox_id: str) -> None` — tear down the sandbox
+- `status(sandbox_id: str) -> SandboxStatus` — query sandbox state
+
+Plus `ExecutionError` exception for sandbox failures (same pattern as `ProviderError`).
+
+### Phase 3: GVisorContainerBackend
+
+**File**: `src/backend/app/execution/gvisor_backend.py`
+
+Docker + gVisor implementation of `ExecutionBackend`:
+
+- `create()`:
+  - Pull/use a base image (e.g., `python:3.13-slim`)
+  - Create container with `runtime="runsc"` (gVisor)
+  - Resource limits: `mem_limit`, `cpu_quota`, `cpu_period`
+  - Network disabled: `network_disabled=True`
+  - Read-only root filesystem with writable `/workspace` tmpfs
+  - Label with `user_id` for per-user tracking
+  - Start the container in idle state (e.g., `tail -f /dev/null`)
+
+- `execute()`:
+  - Write `request.files` into the container's `/workspace` via `put_archive()`
+  - Set environment variables from `request.environment`
+  - Run `request.command` via `exec_create()` + `exec_start()`
+  - Apply timeout — kill container exec if exceeded, set `timed_out=True`
+  - Capture stdout, stderr, exit_code
+  - Return `ExecutionResult`
+
+- `destroy()`:
+  - Stop and remove the container
+  - Handle already-stopped/removed gracefully
+
+- `status()`:
+  - Inspect container state via Docker API
+  - Map Docker states to SandboxStatus
+
+Uses `aiodocker` (async Docker SDK) for non-blocking container operations.
+
+### Phase 4: ExecutionService (public API)
+
+**File**: `src/backend/app/services/execution_service.py`
+
+The facade that crew agents call. Manages sandbox lifecycle:
+
+- `run(request: ExecutionRequest) -> ExecutionResult`:
+  - Get or create a sandbox for the user (pool management)
+  - Call `backend.execute()`
+  - Log the execution as a `CrewAction` (optional, for Ship's Log)
+  - Return the result
+
+- `get_or_create_sandbox(user_id: UUID) -> str`:
+  - Check if user already has an active sandbox
+  - If not, call `backend.create(user_id)`
+  - Track in an in-memory dict `_sandboxes: dict[UUID, str]`
+
+- `destroy_sandbox(user_id: UUID) -> None`:
+  - Call `backend.destroy()` and remove from tracking
+
+- `cleanup_all() -> None`:
+  - Destroy all tracked sandboxes (for shutdown/restart)
+
+Constructor takes the `ExecutionBackend` instance (dependency injection).
+
+### Phase 5: Backend factory + config
+
+**File**: `src/backend/app/execution/factory.py`
+
+- `create_backend(settings: Settings) -> ExecutionBackend`:
+  - Read `settings.execution_backend` (default: `"gvisor"`)
+  - `"gvisor"` → `GVisorContainerBackend(settings)`
+  - Future: `"subprocess"` → `SubprocessBackend(settings)` (for dev/testing)
+  - Raise `ValueError` for unknown backend
+
+**File**: `src/backend/app/core/config.py` — Add:
+- `execution_backend: str = "gvisor"`
+- `execution_image: str = "python:3.13-slim"`
+- `execution_memory_limit: str = "256m"`
+- `execution_cpu_quota: int = 50000` (50% of one core)
+- `execution_cpu_period: int = 100000`
+- `execution_default_timeout: int = 30`
+- `execution_network_enabled: bool = False`
+- `execution_gvisor_runtime: str = "runsc"`
+
+### Phase 6: REST API endpoints
+
+**File**: `src/backend/app/api/v1/execution.py`
+
+- `POST /api/v1/voyages/{voyage_id}/execute` — Run code in sandbox
+  - Body: `ExecutionRequest` (command, files, timeout, etc.)
+  - Returns: `ExecutionResult`
+  - Requires auth + voyage ownership
+  - Sets `user_id` from authenticated user (not from request body)
+
+- `GET /api/v1/sandbox/status` — Get current user's sandbox status
+  - Returns: `SandboxStatus` or 404 if no active sandbox
+
+- `DELETE /api/v1/sandbox` — Destroy current user's sandbox
+  - Returns: 204 No Content
+
+Wire into `src/backend/app/api/v1/router.py`.
+
+---
+
+## Implementation order
+
+```
+Phase 1 (schemas)           — ExecutionRequest, ExecutionResult, SandboxStatus
+Phase 2 (backend ABC)       — ExecutionBackend interface + ExecutionError
+Phase 5 (config)            — execution settings in config.py
+Phase 3 (gVisor backend)    — GVisorContainerBackend using aiodocker
+Phase 4 (service)           — ExecutionService facade with sandbox pooling
+Phase 5b (factory)          — create_backend() factory function
+Phase 6 (API)               — REST endpoints
+```
+
+Schemas and ABC first (no dependencies), then config, then the gVisor implementation, then the service and API layers.
+
+## Testing strategy (TDD)
+
+This is a high-risk security component. Testing needs two layers:
+
+### Unit tests (mocked Docker — run in CI)
+1. **`tests/test_execution_schemas.py`** — Schema validation for request/result
+2. **`tests/test_execution_backend.py`** — GVisorContainerBackend with mocked aiodocker client
+   - Tests that create() sets correct container config (runtime, limits, network)
+   - Tests that execute() handles timeout, captures output
+   - Tests that destroy() handles already-removed containers
+3. **`tests/test_execution_service.py`** — ExecutionService with mocked backend
+   - Tests sandbox pool management (get_or_create, destroy, cleanup)
+   - Tests that run() delegates to backend correctly
+4. **`tests/test_execution_factory.py`** — Factory creates correct backend from config
+5. **`tests/test_execution_api.py`** — API endpoints with mocked service
+
+### Integration tests (real Docker — run locally only)
+6. **`tests/test_execution_integration.py`** — Marked `@pytest.mark.integration`
+   - Verifies actual container creation and code execution
+   - Verifies network isolation
+   - Verifies filesystem isolation
+   - Verifies timeout enforcement
+   - These require Docker daemon running locally
+
+## Dependencies
+
+- `aiodocker>=0.23.0` — async Docker SDK (add to `requirements.txt`)
+- Docker daemon running locally (for integration tests and actual usage)
+- gVisor `runsc` runtime installed on Docker host (for production — falls back gracefully if missing)
+
+## Out of scope
+
+- Git integration inside containers (Phase 9)
+- Per-agent branches and PR workflow (Phase 9)
+- Automatic container scaling (Phase 19 — Kubernetes)
+- WebSocket streaming of execution output (Phase 16 — Observation Deck)
+- Container image caching/warming strategies
+
+## Key design decisions
+
+1. **aiodocker over docker-py**: Async-first — matches FastAPI's async model. docker-py is sync and would require `run_in_executor()` wrappers everywhere.
+
+2. **Per-user sandboxes, not per-execution**: Creating a container per command is too slow (~1s). Instead, each user gets a long-lived container that handles multiple executions. Destroyed on explicit request or timeout.
+
+3. **gVisor runtime is configurable**: In development without gVisor installed, the backend falls back to default Docker runtime but logs a warning. Tests mock the Docker API so they don't need gVisor.
+
+4. **Network disabled by default**: Agents shouldn't be able to exfiltrate data or reach internal services. Network access can be opted-in per-execution via config if needed (e.g., for `pip install`).
+
+5. **Swappable backend**: The `ExecutionBackend` ABC means we can add `SubprocessBackend` for quick local dev, `FirecrackerBackend` for micro-VMs, or `WasmBackend` for lightweight isolation — all without touching `ExecutionService` or any crew agent code.
+
+## Risk: security
+
+This is the highest-risk component in the platform. Key mitigations:
+- gVisor intercepts syscalls at the kernel level — even if code escapes the container namespace, gVisor's Sentry blocks dangerous syscalls
+- Network disabled prevents callback/exfiltration attacks
+- Memory limits prevent DoS via memory exhaustion
+- Timeout prevents DoS via infinite loops
+- Read-only root filesystem prevents persistent modifications
+- Per-user isolation prevents cross-user contamination
+- `/workspace` is a tmpfs — destroyed with the container, no disk persistence

--- a/pdd/prompts/features/sandbox/grandline-08-execution-service.md
+++ b/pdd/prompts/features/sandbox/grandline-08-execution-service.md
@@ -2,13 +2,13 @@
 
 **File**: pdd/prompts/features/sandbox/grandline-08-execution-service.md
 **Created**: 2026-04-09
-**Updated**: 2026-04-09
+**Updated**: 2026-04-12
 **Depends on**: Phase 1 (Docker infrastructure), Phase 3 (CrewAction model)
 **Project type**: Backend (FastAPI + Docker + aiodocker)
 
 ## Context
 
-GrandLine is a One Piece-themed multi-agent orchestration platform. Phases 1-7 delivered Docker infrastructure, database models, JWT auth, the Den Den Mushi message bus, the Dial System LLM gateway, and Vivre Card state checkpointing. 205 tests passing, mypy clean, ruff clean.
+GrandLine is a One Piece-themed multi-agent orchestration platform. Phases 1-7 delivered Docker infrastructure, database models, JWT auth, the Den Den Mushi message bus, the Dial System LLM gateway, and Vivre Card state checkpointing.
 
 Crew agents (Shipwrights, Doctor, Helmsman) generate and execute untrusted code. This code must never run on the host. The Execution Service is the security boundary — it runs all agent-generated code inside isolated containers with gVisor runtime, resource limits, and no network access. The architecture decision mandates a swappable `ExecutionBackend` interface so the sandbox implementation can evolve (gVisor → Firecracker → Wasm) without changing the calling code.
 
@@ -37,7 +37,7 @@ Implement the Execution Service with a swappable backend and Docker + gVisor v1 
 
    - `SandboxStatus`:
      - `sandbox_id: str`
-     - `state: str` — one of: "running", "idle", "destroyed"
+     - `state: Literal["running", "idle", "destroyed"]` — enforced by Pydantic, rejects invalid values
      - `user_id: uuid.UUID`
      - `created_at: datetime`
 
@@ -77,15 +77,19 @@ Implement the Execution Service with a swappable backend and Docker + gVisor v1 
      - Wrap Docker errors in `ExecutionError`
 
    - `execute(sandbox_id, request)`:
-     - If `request.files` is non-empty: create a tar archive in memory from the files dict and inject via `put_archive("/workspace")`
-     - Create exec instance: `exec_create(sandbox_id, cmd=["sh", "-c", request.command], workdir=request.working_dir, environment=[f"{k}={v}" for k, v in request.environment.items()])`
-     - Start exec and capture output with `exec_start()`
-     - Implement timeout using `asyncio.wait_for()` with `request.timeout_seconds`
-       - On `asyncio.TimeoutError`: exec may still be running — inspect exec, set `timed_out=True`
-     - Inspect exec to get exit code: `exec_inspect()` → `ExitCode`
-     - Split output into stdout/stderr (exec_start returns combined — use `Tty=False` and `demux=True` for separation)
+     - If `request.files` is non-empty: validate paths via `_validate_file_path()`, check sizes against `MAX_FILE_SIZE`, create a tar archive in memory, and inject via `put_archive("/workspace")`
+     - Create exec instance: `container.exec(cmd=["sh", "-c", request.command], workdir=request.working_dir, environment=[f"{k}={v}" for k, v in request.environment.items()], tty=False)`
+     - Start exec with `exec_obj.start(detach=False)` — returns a `Stream` object (sync call, NOT async)
+     - Read output via `stream.read_out()` loop: `msg.stream == 1` → stdout, `msg.stream == 2` → stderr, `None` → EOF
+     - Wrap the read loop in `asyncio.wait_for()` with `request.timeout_seconds` for timeout enforcement
+       - On `TimeoutError`: close the stream, set `timed_out=True`
+     - Inspect exec to get exit code: `exec_obj.inspect()` → `ExitCode`
      - Track duration with `time.monotonic()` before/after
      - Return `ExecutionResult`
+     - **Important aiodocker API notes**:
+       - `exec.start(detach=True)` fires and forgets — no output, no blocking. Must use `detach=False`.
+       - `containers.container()` is **sync**, `container.exec/show/kill/delete/put_archive/start` are **async**
+       - `exec.start(detach=False)` is **sync** (returns Stream), `stream.read_out()` is **async**
 
    - `destroy(sandbox_id)`:
      - Get container: `docker.containers.container(sandbox_id)`
@@ -105,7 +109,11 @@ Implement the Execution Service with a swappable backend and Docker + gVisor v1 
 
    - `close()`: Close the aiodocker client session
 
-   **Memory limit parsing**: `_parse_memory("256m")` → `268435456` bytes. Support `m` (MiB) and `g` (GiB) suffixes.
+   **Memory limit parsing**: `_parse_memory("256m")` → `268435456` bytes. Support `m` (MiB) and `g` (GiB) suffixes. Validates input: raises `ValueError` for empty strings, invalid suffixes (e.g. `"256x"`), and non-numeric values (e.g. `"abcm"`).
+
+   **File size limit**: `MAX_FILE_SIZE = 1_048_576` (1 MiB). Each file in `request.files` is checked before tar injection; exceeding the limit raises `ExecutionError`.
+
+   **Path traversal sanitization**: `_validate_file_path()` rejects absolute paths and `..` components in file paths before tar archive creation, raising `ExecutionError`.
 
 4. **ExecutionService** (`app/services/execution_service.py`):
 
@@ -162,7 +170,9 @@ Implement the Execution Service with a swappable backend and Docker + gVisor v1 
      - Requires auth (`get_current_user`) + voyage ownership (`get_authorized_voyage`)
      - Sets `user_id` from the authenticated user — NOT from request body
      - Calls `execution_service.run(user_id, request)`
-     - On `ExecutionError`: raise HTTPException with standard error shape
+     - Error differentiation:
+       - `ExecutionError` with "Invalid file path" or "File too large" → **400** `INVALID_REQUEST`
+       - Other `ExecutionError` → **500** `EXECUTION_ERROR`
 
    - `GET /api/v1/sandbox/status` → `SandboxStatus`:
      - Requires auth (`get_current_user`)
@@ -180,6 +190,11 @@ Implement the Execution Service with a swappable backend and Docker + gVisor v1 
      - Returns the `ExecutionService` singleton
 
    Wire into `app/api/v1/router.py`.
+
+   **App lifespan wiring** (`app/main.py`):
+   - In the `lifespan()` context manager, create the backend via `create_backend(settings)` and wrap it in `ExecutionService(backend)`
+   - Set `app.state.execution_service = ExecutionService(backend)`
+   - On shutdown: `await app.state.execution_service.cleanup_all()` then `await backend.close()`
 
 ## Input
 
@@ -225,6 +240,12 @@ Implement the Execution Service with a swappable backend and Docker + gVisor v1 
 - `get_or_create_sandbox()` when tracked sandbox was killed externally → detect via status check, recreate
 - `cleanup_all()` with some containers already removed → log and continue
 - `files` dict with nested paths (e.g., `"src/main.py"`) → tar archive preserves directory structure
+- `files` dict with `../` traversal paths → rejected by `_validate_file_path()` before tar creation
+- `files` dict with absolute paths (e.g., `/etc/passwd`) → rejected by `_validate_file_path()`
+- `files` dict with file exceeding `MAX_FILE_SIZE` (1 MiB) → rejected before tar creation
+- Invalid memory limit suffix (e.g., `"256x"`) → `_parse_memory` raises `ValueError`
+- Empty memory limit string → `_parse_memory` raises `ValueError`
+- Non-numeric memory value (e.g., `"abcm"`) → `_parse_memory` raises `ValueError`
 - Memory limit exceeded by running process → container OOM-kills the process, captured in exit code
 
 ## Test Plan
@@ -235,6 +256,8 @@ Implement the Execution Service with a swappable backend and Docker + gVisor v1 
 - `test_execution_request_timeout_range` — rejects timeout < 1 or > 300
 - `test_execution_result_fields` — all fields present
 - `test_sandbox_status_fields` — all fields present
+- `test_sandbox_status_state_accepts_valid_values` — "running", "idle", "destroyed" accepted
+- `test_sandbox_status_state_rejects_invalid_value` — "unknown" → ValidationError
 
 ### tests/test_execution_backend.py (mocked aiodocker)
 - `test_create_sets_gvisor_runtime` — container config includes runtime=runsc
@@ -256,6 +279,13 @@ Implement the Execution Service with a swappable backend and Docker + gVisor v1 
 - `test_status_not_found_raises` — missing container → ExecutionError
 - `test_parse_memory_megabytes` — "256m" → 268435456
 - `test_parse_memory_gigabytes` — "1g" → 1073741824
+- `test_parse_memory_invalid_suffix_raises` — "256x" → ValueError
+- `test_parse_memory_empty_raises` — "" → ValueError
+- `test_parse_memory_non_numeric_raises` — "abcm" → ValueError
+- `test_build_tar_rejects_path_traversal` — "../etc/passwd" → ExecutionError
+- `test_build_tar_rejects_absolute_path` — "/etc/passwd" → ExecutionError
+- `test_build_tar_rejects_file_too_large` — exceeds MAX_FILE_SIZE → ExecutionError
+- `test_build_tar_accepts_nested_path` — "src/main.py" → valid tar bytes
 
 ### tests/test_execution_service.py (mocked backend)
 - `test_run_creates_sandbox_and_executes` — happy path
@@ -278,3 +308,5 @@ Implement the Execution Service with a swappable backend and Docker + gVisor v1 
 - `test_destroy_sandbox_204` — DELETE returns 204
 - `test_destroy_sandbox_not_found` — 404 when no sandbox
 - `test_execute_unauthorized_401` — no token → 401
+- `test_execute_invalid_path_returns_400` — path traversal error → 400 INVALID_REQUEST
+- `test_execute_file_too_large_returns_400` — file size error → 400 INVALID_REQUEST

--- a/pdd/prompts/features/sandbox/grandline-08-execution-service.md
+++ b/pdd/prompts/features/sandbox/grandline-08-execution-service.md
@@ -1,0 +1,280 @@
+# Prompt: Execution Service (Containerized Sandbox + gVisor)
+
+**File**: pdd/prompts/features/sandbox/grandline-08-execution-service.md
+**Created**: 2026-04-09
+**Updated**: 2026-04-09
+**Depends on**: Phase 1 (Docker infrastructure), Phase 3 (CrewAction model)
+**Project type**: Backend (FastAPI + Docker + aiodocker)
+
+## Context
+
+GrandLine is a One Piece-themed multi-agent orchestration platform. Phases 1-7 delivered Docker infrastructure, database models, JWT auth, the Den Den Mushi message bus, the Dial System LLM gateway, and Vivre Card state checkpointing. 205 tests passing, mypy clean, ruff clean.
+
+Crew agents (Shipwrights, Doctor, Helmsman) generate and execute untrusted code. This code must never run on the host. The Execution Service is the security boundary — it runs all agent-generated code inside isolated containers with gVisor runtime, resource limits, and no network access. The architecture decision mandates a swappable `ExecutionBackend` interface so the sandbox implementation can evolve (gVisor → Firecracker → Wasm) without changing the calling code.
+
+## Task
+
+Implement the Execution Service with a swappable backend and Docker + gVisor v1 implementation. TDD — tests first, then implementation.
+
+1. **Schemas** (`app/schemas/execution.py`):
+
+   - `ExecutionRequest`:
+     - `command: str` — the shell command to run inside the container
+     - `working_dir: str = "/workspace"` — working directory inside container
+     - `timeout_seconds: int = 30` — max execution time (1-300 range)
+     - `environment: dict[str, str] = {}` — env vars to inject
+     - `files: dict[str, str] = {}` — path → content to write before execution
+   
+   Note: `user_id` and `voyage_id` are NOT in the schema — they come from auth context in the API layer.
+
+   - `ExecutionResult`:
+     - `exit_code: int`
+     - `stdout: str`
+     - `stderr: str`
+     - `timed_out: bool = False`
+     - `duration_seconds: float`
+     - `sandbox_id: str`
+
+   - `SandboxStatus`:
+     - `sandbox_id: str`
+     - `state: str` — one of: "running", "idle", "destroyed"
+     - `user_id: uuid.UUID`
+     - `created_at: datetime`
+
+2. **ExecutionBackend ABC** (`app/execution/backend.py`):
+
+   Create `app/execution/` package with `__init__.py`.
+
+   - `ExecutionBackend(ABC)`:
+     - `async create(user_id: UUID) -> str` — provision a sandbox, return sandbox_id
+     - `async execute(sandbox_id: str, request: ExecutionRequest) -> ExecutionResult`
+     - `async destroy(sandbox_id: str) -> None` — tear down the sandbox
+     - `async status(sandbox_id: str) -> SandboxStatus` — query sandbox state
+
+   - `ExecutionError(Exception)` — raised on sandbox failures (same pattern as `ProviderError` in `dial_system/adapters/base.py`)
+
+3. **GVisorContainerBackend** (`app/execution/gvisor_backend.py`):
+
+   Docker + gVisor implementation using `aiodocker`:
+
+   - Constructor: takes `Settings` instance, creates `aiodocker.Docker()` client
+   
+   - `create(user_id)`:
+     - Container config:
+       - Image: `settings.execution_image` (default `python:3.13-slim`)
+       - Command: `["tail", "-f", "/dev/null"]` (keep container alive)
+       - Runtime: `settings.execution_gvisor_runtime` (default `"runsc"`)
+       - `HostConfig`:
+         - `Memory`: parse `settings.execution_memory_limit` (e.g., `"256m"` → bytes)
+         - `CpuQuota`: `settings.execution_cpu_quota` (default 50000)
+         - `CpuPeriod`: `settings.execution_cpu_period` (default 100000)
+         - `NetworkMode`: `"none"` if not `settings.execution_network_enabled`
+         - `ReadonlyRootfs`: `True`
+         - `Tmpfs`: `{"/workspace": "rw,size=64m", "/tmp": "rw,size=32m"}`
+       - Labels: `{"grandline.user_id": str(user_id), "grandline.managed": "true"}`
+     - Start the container
+     - Return the container ID as sandbox_id
+     - Wrap Docker errors in `ExecutionError`
+
+   - `execute(sandbox_id, request)`:
+     - If `request.files` is non-empty: create a tar archive in memory from the files dict and inject via `put_archive("/workspace")`
+     - Create exec instance: `exec_create(sandbox_id, cmd=["sh", "-c", request.command], workdir=request.working_dir, environment=[f"{k}={v}" for k, v in request.environment.items()])`
+     - Start exec and capture output with `exec_start()`
+     - Implement timeout using `asyncio.wait_for()` with `request.timeout_seconds`
+       - On `asyncio.TimeoutError`: exec may still be running — inspect exec, set `timed_out=True`
+     - Inspect exec to get exit code: `exec_inspect()` → `ExitCode`
+     - Split output into stdout/stderr (exec_start returns combined — use `Tty=False` and `demux=True` for separation)
+     - Track duration with `time.monotonic()` before/after
+     - Return `ExecutionResult`
+
+   - `destroy(sandbox_id)`:
+     - Get container: `docker.containers.container(sandbox_id)`
+     - Kill (force stop): `container.kill()`
+     - Delete: `container.delete(force=True)`
+     - Catch `DockerError` for already-removed containers — log and ignore
+   
+   - `status(sandbox_id)`:
+     - Inspect container: `container.show()`
+     - Map Docker `State.Status` to SandboxStatus state:
+       - `"running"` → `"running"`
+       - `"created"`, `"paused"` → `"idle"`
+       - Everything else → `"destroyed"`
+     - Extract `user_id` from labels
+     - Extract `Created` timestamp
+     - Raise `ExecutionError` if container not found
+
+   - `close()`: Close the aiodocker client session
+
+   **Memory limit parsing**: `_parse_memory("256m")` → `268435456` bytes. Support `m` (MiB) and `g` (GiB) suffixes.
+
+4. **ExecutionService** (`app/services/execution_service.py`):
+
+   Class-based (needs state for sandbox pool tracking):
+
+   - `__init__(self, backend: ExecutionBackend)` — inject the backend
+   - `_sandboxes: dict[uuid.UUID, str]` — maps user_id → sandbox_id
+
+   - `async run(self, user_id: UUID, request: ExecutionRequest) -> ExecutionResult`:
+     - Get or create sandbox for the user
+     - Call `backend.execute(sandbox_id, request)`
+     - Return result
+
+   - `async get_or_create_sandbox(self, user_id: UUID) -> str`:
+     - If `user_id` in `_sandboxes`: verify sandbox is still alive via `backend.status()`
+       - If status check fails (ExecutionError): remove from tracking, create new
+     - If not tracked: `sandbox_id = await backend.create(user_id)`
+     - Store in `_sandboxes[user_id] = sandbox_id`
+     - Return sandbox_id
+
+   - `async destroy_sandbox(self, user_id: UUID) -> None`:
+     - If user has a tracked sandbox: `await backend.destroy(sandbox_id)`, remove from `_sandboxes`
+     - Raise `ExecutionError("SANDBOX_NOT_FOUND", ...)` if no sandbox for user
+
+   - `async cleanup_all(self) -> None`:
+     - Destroy all tracked sandboxes (for app shutdown)
+     - Log but don't raise on individual failures
+     - Clear `_sandboxes`
+
+5. **Backend factory** (`app/execution/factory.py`):
+
+   - `create_backend(settings: Settings) -> ExecutionBackend`:
+     - `"gvisor"` → `GVisorContainerBackend(settings)`
+     - Raise `ValueError(f"Unknown execution backend: {name}")` for unknown
+
+6. **Config settings** (`app/core/config.py`):
+
+   Add under a `# Execution Service (Sandbox)` comment block:
+   - `execution_backend: str = "gvisor"`
+   - `execution_image: str = "python:3.13-slim"`
+   - `execution_memory_limit: str = "256m"`
+   - `execution_cpu_quota: int = 50000`
+   - `execution_cpu_period: int = 100000`
+   - `execution_default_timeout: int = 30`
+   - `execution_network_enabled: bool = False`
+   - `execution_gvisor_runtime: str = "runsc"`
+
+7. **REST API** (`app/api/v1/execution.py`):
+
+   Router prefix: none (endpoints have distinct paths). Tags: `["execution"]`.
+
+   - `POST /api/v1/voyages/{voyage_id}/execute` → `ExecutionResult`:
+     - Body: `ExecutionRequest`
+     - Requires auth (`get_current_user`) + voyage ownership (`get_authorized_voyage`)
+     - Sets `user_id` from the authenticated user — NOT from request body
+     - Calls `execution_service.run(user_id, request)`
+     - On `ExecutionError`: raise HTTPException with standard error shape
+
+   - `GET /api/v1/sandbox/status` → `SandboxStatus`:
+     - Requires auth (`get_current_user`)
+     - Calls `execution_service.get_sandbox_status(user_id)` → looks up user's sandbox, calls `backend.status()`
+     - 404 if no active sandbox
+
+   - `DELETE /api/v1/sandbox` → 204 No Content:
+     - Requires auth (`get_current_user`)
+     - Calls `execution_service.destroy_sandbox(user_id)`
+     - 404 if no active sandbox
+
+   **Dependencies** (`app/api/v1/dependencies.py`):
+   - Add `get_execution_service()` dependency:
+     - Uses `request.app.state.execution_service` (set during app startup)
+     - Returns the `ExecutionService` singleton
+
+   Wire into `app/api/v1/router.py`.
+
+## Input
+
+- Existing `CrewAction` model at `src/backend/app/models/crew_action.py` — for future Ship's Log integration
+- Existing `ProviderAdapter` ABC at `src/backend/app/dial_system/adapters/base.py` — pattern reference for the `ExecutionBackend` ABC
+- Existing `Settings` at `src/backend/app/core/config.py` — GRANDLINE_ prefix, pydantic-settings
+- Existing `get_current_user`, `get_authorized_voyage` at `src/backend/app/api/v1/dependencies.py`
+- Existing `AuthError` pattern at `src/backend/app/services/auth_service.py`
+
+## Output format
+
+- Python files following existing conventions (async, type-annotated, Pydantic v2)
+- New `execution/` package under `src/backend/app/`
+- ExecutionService is a class (needs state), unlike auth_service/vivre_card_service which are module-level functions
+- Unit tests with mocked aiodocker (AsyncMock) — no Docker daemon required for CI
+- Integration tests marked `@pytest.mark.integration` — require Docker daemon
+- All new files under `src/backend/app/` and `src/backend/tests/`
+
+## Constraints
+
+- Add `aiodocker>=0.23.0` to `requirements.txt`
+- Never execute code on the host — all execution goes through the backend
+- `user_id` comes from auth context, never from the request body (prevents impersonation)
+- Network disabled by default — `NetworkMode: "none"`
+- Read-only root filesystem — only `/workspace` (tmpfs) and `/tmp` (tmpfs) are writable
+- Memory limit enforced at container level, not just in-process
+- Timeout enforced via `asyncio.wait_for()`, not `signal.alarm()`
+- `ExecutionError` follows the same pattern as `ProviderError` (simple exception with message)
+- Container labels must include `grandline.user_id` and `grandline.managed=true` for tracking
+- Factory only supports `"gvisor"` backend in v1 — no subprocess fallback yet
+- gVisor runtime name is configurable — dev environments may not have `runsc` installed
+
+## Edge Cases
+
+- `create()` when Docker daemon is not running → `ExecutionError` with clear message
+- `create()` when image doesn't exist locally → aiodocker pulls it (may be slow first time)
+- `execute()` with timeout of 0 or negative → schema validation rejects (min=1)
+- `execute()` when container was killed externally → `ExecutionError`
+- `execute()` with empty command → let container handle it (will fail with exit code)
+- `execute()` exceeds timeout → `timed_out=True`, stdout/stderr may be partial
+- `destroy()` on already-destroyed container → handle gracefully, no error
+- `status()` on non-existent container → `ExecutionError`
+- `get_or_create_sandbox()` when tracked sandbox was killed externally → detect via status check, recreate
+- `cleanup_all()` with some containers already removed → log and continue
+- `files` dict with nested paths (e.g., `"src/main.py"`) → tar archive preserves directory structure
+- Memory limit exceeded by running process → container OOM-kills the process, captured in exit code
+
+## Test Plan
+
+### tests/test_execution_schemas.py
+- `test_execution_request_defaults` — default working_dir, timeout, empty env/files
+- `test_execution_request_custom_values` — all fields set
+- `test_execution_request_timeout_range` — rejects timeout < 1 or > 300
+- `test_execution_result_fields` — all fields present
+- `test_sandbox_status_fields` — all fields present
+
+### tests/test_execution_backend.py (mocked aiodocker)
+- `test_create_sets_gvisor_runtime` — container config includes runtime=runsc
+- `test_create_sets_resource_limits` — memory, cpu_quota, cpu_period in HostConfig
+- `test_create_disables_network` — NetworkMode=none when network disabled
+- `test_create_sets_readonly_rootfs` — ReadonlyRootfs=True with tmpfs mounts
+- `test_create_labels_include_user_id` — grandline.user_id label set
+- `test_create_starts_container` — container.start() called
+- `test_execute_captures_output` — stdout and stderr returned
+- `test_execute_captures_exit_code` — non-zero exit code preserved
+- `test_execute_respects_timeout` — asyncio.TimeoutError sets timed_out=True
+- `test_execute_writes_files` — put_archive called with correct tar data
+- `test_execute_sets_environment` — env vars passed to exec_create
+- `test_execute_tracks_duration` — duration_seconds > 0
+- `test_destroy_removes_container` — kill + delete called
+- `test_destroy_handles_already_removed` — DockerError caught gracefully
+- `test_status_maps_running` — Docker "running" → SandboxStatus "running"
+- `test_status_maps_created_to_idle` — Docker "created" → "idle"
+- `test_status_not_found_raises` — missing container → ExecutionError
+- `test_parse_memory_megabytes` — "256m" → 268435456
+- `test_parse_memory_gigabytes` — "1g" → 1073741824
+
+### tests/test_execution_service.py (mocked backend)
+- `test_run_creates_sandbox_and_executes` — happy path
+- `test_run_reuses_existing_sandbox` — second call uses same sandbox
+- `test_get_or_create_detects_dead_sandbox` — recreates if status check fails
+- `test_destroy_sandbox_calls_backend` — delegates to backend.destroy()
+- `test_destroy_sandbox_not_found_raises` — no sandbox for user
+- `test_cleanup_all_destroys_all` — all tracked sandboxes destroyed
+- `test_cleanup_all_continues_on_error` — one failure doesn't block others
+
+### tests/test_execution_factory.py
+- `test_creates_gvisor_backend` — "gvisor" → GVisorContainerBackend
+- `test_raises_for_unknown_backend` — "unknown" → ValueError
+
+### tests/test_execution_api.py (mocked service)
+- `test_execute_returns_result` — POST returns ExecutionResult
+- `test_execute_sets_user_from_auth` — user_id from token, not body
+- `test_sandbox_status_returns_status` — GET returns SandboxStatus
+- `test_sandbox_status_not_found` — 404 when no sandbox
+- `test_destroy_sandbox_204` — DELETE returns 204
+- `test_destroy_sandbox_not_found` — 404 when no sandbox
+- `test_execute_unauthorized_401` — no token → 401

--- a/src/backend/app/api/v1/dependencies.py
+++ b/src/backend/app/api/v1/dependencies.py
@@ -19,6 +19,7 @@ from app.models import get_db
 from app.models.dial_config import DialConfig
 from app.models.user import User
 from app.models.voyage import Voyage
+from app.services.execution_service import ExecutionService
 
 bearer_scheme = HTTPBearer(auto_error=False)
 
@@ -98,6 +99,11 @@ async def get_authorized_voyage(
             detail="Voyage not found",
         )
     return voyage
+
+
+def get_execution_service(request: Request) -> ExecutionService:
+    svc: ExecutionService = request.app.state.execution_service
+    return svc
 
 
 async def get_dial_router(

--- a/src/backend/app/api/v1/execution.py
+++ b/src/backend/app/api/v1/execution.py
@@ -1,0 +1,72 @@
+"""Execution Service REST API endpoints."""
+
+from __future__ import annotations
+
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, Response, status
+
+from app.api.v1.dependencies import get_authorized_voyage, get_current_user, get_execution_service
+from app.execution.backend import ExecutionError
+from app.models.user import User
+from app.models.voyage import Voyage
+from app.schemas.execution import ExecutionRequest, ExecutionResult, SandboxStatus
+from app.services.execution_service import ExecutionService
+
+router = APIRouter(tags=["execution"])
+
+
+@router.post(
+    "/voyages/{voyage_id}/execute",
+    response_model=ExecutionResult,
+)
+async def execute_code(
+    voyage_id: uuid.UUID,
+    body: ExecutionRequest,
+    user: User = Depends(get_current_user),
+    voyage: Voyage = Depends(get_authorized_voyage),
+    execution_service: ExecutionService = Depends(get_execution_service),
+) -> ExecutionResult:
+    try:
+        return await execution_service.run(user.id, body)
+    except ExecutionError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail={"error": {"code": "EXECUTION_ERROR", "message": str(exc)}},
+        ) from exc
+
+
+@router.get(
+    "/sandbox/status",
+    response_model=SandboxStatus,
+)
+async def get_sandbox_status(
+    user: User = Depends(get_current_user),
+    execution_service: ExecutionService = Depends(get_execution_service),
+) -> SandboxStatus:
+    try:
+        return await execution_service.get_sandbox_status(user.id)
+    except ExecutionError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"error": {"code": "SANDBOX_NOT_FOUND", "message": str(exc)}},
+        ) from exc
+
+
+@router.delete(
+    "/sandbox",
+    status_code=status.HTTP_204_NO_CONTENT,
+    response_class=Response,
+)
+async def destroy_sandbox(
+    user: User = Depends(get_current_user),
+    execution_service: ExecutionService = Depends(get_execution_service),
+) -> Response:
+    try:
+        await execution_service.destroy_sandbox(user.id)
+    except ExecutionError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"error": {"code": "SANDBOX_NOT_FOUND", "message": str(exc)}},
+        ) from exc
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/src/backend/app/api/v1/execution.py
+++ b/src/backend/app/api/v1/execution.py
@@ -30,9 +30,15 @@ async def execute_code(
     try:
         return await execution_service.run(user.id, body)
     except ExecutionError as exc:
+        msg = str(exc)
+        if "Invalid file path" in msg or "File too large" in msg:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail={"error": {"code": "INVALID_REQUEST", "message": msg}},
+            ) from exc
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail={"error": {"code": "EXECUTION_ERROR", "message": str(exc)}},
+            detail={"error": {"code": "EXECUTION_ERROR", "message": msg}},
         ) from exc
 
 

--- a/src/backend/app/api/v1/router.py
+++ b/src/backend/app/api/v1/router.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter
 
 from app.api.v1.auth import router as auth_router
 from app.api.v1.dial import router as dial_router
+from app.api.v1.execution import router as execution_router
 from app.api.v1.health import router as health_router
 from app.api.v1.vivre_cards import router as vivre_cards_router
 
@@ -10,3 +11,4 @@ v1_router.include_router(health_router, tags=["health"])
 v1_router.include_router(auth_router)
 v1_router.include_router(dial_router)
 v1_router.include_router(vivre_cards_router)
+v1_router.include_router(execution_router)

--- a/src/backend/app/core/config.py
+++ b/src/backend/app/core/config.py
@@ -27,6 +27,16 @@ class Settings(BaseSettings):
     vivre_card_checkpoint_interval_seconds: int = 300  # 5 minutes
     vivre_card_cleanup_keep_last_n: int = 10
 
+    # Execution Service (Sandbox)
+    execution_backend: str = "gvisor"
+    execution_image: str = "python:3.13-slim"
+    execution_memory_limit: str = "256m"
+    execution_cpu_quota: int = 50000
+    execution_cpu_period: int = 100000
+    execution_default_timeout: int = 30
+    execution_network_enabled: bool = False
+    execution_gvisor_runtime: str = "runsc"
+
     # CORS
     cors_origins: list[str] = ["http://localhost:3000"]
 

--- a/src/backend/app/execution/backend.py
+++ b/src/backend/app/execution/backend.py
@@ -30,3 +30,6 @@ class ExecutionBackend(ABC):
     async def status(self, sandbox_id: str) -> SandboxStatus:
         """Query sandbox state."""
         ...
+
+    async def close(self) -> None:
+        """Release resources (e.g. Docker client session)."""

--- a/src/backend/app/execution/backend.py
+++ b/src/backend/app/execution/backend.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import uuid
+from abc import ABC, abstractmethod
+
+from app.schemas.execution import ExecutionRequest, ExecutionResult, SandboxStatus
+
+
+class ExecutionError(Exception):
+    """Raised when a sandbox operation fails."""
+
+
+class ExecutionBackend(ABC):
+    @abstractmethod
+    async def create(self, user_id: uuid.UUID) -> str:
+        """Provision a sandbox and return its ID."""
+        ...
+
+    @abstractmethod
+    async def execute(self, sandbox_id: str, request: ExecutionRequest) -> ExecutionResult:
+        """Run a command inside the sandbox."""
+        ...
+
+    @abstractmethod
+    async def destroy(self, sandbox_id: str) -> None:
+        """Tear down the sandbox."""
+        ...
+
+    @abstractmethod
+    async def status(self, sandbox_id: str) -> SandboxStatus:
+        """Query sandbox state."""
+        ...

--- a/src/backend/app/execution/factory.py
+++ b/src/backend/app/execution/factory.py
@@ -1,0 +1,16 @@
+"""Factory for creating execution backends."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.execution.backend import ExecutionBackend
+
+
+def create_backend(settings: Any) -> ExecutionBackend:
+    name = getattr(settings, "execution_backend", "gvisor")
+    if name == "gvisor":
+        from app.execution.gvisor_backend import GVisorContainerBackend
+
+        return GVisorContainerBackend(settings)
+    raise ValueError(f"Unknown execution backend: {name}")

--- a/src/backend/app/execution/gvisor_backend.py
+++ b/src/backend/app/execution/gvisor_backend.py
@@ -1,0 +1,167 @@
+"""Docker + gVisor execution backend."""
+
+from __future__ import annotations
+
+import io
+import logging
+import tarfile
+import time
+import uuid
+from asyncio import wait_for
+from datetime import datetime
+from typing import Any
+
+import aiodocker
+from aiodocker.exceptions import DockerError
+
+from app.execution.backend import ExecutionBackend, ExecutionError
+from app.schemas.execution import ExecutionRequest, ExecutionResult, SandboxStatus
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_memory(value: str) -> int:
+    """Parse memory limit string to bytes. Supports 'm' (MiB) and 'g' (GiB)."""
+    value = value.strip().lower()
+    if value.endswith("m"):
+        return int(value[:-1]) * 1024 * 1024
+    if value.endswith("g"):
+        return int(value[:-1]) * 1024 * 1024 * 1024
+    return int(value)
+
+
+def _build_tar(files: dict[str, str]) -> bytes:
+    """Create an in-memory tar archive from a path→content dict."""
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w") as tar:
+        for path, content in files.items():
+            data = content.encode()
+            info = tarfile.TarInfo(name=path)
+            info.size = len(data)
+            tar.addfile(info, io.BytesIO(data))
+    buf.seek(0)
+    return buf.read()
+
+
+class GVisorContainerBackend(ExecutionBackend):
+    def __init__(self, settings: Any) -> None:
+        self._settings = settings
+        self._docker = aiodocker.Docker()
+
+    async def create(self, user_id: uuid.UUID) -> str:
+        config = {
+            "Image": self._settings.execution_image,
+            "Cmd": ["tail", "-f", "/dev/null"],
+            "Labels": {
+                "grandline.user_id": str(user_id),
+                "grandline.managed": "true",
+            },
+            "HostConfig": {
+                "Runtime": self._settings.execution_gvisor_runtime,
+                "Memory": _parse_memory(self._settings.execution_memory_limit),
+                "CpuQuota": self._settings.execution_cpu_quota,
+                "CpuPeriod": self._settings.execution_cpu_period,
+                "NetworkMode": "none" if not self._settings.execution_network_enabled else "bridge",
+                "ReadonlyRootfs": True,
+                "Tmpfs": {
+                    "/workspace": "rw,size=64m",
+                    "/tmp": "rw,size=32m",
+                },
+            },
+        }
+        try:
+            container = await self._docker.containers.create_or_replace(
+                name=f"grandline-{user_id}-{uuid.uuid4().hex[:8]}",
+                config=config,
+            )
+            await container.start()
+            return container.id
+        except DockerError as exc:
+            raise ExecutionError(f"Failed to create sandbox: {exc}") from exc
+
+    async def execute(self, sandbox_id: str, request: ExecutionRequest) -> ExecutionResult:
+        try:
+            container = self._docker.containers.container(sandbox_id)
+
+            if request.files:
+                tar_data = _build_tar(request.files)
+                await container.put_archive("/workspace", tar_data)  # type: ignore[no-untyped-call]
+
+            exec_obj = await container.exec(
+                cmd=["sh", "-c", request.command],
+                workdir=request.working_dir,
+                environment=[f"{k}={v}" for k, v in request.environment.items()],
+                tty=False,
+            )
+
+            timed_out = False
+            output = b""
+            start = time.monotonic()
+
+            try:
+                output = await wait_for(
+                    exec_obj.start(detach=True),
+                    timeout=request.timeout_seconds,
+                )
+            except TimeoutError:
+                timed_out = True
+
+            duration = time.monotonic() - start
+
+            inspect_data = await exec_obj.inspect()
+            exit_code = inspect_data.get("ExitCode", -1)
+            if exit_code is None:
+                exit_code = -1
+
+            stdout = output.decode(errors="replace") if isinstance(output, bytes) else str(output)
+            # aiodocker detach mode returns combined output; stderr from exit code
+            stderr = "" if exit_code == 0 else stdout
+
+            return ExecutionResult(
+                exit_code=exit_code,
+                stdout=stdout,
+                stderr="" if exit_code == 0 else stderr,
+                timed_out=timed_out,
+                duration_seconds=round(duration, 3),
+                sandbox_id=sandbox_id,
+            )
+        except ExecutionError:
+            raise
+        except DockerError as exc:
+            raise ExecutionError(f"Execution failed: {exc}") from exc
+
+    async def destroy(self, sandbox_id: str) -> None:
+        try:
+            container = self._docker.containers.container(sandbox_id)
+            await container.kill()
+            await container.delete(force=True)
+        except DockerError:
+            logger.debug("Container %s already removed", sandbox_id)
+
+    async def status(self, sandbox_id: str) -> SandboxStatus:
+        try:
+            container = self._docker.containers.container(sandbox_id)
+            info = await container.show()
+        except DockerError as exc:
+            raise ExecutionError(f"Container not found: {sandbox_id}") from exc
+
+        docker_state = info["State"]["Status"]
+        if docker_state == "running":
+            state = "running"
+        elif docker_state in ("created", "paused"):
+            state = "idle"
+        else:
+            state = "destroyed"
+
+        user_id_str = info["Config"]["Labels"].get("grandline.user_id", "")
+        created_str = info["Created"]
+
+        return SandboxStatus(
+            sandbox_id=sandbox_id,
+            state=state,
+            user_id=uuid.UUID(user_id_str),
+            created_at=datetime.fromisoformat(created_str.replace("Z", "+00:00")),
+        )
+
+    async def close(self) -> None:
+        await self._docker.close()

--- a/src/backend/app/execution/gvisor_backend.py
+++ b/src/backend/app/execution/gvisor_backend.py
@@ -94,17 +94,28 @@ class GVisorContainerBackend(ExecutionBackend):
                 tty=False,
             )
 
+            stream = exec_obj.start(detach=False)
             timed_out = False
-            output = b""
+            stdout_buf = b""
+            stderr_buf = b""
             start = time.monotonic()
 
+            async def _read_stream() -> None:
+                nonlocal stdout_buf, stderr_buf
+                while True:
+                    msg = await stream.read_out()
+                    if msg is None:
+                        break
+                    if msg.stream == 1:
+                        stdout_buf += msg.data
+                    elif msg.stream == 2:
+                        stderr_buf += msg.data
+
             try:
-                output = await wait_for(
-                    exec_obj.start(detach=True),
-                    timeout=request.timeout_seconds,
-                )
+                await wait_for(_read_stream(), timeout=request.timeout_seconds)
             except TimeoutError:
                 timed_out = True
+                await stream.close()
 
             duration = time.monotonic() - start
 
@@ -113,14 +124,10 @@ class GVisorContainerBackend(ExecutionBackend):
             if exit_code is None:
                 exit_code = -1
 
-            stdout = output.decode(errors="replace") if isinstance(output, bytes) else str(output)
-            # aiodocker detach mode returns combined output; stderr from exit code
-            stderr = "" if exit_code == 0 else stdout
-
             return ExecutionResult(
                 exit_code=exit_code,
-                stdout=stdout,
-                stderr="" if exit_code == 0 else stderr,
+                stdout=stdout_buf.decode(errors="replace"),
+                stderr=stderr_buf.decode(errors="replace"),
                 timed_out=timed_out,
                 duration_seconds=round(duration, 3),
                 sandbox_id=sandbox_id,

--- a/src/backend/app/execution/gvisor_backend.py
+++ b/src/backend/app/execution/gvisor_backend.py
@@ -20,14 +20,36 @@ from app.schemas.execution import ExecutionRequest, ExecutionResult, SandboxStat
 logger = logging.getLogger(__name__)
 
 
+MAX_FILE_SIZE = 1_048_576  # 1 MiB per injected file
+
+
 def _parse_memory(value: str) -> int:
     """Parse memory limit string to bytes. Supports 'm' (MiB) and 'g' (GiB)."""
     value = value.strip().lower()
-    if value.endswith("m"):
-        return int(value[:-1]) * 1024 * 1024
-    if value.endswith("g"):
-        return int(value[:-1]) * 1024 * 1024 * 1024
+    if not value:
+        raise ValueError("Empty memory limit")
+    suffix = value[-1]
+    if suffix in ("m", "g"):
+        numeric = value[:-1]
+        if not numeric:
+            raise ValueError(f"Invalid memory limit: {value!r}")
+        n = int(numeric)  # raises ValueError for non-numeric
+        return n * 1024 * 1024 * (1024 if suffix == "g" else 1)
+    if not value.isdigit():
+        raise ValueError(f"Invalid memory limit suffix: {value!r}")
     return int(value)
+
+
+def _validate_file_path(path: str) -> None:
+    """Reject paths that escape the working directory."""
+    from pathlib import PurePosixPath
+
+    if not path or path.startswith("/"):
+        raise ExecutionError(f"Invalid file path: absolute paths not allowed: {path!r}")
+    resolved = PurePosixPath(path)
+    for part in resolved.parts:
+        if part == "..":
+            raise ExecutionError(f"Invalid file path: path traversal detected: {path!r}")
 
 
 def _build_tar(files: dict[str, str]) -> bytes:
@@ -35,7 +57,12 @@ def _build_tar(files: dict[str, str]) -> bytes:
     buf = io.BytesIO()
     with tarfile.open(fileobj=buf, mode="w") as tar:
         for path, content in files.items():
+            _validate_file_path(path)
             data = content.encode()
+            if len(data) > MAX_FILE_SIZE:
+                raise ExecutionError(
+                    f"File too large: {path!r} is {len(data)} bytes (max {MAX_FILE_SIZE})"
+                )
             info = tarfile.TarInfo(name=path)
             info.size = len(data)
             tar.addfile(info, io.BytesIO(data))

--- a/src/backend/app/main.py
+++ b/src/backend/app/main.py
@@ -9,6 +9,8 @@ from app.api.v1.router import v1_router
 from app.core.config import settings
 from app.core.middleware import DefaultDenyMiddleware
 from app.den_den_mushi.mushi import DenDenMushi
+from app.execution.factory import create_backend
+from app.services.execution_service import ExecutionService
 
 
 @asynccontextmanager
@@ -16,7 +18,14 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     pool = ConnectionPool.from_url(settings.redis_url, decode_responses=True)
     app.state.redis_pool = pool
     app.state.den_den_mushi = DenDenMushi(Redis(connection_pool=pool))
+
+    backend = create_backend(settings)
+    app.state.execution_service = ExecutionService(backend)
+
     yield
+
+    await app.state.execution_service.cleanup_all()
+    await backend.close()
     await pool.aclose()
 
 

--- a/src/backend/app/schemas/execution.py
+++ b/src/backend/app/schemas/execution.py
@@ -1,0 +1,28 @@
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+class ExecutionRequest(BaseModel):
+    command: str
+    working_dir: str = "/workspace"
+    timeout_seconds: int = Field(default=30, ge=1, le=300)
+    environment: dict[str, str] = Field(default_factory=dict)
+    files: dict[str, str] = Field(default_factory=dict)
+
+
+class ExecutionResult(BaseModel):
+    exit_code: int
+    stdout: str
+    stderr: str
+    timed_out: bool = False
+    duration_seconds: float
+    sandbox_id: str
+
+
+class SandboxStatus(BaseModel):
+    sandbox_id: str
+    state: str
+    user_id: uuid.UUID
+    created_at: datetime

--- a/src/backend/app/schemas/execution.py
+++ b/src/backend/app/schemas/execution.py
@@ -1,5 +1,6 @@
 import uuid
 from datetime import datetime
+from typing import Literal
 
 from pydantic import BaseModel, Field
 
@@ -23,6 +24,6 @@ class ExecutionResult(BaseModel):
 
 class SandboxStatus(BaseModel):
     sandbox_id: str
-    state: str
+    state: Literal["running", "idle", "destroyed"]
     user_id: uuid.UUID
     created_at: datetime

--- a/src/backend/app/services/execution_service.py
+++ b/src/backend/app/services/execution_service.py
@@ -1,0 +1,54 @@
+"""Execution Service — manages per-user sandbox lifecycle."""
+
+from __future__ import annotations
+
+import logging
+import uuid
+
+from app.execution.backend import ExecutionBackend, ExecutionError
+from app.schemas.execution import ExecutionRequest, ExecutionResult, SandboxStatus
+
+logger = logging.getLogger(__name__)
+
+
+class ExecutionService:
+    def __init__(self, backend: ExecutionBackend) -> None:
+        self._backend = backend
+        self._sandboxes: dict[uuid.UUID, str] = {}
+
+    async def run(self, user_id: uuid.UUID, request: ExecutionRequest) -> ExecutionResult:
+        sandbox_id = await self.get_or_create_sandbox(user_id)
+        return await self._backend.execute(sandbox_id, request)
+
+    async def get_or_create_sandbox(self, user_id: uuid.UUID) -> str:
+        if user_id in self._sandboxes:
+            sandbox_id = self._sandboxes[user_id]
+            try:
+                await self._backend.status(sandbox_id)
+                return sandbox_id
+            except ExecutionError:
+                logger.info("Sandbox %s for user %s is dead, recreating", sandbox_id, user_id)
+                del self._sandboxes[user_id]
+
+        sandbox_id = await self._backend.create(user_id)
+        self._sandboxes[user_id] = sandbox_id
+        return sandbox_id
+
+    async def get_sandbox_status(self, user_id: uuid.UUID) -> SandboxStatus:
+        if user_id not in self._sandboxes:
+            raise ExecutionError("SANDBOX_NOT_FOUND")
+        return await self._backend.status(self._sandboxes[user_id])
+
+    async def destroy_sandbox(self, user_id: uuid.UUID) -> None:
+        if user_id not in self._sandboxes:
+            raise ExecutionError("SANDBOX_NOT_FOUND")
+        sandbox_id = self._sandboxes.pop(user_id)
+        await self._backend.destroy(sandbox_id)
+
+    async def cleanup_all(self) -> None:
+        for user_id, sandbox_id in list(self._sandboxes.items()):
+            try:
+                await self._backend.destroy(sandbox_id)
+            except Exception:
+                logger.warning("Failed to destroy sandbox %s for user %s", sandbox_id, user_id)
+        self._sandboxes.clear()

--- a/src/backend/requirements.txt
+++ b/src/backend/requirements.txt
@@ -20,6 +20,9 @@ redis==5.1.1
 anthropic>=0.40.0
 openai>=1.50.0
 
+# Container Execution
+aiodocker>=0.23.0
+
 # Testing
 pytest==8.3.3
 pytest-asyncio==0.24.0

--- a/src/backend/tests/test_execution_api.py
+++ b/src/backend/tests/test_execution_api.py
@@ -80,7 +80,7 @@ class TestExecuteEndpoint:
         assert call_args[0][0] == USER_ID
 
     @pytest.mark.asyncio
-    async def test_execute_error_raises_http(self) -> None:
+    async def test_execute_error_raises_http_500(self) -> None:
         from app.api.v1.execution import execute_code
 
         svc = _mock_exec_service()
@@ -91,6 +91,32 @@ class TestExecuteEndpoint:
             await execute_code(VOYAGE_ID, body, _mock_user(), _mock_voyage(), svc)
 
         assert exc_info.value.status_code == 500
+
+    @pytest.mark.asyncio
+    async def test_execute_invalid_path_returns_400(self) -> None:
+        from app.api.v1.execution import execute_code
+
+        svc = _mock_exec_service()
+        svc.run.side_effect = ExecutionError("Invalid file path: path traversal detected")
+        body = ExecutionRequest(command="echo hello")
+
+        with pytest.raises(HTTPException) as exc_info:
+            await execute_code(VOYAGE_ID, body, _mock_user(), _mock_voyage(), svc)
+
+        assert exc_info.value.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_execute_file_too_large_returns_400(self) -> None:
+        from app.api.v1.execution import execute_code
+
+        svc = _mock_exec_service()
+        svc.run.side_effect = ExecutionError("File too large: big.txt")
+        body = ExecutionRequest(command="echo hello")
+
+        with pytest.raises(HTTPException) as exc_info:
+            await execute_code(VOYAGE_ID, body, _mock_user(), _mock_voyage(), svc)
+
+        assert exc_info.value.status_code == 400
 
 
 class TestSandboxStatusEndpoint:

--- a/src/backend/tests/test_execution_api.py
+++ b/src/backend/tests/test_execution_api.py
@@ -1,0 +1,152 @@
+"""Tests for Execution Service REST API endpoints."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+from app.execution.backend import ExecutionError
+from app.schemas.execution import ExecutionRequest, ExecutionResult, SandboxStatus
+
+VOYAGE_ID = uuid.uuid4()
+USER_ID = uuid.uuid4()
+
+
+def _mock_user() -> MagicMock:
+    user = MagicMock()
+    user.id = USER_ID
+    return user
+
+
+def _mock_voyage() -> MagicMock:
+    voyage = MagicMock()
+    voyage.id = VOYAGE_ID
+    return voyage
+
+
+def _mock_exec_service() -> AsyncMock:
+    svc = AsyncMock()
+    svc.run = AsyncMock(
+        return_value=ExecutionResult(
+            exit_code=0,
+            stdout="ok",
+            stderr="",
+            timed_out=False,
+            duration_seconds=0.5,
+            sandbox_id="sandbox-1",
+        )
+    )
+    svc.get_sandbox_status = AsyncMock(
+        return_value=SandboxStatus(
+            sandbox_id="sandbox-1",
+            state="running",
+            user_id=USER_ID,
+            created_at=datetime.now(UTC),
+        )
+    )
+    svc.destroy_sandbox = AsyncMock()
+    return svc
+
+
+class TestExecuteEndpoint:
+    @pytest.mark.asyncio
+    async def test_execute_returns_result(self) -> None:
+        from app.api.v1.execution import execute_code
+
+        svc = _mock_exec_service()
+        body = ExecutionRequest(command="echo hello")
+        result = await execute_code(VOYAGE_ID, body, _mock_user(), _mock_voyage(), svc)
+
+        assert result.exit_code == 0
+        assert result.stdout == "ok"
+        svc.run.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_execute_sets_user_from_auth(self) -> None:
+        from app.api.v1.execution import execute_code
+
+        svc = _mock_exec_service()
+        body = ExecutionRequest(command="echo hello")
+        user = _mock_user()
+
+        await execute_code(VOYAGE_ID, body, user, _mock_voyage(), svc)
+
+        # user_id passed to service.run comes from auth, not request body
+        call_args = svc.run.call_args
+        assert call_args[0][0] == USER_ID
+
+    @pytest.mark.asyncio
+    async def test_execute_error_raises_http(self) -> None:
+        from app.api.v1.execution import execute_code
+
+        svc = _mock_exec_service()
+        svc.run.side_effect = ExecutionError("Container failed")
+        body = ExecutionRequest(command="echo hello")
+
+        with pytest.raises(HTTPException) as exc_info:
+            await execute_code(VOYAGE_ID, body, _mock_user(), _mock_voyage(), svc)
+
+        assert exc_info.value.status_code == 500
+
+
+class TestSandboxStatusEndpoint:
+    @pytest.mark.asyncio
+    async def test_sandbox_status_returns_status(self) -> None:
+        from app.api.v1.execution import get_sandbox_status
+
+        svc = _mock_exec_service()
+        result = await get_sandbox_status(_mock_user(), svc)
+
+        assert result.state == "running"
+        assert result.sandbox_id == "sandbox-1"
+
+    @pytest.mark.asyncio
+    async def test_sandbox_status_not_found(self) -> None:
+        from app.api.v1.execution import get_sandbox_status
+
+        svc = _mock_exec_service()
+        svc.get_sandbox_status.side_effect = ExecutionError("SANDBOX_NOT_FOUND")
+
+        with pytest.raises(HTTPException) as exc_info:
+            await get_sandbox_status(_mock_user(), svc)
+
+        assert exc_info.value.status_code == 404
+
+
+class TestDestroySandboxEndpoint:
+    @pytest.mark.asyncio
+    async def test_destroy_sandbox_204(self) -> None:
+        from app.api.v1.execution import destroy_sandbox
+
+        svc = _mock_exec_service()
+        await destroy_sandbox(_mock_user(), svc)
+
+        svc.destroy_sandbox.assert_awaited_once_with(USER_ID)
+
+    @pytest.mark.asyncio
+    async def test_destroy_sandbox_not_found(self) -> None:
+        from app.api.v1.execution import destroy_sandbox
+
+        svc = _mock_exec_service()
+        svc.destroy_sandbox.side_effect = ExecutionError("SANDBOX_NOT_FOUND")
+
+        with pytest.raises(HTTPException) as exc_info:
+            await destroy_sandbox(_mock_user(), svc)
+
+        assert exc_info.value.status_code == 404
+
+
+class TestAuthRequired:
+    @pytest.mark.asyncio
+    async def test_execute_unauthorized_401(self) -> None:
+        """get_current_user raises 401 when no credentials are provided."""
+        from app.api.v1.dependencies import get_current_user
+
+        with pytest.raises(HTTPException) as exc_info:
+            await get_current_user(credentials=None, session=AsyncMock())
+
+        assert exc_info.value.status_code == 401

--- a/src/backend/tests/test_execution_backend.py
+++ b/src/backend/tests/test_execution_backend.py
@@ -388,3 +388,48 @@ class TestParseMemory:
         from app.execution.gvisor_backend import _parse_memory
 
         assert _parse_memory("1g") == 1073741824
+
+    def test_parse_memory_invalid_suffix_raises(self) -> None:
+        from app.execution.gvisor_backend import _parse_memory
+
+        with pytest.raises(ValueError, match="Invalid memory limit suffix"):
+            _parse_memory("256x")
+
+    def test_parse_memory_empty_raises(self) -> None:
+        from app.execution.gvisor_backend import _parse_memory
+
+        with pytest.raises(ValueError, match="Empty memory limit"):
+            _parse_memory("")
+
+    def test_parse_memory_non_numeric_raises(self) -> None:
+        from app.execution.gvisor_backend import _parse_memory
+
+        with pytest.raises(ValueError):
+            _parse_memory("abcm")
+
+
+class TestBuildTar:
+    def test_rejects_path_traversal(self) -> None:
+        from app.execution.gvisor_backend import _build_tar
+
+        with pytest.raises(ExecutionError, match="path traversal"):
+            _build_tar({"../etc/passwd": "data"})
+
+    def test_rejects_absolute_path(self) -> None:
+        from app.execution.gvisor_backend import _build_tar
+
+        with pytest.raises(ExecutionError, match="absolute paths not allowed"):
+            _build_tar({"/etc/passwd": "data"})
+
+    def test_rejects_file_too_large(self) -> None:
+        from app.execution.gvisor_backend import MAX_FILE_SIZE, _build_tar
+
+        with pytest.raises(ExecutionError, match="File too large"):
+            _build_tar({"big.txt": "x" * (MAX_FILE_SIZE + 1)})
+
+    def test_accepts_nested_path(self) -> None:
+        from app.execution.gvisor_backend import _build_tar
+
+        result = _build_tar({"src/main.py": "print('hi')"})
+        assert isinstance(result, bytes)
+        assert len(result) > 0

--- a/src/backend/tests/test_execution_backend.py
+++ b/src/backend/tests/test_execution_backend.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import uuid
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -12,6 +13,39 @@ import pytest
 from app.execution.backend import ExecutionError
 from app.execution.gvisor_backend import GVisorContainerBackend
 from app.schemas.execution import ExecutionRequest
+
+
+@dataclass
+class _FakeMessage:
+    stream: int  # 1=stdout, 2=stderr
+    data: bytes
+
+
+def _mock_stream(stdout: bytes = b"", stderr: bytes = b"") -> MagicMock:
+    """Create a mock Stream that yields messages then returns None."""
+    messages: list[_FakeMessage | None] = []
+    if stdout:
+        messages.append(_FakeMessage(stream=1, data=stdout))
+    if stderr:
+        messages.append(_FakeMessage(stream=2, data=stderr))
+    messages.append(None)  # EOF
+    it = iter(messages)
+    stream = MagicMock()
+    stream.read_out = AsyncMock(side_effect=lambda: next(it))
+    stream.close = AsyncMock()
+    return stream
+
+
+def _timeout_stream() -> MagicMock:
+    """Create a mock Stream whose read_out hangs forever (for timeout tests)."""
+    stream = MagicMock()
+
+    async def _hang() -> None:
+        await asyncio.sleep(3600)
+
+    stream.read_out = AsyncMock(side_effect=_hang)
+    stream.close = AsyncMock()
+    return stream
 
 
 @pytest.fixture
@@ -156,7 +190,7 @@ class TestExecute:
         mock_docker.containers.container.return_value = container
 
         exec_obj = AsyncMock()
-        exec_obj.start = AsyncMock(return_value=b"hello\n")
+        exec_obj.start = MagicMock(return_value=_mock_stream(stdout=b"hello\n"))
         exec_obj.inspect = AsyncMock(return_value={"ExitCode": 0})
         container.exec = AsyncMock(return_value=exec_obj)
 
@@ -175,7 +209,7 @@ class TestExecute:
         mock_docker.containers.container.return_value = container
 
         exec_obj = AsyncMock()
-        exec_obj.start = AsyncMock(return_value=b"error\n")
+        exec_obj.start = MagicMock(return_value=_mock_stream(stderr=b"error\n"))
         exec_obj.inspect = AsyncMock(return_value={"ExitCode": 1})
         container.exec = AsyncMock(return_value=exec_obj)
 
@@ -183,7 +217,7 @@ class TestExecute:
         result = await backend.execute("abc123", request)
 
         assert result.exit_code == 1
-        assert result.stderr != ""
+        assert result.stderr == "error\n"
 
     @pytest.mark.asyncio
     async def test_execute_respects_timeout(
@@ -193,7 +227,7 @@ class TestExecute:
         mock_docker.containers.container.return_value = container
 
         exec_obj = AsyncMock()
-        exec_obj.start = AsyncMock(side_effect=asyncio.TimeoutError)
+        exec_obj.start = MagicMock(return_value=_timeout_stream())
         exec_obj.inspect = AsyncMock(return_value={"ExitCode": -1})
         container.exec = AsyncMock(return_value=exec_obj)
 
@@ -211,7 +245,7 @@ class TestExecute:
         container.put_archive = AsyncMock()
 
         exec_obj = AsyncMock()
-        exec_obj.start = AsyncMock(return_value=b"ok")
+        exec_obj.start = MagicMock(return_value=_mock_stream(stdout=b"ok"))
         exec_obj.inspect = AsyncMock(return_value={"ExitCode": 0})
         container.exec = AsyncMock(return_value=exec_obj)
 
@@ -232,7 +266,7 @@ class TestExecute:
         mock_docker.containers.container.return_value = container
 
         exec_obj = AsyncMock()
-        exec_obj.start = AsyncMock(return_value=b"1")
+        exec_obj.start = MagicMock(return_value=_mock_stream(stdout=b"1"))
         exec_obj.inspect = AsyncMock(return_value={"ExitCode": 0})
         container.exec = AsyncMock(return_value=exec_obj)
 
@@ -254,7 +288,7 @@ class TestExecute:
         mock_docker.containers.container.return_value = container
 
         exec_obj = AsyncMock()
-        exec_obj.start = AsyncMock(return_value=b"")
+        exec_obj.start = MagicMock(return_value=_mock_stream())
         exec_obj.inspect = AsyncMock(return_value={"ExitCode": 0})
         container.exec = AsyncMock(return_value=exec_obj)
 

--- a/src/backend/tests/test_execution_backend.py
+++ b/src/backend/tests/test_execution_backend.py
@@ -1,0 +1,356 @@
+"""Tests for GVisorContainerBackend (mocked aiodocker)."""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.execution.backend import ExecutionError
+from app.execution.gvisor_backend import GVisorContainerBackend
+from app.schemas.execution import ExecutionRequest
+
+
+@pytest.fixture
+def settings() -> MagicMock:
+    s = MagicMock()
+    s.execution_image = "python:3.13-slim"
+    s.execution_gvisor_runtime = "runsc"
+    s.execution_memory_limit = "256m"
+    s.execution_cpu_quota = 50000
+    s.execution_cpu_period = 100000
+    s.execution_network_enabled = False
+    s.execution_default_timeout = 30
+    return s
+
+
+@pytest.fixture
+def mock_docker() -> MagicMock:
+    docker = MagicMock()
+    docker.containers = MagicMock()
+    docker.containers.create_or_replace = AsyncMock()
+    # containers.container() is synchronous in aiodocker — returns a DockerContainer
+    docker.containers.container = MagicMock()
+    return docker
+
+
+@pytest.fixture
+def backend(settings: MagicMock, mock_docker: MagicMock) -> GVisorContainerBackend:
+    with patch("app.execution.gvisor_backend.aiodocker.Docker"):
+        b = GVisorContainerBackend(settings)
+    b._docker = mock_docker
+    return b
+
+
+USER_ID = uuid.uuid4()
+
+
+def _container_mock(container_id: str = "abc123") -> AsyncMock:
+    container = AsyncMock()
+    container.id = container_id
+    container.start = AsyncMock()
+    container.kill = AsyncMock()
+    container.delete = AsyncMock()
+    container.show = AsyncMock(
+        return_value={
+            "Id": container_id,
+            "State": {"Status": "running"},
+            "Config": {"Labels": {"grandline.user_id": str(USER_ID)}},
+            "Created": datetime.now(UTC).isoformat(),
+        }
+    )
+    return container
+
+
+class TestCreate:
+    @pytest.mark.asyncio
+    async def test_create_sets_gvisor_runtime(
+        self, backend: GVisorContainerBackend, mock_docker: AsyncMock
+    ) -> None:
+        container = _container_mock()
+        mock_docker.containers.create_or_replace = AsyncMock(return_value=container)
+
+        await backend.create(USER_ID)
+
+        config = mock_docker.containers.create_or_replace.call_args[1]["config"]
+        assert config["HostConfig"]["Runtime"] == "runsc"
+
+    @pytest.mark.asyncio
+    async def test_create_sets_resource_limits(
+        self, backend: GVisorContainerBackend, mock_docker: AsyncMock
+    ) -> None:
+        container = _container_mock()
+        mock_docker.containers.create_or_replace = AsyncMock(return_value=container)
+
+        await backend.create(USER_ID)
+
+        config = mock_docker.containers.create_or_replace.call_args[1]["config"]
+        host = config["HostConfig"]
+        assert host["Memory"] == 268435456  # 256m in bytes
+        assert host["CpuQuota"] == 50000
+        assert host["CpuPeriod"] == 100000
+
+    @pytest.mark.asyncio
+    async def test_create_disables_network(
+        self, backend: GVisorContainerBackend, mock_docker: AsyncMock
+    ) -> None:
+        container = _container_mock()
+        mock_docker.containers.create_or_replace = AsyncMock(return_value=container)
+
+        await backend.create(USER_ID)
+
+        config = mock_docker.containers.create_or_replace.call_args[1]["config"]
+        assert config["HostConfig"]["NetworkMode"] == "none"
+
+    @pytest.mark.asyncio
+    async def test_create_sets_readonly_rootfs(
+        self, backend: GVisorContainerBackend, mock_docker: AsyncMock
+    ) -> None:
+        container = _container_mock()
+        mock_docker.containers.create_or_replace = AsyncMock(return_value=container)
+
+        await backend.create(USER_ID)
+
+        config = mock_docker.containers.create_or_replace.call_args[1]["config"]
+        host = config["HostConfig"]
+        assert host["ReadonlyRootfs"] is True
+        assert "/workspace" in host["Tmpfs"]
+        assert "/tmp" in host["Tmpfs"]
+
+    @pytest.mark.asyncio
+    async def test_create_labels_include_user_id(
+        self, backend: GVisorContainerBackend, mock_docker: AsyncMock
+    ) -> None:
+        container = _container_mock()
+        mock_docker.containers.create_or_replace = AsyncMock(return_value=container)
+
+        await backend.create(USER_ID)
+
+        config = mock_docker.containers.create_or_replace.call_args[1]["config"]
+        labels = config["Labels"]
+        assert labels["grandline.user_id"] == str(USER_ID)
+        assert labels["grandline.managed"] == "true"
+
+    @pytest.mark.asyncio
+    async def test_create_starts_container(
+        self, backend: GVisorContainerBackend, mock_docker: AsyncMock
+    ) -> None:
+        container = _container_mock()
+        mock_docker.containers.create_or_replace = AsyncMock(return_value=container)
+
+        sandbox_id = await backend.create(USER_ID)
+
+        container.start.assert_awaited_once()
+        assert sandbox_id == "abc123"
+
+
+class TestExecute:
+    @pytest.mark.asyncio
+    async def test_execute_captures_output(
+        self, backend: GVisorContainerBackend, mock_docker: MagicMock
+    ) -> None:
+        container = _container_mock()
+        mock_docker.containers.container.return_value = container
+
+        exec_obj = AsyncMock()
+        exec_obj.start = AsyncMock(return_value=b"hello\n")
+        exec_obj.inspect = AsyncMock(return_value={"ExitCode": 0})
+        container.exec = AsyncMock(return_value=exec_obj)
+
+        request = ExecutionRequest(command="echo hello")
+        result = await backend.execute("abc123", request)
+
+        assert result.stdout == "hello\n"
+        assert result.stderr == ""
+        assert result.exit_code == 0
+
+    @pytest.mark.asyncio
+    async def test_execute_captures_exit_code(
+        self, backend: GVisorContainerBackend, mock_docker: MagicMock
+    ) -> None:
+        container = _container_mock()
+        mock_docker.containers.container.return_value = container
+
+        exec_obj = AsyncMock()
+        exec_obj.start = AsyncMock(return_value=b"error\n")
+        exec_obj.inspect = AsyncMock(return_value={"ExitCode": 1})
+        container.exec = AsyncMock(return_value=exec_obj)
+
+        request = ExecutionRequest(command="false")
+        result = await backend.execute("abc123", request)
+
+        assert result.exit_code == 1
+        assert result.stderr != ""
+
+    @pytest.mark.asyncio
+    async def test_execute_respects_timeout(
+        self, backend: GVisorContainerBackend, mock_docker: MagicMock
+    ) -> None:
+        container = _container_mock()
+        mock_docker.containers.container.return_value = container
+
+        exec_obj = AsyncMock()
+        exec_obj.start = AsyncMock(side_effect=asyncio.TimeoutError)
+        exec_obj.inspect = AsyncMock(return_value={"ExitCode": -1})
+        container.exec = AsyncMock(return_value=exec_obj)
+
+        request = ExecutionRequest(command="sleep 999", timeout_seconds=1)
+        result = await backend.execute("abc123", request)
+
+        assert result.timed_out is True
+
+    @pytest.mark.asyncio
+    async def test_execute_writes_files(
+        self, backend: GVisorContainerBackend, mock_docker: MagicMock
+    ) -> None:
+        container = _container_mock()
+        mock_docker.containers.container.return_value = container
+        container.put_archive = AsyncMock()
+
+        exec_obj = AsyncMock()
+        exec_obj.start = AsyncMock(return_value=b"ok")
+        exec_obj.inspect = AsyncMock(return_value={"ExitCode": 0})
+        container.exec = AsyncMock(return_value=exec_obj)
+
+        request = ExecutionRequest(
+            command="python main.py",
+            files={"main.py": "print('ok')"},
+        )
+        result = await backend.execute("abc123", request)
+
+        container.put_archive.assert_awaited_once()
+        assert result.stdout == "ok"
+
+    @pytest.mark.asyncio
+    async def test_execute_sets_environment(
+        self, backend: GVisorContainerBackend, mock_docker: MagicMock
+    ) -> None:
+        container = _container_mock()
+        mock_docker.containers.container.return_value = container
+
+        exec_obj = AsyncMock()
+        exec_obj.start = AsyncMock(return_value=b"1")
+        exec_obj.inspect = AsyncMock(return_value={"ExitCode": 0})
+        container.exec = AsyncMock(return_value=exec_obj)
+
+        request = ExecutionRequest(
+            command="echo $DEBUG",
+            environment={"DEBUG": "1"},
+        )
+        await backend.execute("abc123", request)
+
+        exec_call = container.exec.call_args
+        env = exec_call[1].get("environment") or exec_call[1].get("env")
+        assert "DEBUG=1" in env
+
+    @pytest.mark.asyncio
+    async def test_execute_tracks_duration(
+        self, backend: GVisorContainerBackend, mock_docker: MagicMock
+    ) -> None:
+        container = _container_mock()
+        mock_docker.containers.container.return_value = container
+
+        exec_obj = AsyncMock()
+        exec_obj.start = AsyncMock(return_value=b"")
+        exec_obj.inspect = AsyncMock(return_value={"ExitCode": 0})
+        container.exec = AsyncMock(return_value=exec_obj)
+
+        request = ExecutionRequest(command="true")
+        result = await backend.execute("abc123", request)
+
+        assert result.duration_seconds >= 0
+
+
+class TestDestroy:
+    @pytest.mark.asyncio
+    async def test_destroy_removes_container(
+        self, backend: GVisorContainerBackend, mock_docker: AsyncMock
+    ) -> None:
+        container = _container_mock()
+        mock_docker.containers.container.return_value = container
+
+        await backend.destroy("abc123")
+
+        container.kill.assert_awaited_once()
+        container.delete.assert_awaited_once_with(force=True)
+
+    @pytest.mark.asyncio
+    async def test_destroy_handles_already_removed(
+        self, backend: GVisorContainerBackend, mock_docker: AsyncMock
+    ) -> None:
+        from aiodocker.exceptions import DockerError
+
+        container = _container_mock()
+        container.kill = AsyncMock(side_effect=DockerError(404, {"message": "not found"}))
+        mock_docker.containers.container.return_value = container
+
+        # Should not raise
+        await backend.destroy("abc123")
+
+
+class TestStatus:
+    @pytest.mark.asyncio
+    async def test_status_maps_running(
+        self, backend: GVisorContainerBackend, mock_docker: AsyncMock
+    ) -> None:
+        container = _container_mock()
+        container.show = AsyncMock(
+            return_value={
+                "Id": "abc123",
+                "State": {"Status": "running"},
+                "Config": {"Labels": {"grandline.user_id": str(USER_ID)}},
+                "Created": datetime.now(UTC).isoformat(),
+            }
+        )
+        mock_docker.containers.container.return_value = container
+
+        status = await backend.status("abc123")
+
+        assert status.state == "running"
+
+    @pytest.mark.asyncio
+    async def test_status_maps_created_to_idle(
+        self, backend: GVisorContainerBackend, mock_docker: AsyncMock
+    ) -> None:
+        container = _container_mock()
+        container.show = AsyncMock(
+            return_value={
+                "Id": "abc123",
+                "State": {"Status": "created"},
+                "Config": {"Labels": {"grandline.user_id": str(USER_ID)}},
+                "Created": datetime.now(UTC).isoformat(),
+            }
+        )
+        mock_docker.containers.container.return_value = container
+
+        status = await backend.status("abc123")
+
+        assert status.state == "idle"
+
+    @pytest.mark.asyncio
+    async def test_status_not_found_raises(
+        self, backend: GVisorContainerBackend, mock_docker: AsyncMock
+    ) -> None:
+        from aiodocker.exceptions import DockerError
+
+        mock_docker.containers.container.return_value = AsyncMock(
+            show=AsyncMock(side_effect=DockerError(404, {"message": "not found"}))
+        )
+
+        with pytest.raises(ExecutionError):
+            await backend.status("nonexistent")
+
+
+class TestParseMemory:
+    def test_parse_memory_megabytes(self) -> None:
+        from app.execution.gvisor_backend import _parse_memory
+
+        assert _parse_memory("256m") == 268435456
+
+    def test_parse_memory_gigabytes(self) -> None:
+        from app.execution.gvisor_backend import _parse_memory
+
+        assert _parse_memory("1g") == 1073741824

--- a/src/backend/tests/test_execution_factory.py
+++ b/src/backend/tests/test_execution_factory.py
@@ -1,0 +1,29 @@
+"""Tests for execution backend factory."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestCreateBackend:
+    def test_creates_gvisor_backend(self) -> None:
+        from app.execution.factory import create_backend
+        from app.execution.gvisor_backend import GVisorContainerBackend
+
+        settings = MagicMock()
+        settings.execution_backend = "gvisor"
+        with patch("app.execution.gvisor_backend.aiodocker.Docker"):
+            backend = create_backend(settings)
+
+        assert isinstance(backend, GVisorContainerBackend)
+
+    def test_raises_for_unknown_backend(self) -> None:
+        from app.execution.factory import create_backend
+
+        settings = MagicMock()
+        settings.execution_backend = "unknown"
+
+        with pytest.raises(ValueError, match="Unknown execution backend"):
+            create_backend(settings)

--- a/src/backend/tests/test_execution_schemas.py
+++ b/src/backend/tests/test_execution_schemas.py
@@ -1,0 +1,97 @@
+"""Tests for Execution Service schemas."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+import pytest
+from pydantic import ValidationError
+
+from app.schemas.execution import ExecutionRequest, ExecutionResult, SandboxStatus
+
+
+class TestExecutionRequestDefaults:
+    def test_defaults(self) -> None:
+        req = ExecutionRequest(command="echo hello")
+        assert req.command == "echo hello"
+        assert req.working_dir == "/workspace"
+        assert req.timeout_seconds == 30
+        assert req.environment == {}
+        assert req.files == {}
+
+
+class TestExecutionRequestCustom:
+    def test_custom_values(self) -> None:
+        req = ExecutionRequest(
+            command="python main.py",
+            working_dir="/app",
+            timeout_seconds=120,
+            environment={"DEBUG": "1"},
+            files={"main.py": "print('hi')"},
+        )
+        assert req.command == "python main.py"
+        assert req.working_dir == "/app"
+        assert req.timeout_seconds == 120
+        assert req.environment == {"DEBUG": "1"}
+        assert req.files == {"main.py": "print('hi')"}
+
+
+class TestExecutionRequestTimeoutRange:
+    def test_timeout_below_min_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ExecutionRequest(command="echo", timeout_seconds=0)
+
+    def test_timeout_above_max_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ExecutionRequest(command="echo", timeout_seconds=301)
+
+    def test_timeout_at_boundaries_accepted(self) -> None:
+        req_min = ExecutionRequest(command="echo", timeout_seconds=1)
+        assert req_min.timeout_seconds == 1
+        req_max = ExecutionRequest(command="echo", timeout_seconds=300)
+        assert req_max.timeout_seconds == 300
+
+
+class TestExecutionResultFields:
+    def test_all_fields(self) -> None:
+        result = ExecutionResult(
+            exit_code=0,
+            stdout="hello\n",
+            stderr="",
+            timed_out=False,
+            duration_seconds=1.23,
+            sandbox_id="abc123",
+        )
+        assert result.exit_code == 0
+        assert result.stdout == "hello\n"
+        assert result.stderr == ""
+        assert result.timed_out is False
+        assert result.duration_seconds == 1.23
+        assert result.sandbox_id == "abc123"
+
+    def test_timed_out_default_false(self) -> None:
+        result = ExecutionResult(
+            exit_code=1,
+            stdout="",
+            stderr="err",
+            duration_seconds=0.5,
+            sandbox_id="x",
+        )
+        assert result.timed_out is False
+
+
+class TestSandboxStatusFields:
+    def test_all_fields(self) -> None:
+        uid = uuid.uuid4()
+        now = datetime.now(UTC)
+        status = SandboxStatus(
+            sandbox_id="container-1",
+            state="running",
+            user_id=uid,
+            created_at=now,
+        )
+        assert status.sandbox_id == "container-1"
+        assert status.state == "running"
+        assert status.user_id == uid
+        assert status.created_at == now

--- a/src/backend/tests/test_execution_schemas.py
+++ b/src/backend/tests/test_execution_schemas.py
@@ -95,3 +95,16 @@ class TestSandboxStatusFields:
         assert status.state == "running"
         assert status.user_id == uid
         assert status.created_at == now
+
+    def test_state_accepts_valid_values(self) -> None:
+        uid = uuid.uuid4()
+        now = datetime.now(UTC)
+        for valid_state in ("running", "idle", "destroyed"):
+            s = SandboxStatus(sandbox_id="c1", state=valid_state, user_id=uid, created_at=now)
+            assert s.state == valid_state
+
+    def test_state_rejects_invalid_value(self) -> None:
+        uid = uuid.uuid4()
+        now = datetime.now(UTC)
+        with pytest.raises(ValidationError):
+            SandboxStatus(sandbox_id="c1", state="unknown", user_id=uid, created_at=now)

--- a/src/backend/tests/test_execution_service.py
+++ b/src/backend/tests/test_execution_service.py
@@ -1,0 +1,133 @@
+"""Tests for ExecutionService (mocked backend)."""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.execution.backend import ExecutionError
+from app.schemas.execution import ExecutionRequest, ExecutionResult
+from app.services.execution_service import ExecutionService
+
+
+@pytest.fixture
+def mock_backend() -> AsyncMock:
+    backend = AsyncMock()
+    backend.create = AsyncMock(return_value="sandbox-1")
+    backend.execute = AsyncMock(
+        return_value=ExecutionResult(
+            exit_code=0,
+            stdout="ok",
+            stderr="",
+            timed_out=False,
+            duration_seconds=0.5,
+            sandbox_id="sandbox-1",
+        )
+    )
+    backend.destroy = AsyncMock()
+    backend.status = AsyncMock()
+    return backend
+
+
+@pytest.fixture
+def service(mock_backend: AsyncMock) -> ExecutionService:
+    return ExecutionService(mock_backend)
+
+
+USER_ID = uuid.uuid4()
+OTHER_USER = uuid.uuid4()
+
+
+class TestRun:
+    @pytest.mark.asyncio
+    async def test_run_creates_sandbox_and_executes(
+        self, service: ExecutionService, mock_backend: AsyncMock
+    ) -> None:
+        request = ExecutionRequest(command="echo hello")
+        result = await service.run(USER_ID, request)
+
+        mock_backend.create.assert_awaited_once_with(USER_ID)
+        mock_backend.execute.assert_awaited_once_with("sandbox-1", request)
+        assert result.exit_code == 0
+        assert result.stdout == "ok"
+
+    @pytest.mark.asyncio
+    async def test_run_reuses_existing_sandbox(
+        self, service: ExecutionService, mock_backend: AsyncMock
+    ) -> None:
+        request = ExecutionRequest(command="echo 1")
+        await service.run(USER_ID, request)
+        await service.run(USER_ID, request)
+
+        # create called only once — sandbox is reused
+        mock_backend.create.assert_awaited_once()
+        assert mock_backend.execute.await_count == 2
+
+
+class TestGetOrCreateSandbox:
+    @pytest.mark.asyncio
+    async def test_detects_dead_sandbox(
+        self, service: ExecutionService, mock_backend: AsyncMock
+    ) -> None:
+        # First call: create normally
+        request = ExecutionRequest(command="echo 1")
+        await service.run(USER_ID, request)
+
+        # Simulate dead sandbox on status check
+        mock_backend.status.side_effect = ExecutionError("Container gone")
+        mock_backend.create.reset_mock()
+        mock_backend.create.return_value = "sandbox-2"
+
+        await service.run(USER_ID, request)
+
+        # Should have created a new sandbox
+        mock_backend.create.assert_awaited_once_with(USER_ID)
+
+
+class TestDestroySandbox:
+    @pytest.mark.asyncio
+    async def test_destroy_sandbox_calls_backend(
+        self, service: ExecutionService, mock_backend: AsyncMock
+    ) -> None:
+        # Create a sandbox first
+        await service.run(USER_ID, ExecutionRequest(command="echo"))
+        await service.destroy_sandbox(USER_ID)
+
+        mock_backend.destroy.assert_awaited_once_with("sandbox-1")
+
+    @pytest.mark.asyncio
+    async def test_destroy_sandbox_not_found_raises(self, service: ExecutionService) -> None:
+        with pytest.raises(ExecutionError, match="SANDBOX_NOT_FOUND"):
+            await service.destroy_sandbox(OTHER_USER)
+
+
+class TestCleanupAll:
+    @pytest.mark.asyncio
+    async def test_cleanup_all_destroys_all(
+        self, service: ExecutionService, mock_backend: AsyncMock
+    ) -> None:
+        # Create sandboxes for two users
+        mock_backend.create.side_effect = ["sandbox-1", "sandbox-2"]
+        await service.run(USER_ID, ExecutionRequest(command="echo"))
+        await service.run(OTHER_USER, ExecutionRequest(command="echo"))
+
+        await service.cleanup_all()
+
+        assert mock_backend.destroy.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_cleanup_all_continues_on_error(
+        self, service: ExecutionService, mock_backend: AsyncMock
+    ) -> None:
+        mock_backend.create.side_effect = ["sandbox-1", "sandbox-2"]
+        await service.run(USER_ID, ExecutionRequest(command="echo"))
+        await service.run(OTHER_USER, ExecutionRequest(command="echo"))
+
+        # First destroy fails, second should still be called
+        mock_backend.destroy.side_effect = [ExecutionError("fail"), None]
+
+        await service.cleanup_all()
+
+        assert mock_backend.destroy.await_count == 2


### PR DESCRIPTION
## Summary

- Implements the **Execution Service** — the security boundary that runs agent-generated code inside isolated Docker containers with gVisor runtime (Phase 8, closes #9)
- **ExecutionBackend ABC** with swappable interface pattern (gVisor → Firecracker → Wasm) matching the existing DialSystem adapter pattern
- **GVisorContainerBackend** via `aiodocker`: per-user containers with memory/CPU limits, readonly rootfs, tmpfs workspace, no network access, container labels for tracking
- **ExecutionService** class: per-user sandbox lifecycle — get-or-create, reuse, dead-sandbox detection, graceful cleanup
- **REST API**: `POST /voyages/{id}/execute`, `GET /sandbox/status`, `DELETE /sandbox` with auth + voyage ownership
- **44 unit tests** across 5 test files (schemas, backend, service, factory, API) — all mocked, no Docker daemon required

## New files

| File | Purpose |
|------|---------|
| `app/execution/__init__.py` | Package init |
| `app/execution/backend.py` | ExecutionBackend ABC + ExecutionError |
| `app/execution/gvisor_backend.py` | Docker + gVisor implementation |
| `app/execution/factory.py` | Backend factory |
| `app/services/execution_service.py` | Per-user sandbox lifecycle service |
| `app/schemas/execution.py` | ExecutionRequest, ExecutionResult, SandboxStatus |
| `app/api/v1/execution.py` | REST API endpoints |
| `tests/test_execution_schemas.py` | 8 schema tests |
| `tests/test_execution_backend.py` | 19 backend tests (mocked aiodocker) |
| `tests/test_execution_service.py` | 7 service tests (mocked backend) |
| `tests/test_execution_factory.py` | 2 factory tests |
| `tests/test_execution_api.py` | 8 API tests (mocked service) |

## Security constraints

- All code execution goes through the backend — never on the host
- `user_id` from auth context, never from request body
- Network disabled by default (`NetworkMode: "none"`)
- Read-only root filesystem with tmpfs `/workspace` and `/tmp`
- Memory/CPU limits enforced at container level
- Timeout via `asyncio.wait_for()`, not signals

## Test plan

- [x] 249 tests passing (44 new + 205 existing), 10 skipped (integration)
- [x] ruff lint clean
- [x] ruff format clean
- [x] mypy clean (only pre-existing `jose` stubs warning)
- [ ] Manual: verify Docker + gVisor sandbox works with actual daemon