### PR TITLE
feat: add Git Integration Service with per-voyage sandboxed operations (Phase 9)

### DIFF
--- a/pdd/prompts/features/git/grandline-09-git-integration.md
+++ b/pdd/prompts/features/git/grandline-09-git-integration.md
@@ -1,0 +1,348 @@
+# Prompt: Git Integration Service
+
+**File**: pdd/prompts/features/git/grandline-09-git-integration.md
+**Created**: 2026-04-12
+**Updated**: 2026-04-12
+**Depends on**: Phase 3 (models), Phase 8 (Execution Service)
+**Project type**: Backend (FastAPI + aiodocker + GitHub REST API)
+
+## Context
+
+GrandLine is a One Piece-themed multi-agent orchestration platform. Phases 1-8 delivered Docker infrastructure, database models, JWT auth, Den Den Mushi message bus, Dial System LLM gateway, Vivre Card state checkpointing, and the Execution Service (containerized sandbox with gVisor). Crew agents (Shipwright, Doctor, Helmsman) work in real git repos with per-agent branches. Git is the source of truth — code merges via the standard PR flow.
+
+The Git Integration Service manages the full git lifecycle for agent work: cloning repos into sandboxes, creating per-agent branches, committing with crew member attribution, pushing to remotes, creating PRs via GitHub API, and detecting conflicts before merge. All git operations (clone, branch, commit, push) run inside the Execution Service sandbox. GitHub API operations (create PR, list PRs) run from the backend via `httpx`.
+
+## Task
+
+Implement the Git Integration Service. TDD — tests first, then implementation.
+
+1. **Schemas** (`app/schemas/git.py`):
+
+   - `GitCloneRequest`:
+     - `repo_url: str | None = None` — HTTPS git URL; defaults to `voyage.target_repo` if None
+     - Validate: must start with `https://` if provided
+
+   - `GitBranchRequest`:
+     - `crew_member: str` — agent role (e.g. "shipwright", "doctor")
+     - `base_branch: str = "main"` — branch to create from
+
+   - `GitCommitRequest`:
+     - `message: str` — commit message (1-500 chars)
+     - `crew_member: str` — for author attribution
+     - `files: dict[str, str] = {}` — path -> content to write before committing
+
+   - `GitPushRequest`:
+     - `branch: str` — branch to push
+
+   - `GitPRRequest`:
+     - `title: str` — PR title (1-200 chars)
+     - `body: str = ""` — PR description
+     - `head_branch: str` — source branch
+     - `base_branch: str = "main"` — target branch
+
+   - `GitConflictCheckRequest`:
+     - `branch: str` — branch to check
+     - `target_branch: str = "main"` — merge target
+
+   Response schemas:
+
+   - `GitRepoInfo`:
+     - `sandbox_id: str`
+     - `repo_url: str`
+     - `default_branch: str`
+
+   - `GitBranchInfo`:
+     - `name: str`
+     - `is_current: bool`
+
+   - `GitCommitInfo`:
+     - `sha: str`
+     - `short_sha: str`
+     - `message: str`
+     - `author: str`
+     - `timestamp: str`
+
+   - `GitPushInfo`:
+     - `branch: str`
+     - `pushed: bool`
+
+   - `GitPRInfo`:
+     - `number: int`
+     - `url: str`
+     - `title: str`
+     - `head: str`
+     - `base: str`
+
+   - `GitConflictInfo`:
+     - `has_conflicts: bool`
+     - `conflicting_files: list[str] = []`
+
+2. **GitService** (`app/services/git_service.py`):
+
+   Class-based (needs state for sandbox tracking per voyage):
+
+   - `__init__(self, backend: ExecutionBackend, settings: Any)` — inject the git-configured backend and settings
+   - `_repos: dict[uuid.UUID, str]` — maps voyage_id -> sandbox_id
+   - `REPO_PATH = "/workspace/repo"` — cloned repo path inside sandbox
+
+   **Branch naming convention**: `agent/<crew_member>/<voyage_id_hex8>`
+   - e.g. `agent/shipwright/a1b2c3d4` (first 8 hex chars of voyage UUID)
+   - Computed via `_branch_name(crew_member, voyage_id)` helper
+
+   Methods:
+
+   - `async clone_repo(voyage_id, user_id, repo_url) -> GitRepoInfo`:
+     - Create sandbox via `backend.create(user_id)`
+     - Store in `_repos[voyage_id] = sandbox_id`
+     - Run: `git clone <repo_url> /workspace/repo`
+     - Configure author: `git config user.name`, `git config user.email`
+     - Return `GitRepoInfo`
+     - Repo URL injected via HTTPS token URL: `https://<token>@github.com/owner/repo.git`
+     - Parse owner/repo from URL for later GitHub API calls
+
+   - `async create_branch(voyage_id, user_id, crew_member, base_branch) -> GitBranchInfo`:
+     - Get sandbox from `_repos[voyage_id]`; raise `GitError("REPO_NOT_CLONED")` if missing
+     - Branch name: `agent/<crew_member>/<voyage_id_hex8>`
+     - Run: `cd /workspace/repo && git fetch origin && git checkout <base> && git checkout -b <branch_name>`
+     - Return `GitBranchInfo(name=branch_name, is_current=True)`
+
+   - `async list_branches(voyage_id, user_id) -> list[GitBranchInfo]`:
+     - Run: `cd /workspace/repo && git branch --format='%(refname:short) %(HEAD)'`
+     - Parse output: lines like `main ` or `agent/shipwright/abc12345 *`
+     - Return list of `GitBranchInfo`
+
+   - `async commit(voyage_id, user_id, message, crew_member, files) -> GitCommitInfo`:
+     - If `files` non-empty: inject files via `backend.execute()` with `ExecutionRequest.files`
+     - Run: `cd /workspace/repo && git add -A && git commit -m "<message>" --author="<crew_member> <GrandLine Crew <crew_member>@grandline.dev>"`
+     - Parse output for commit SHA: `git rev-parse --short HEAD` and `git rev-parse HEAD`
+     - Return `GitCommitInfo`
+
+   - `async push(voyage_id, user_id, branch) -> GitPushInfo`:
+     - Run: `cd /workspace/repo && git push origin <branch>`
+     - Return `GitPushInfo(branch=branch, pushed=True)`
+
+   - `async create_pr(voyage_id, user_id, title, body, head, base) -> GitPRInfo`:
+     - **Not sandboxed** — uses `httpx.AsyncClient` to call GitHub REST API
+     - Parse owner/repo from stored repo URL
+     - `POST https://api.github.com/repos/{owner}/{repo}/pulls`
+     - Headers: `Authorization: Bearer <github_token>`, `Accept: application/vnd.github+json`
+     - Body: `{"title": title, "body": body, "head": head, "base": base}`
+     - Return `GitPRInfo` from response
+
+   - `async get_log(voyage_id, user_id, branch, limit=20) -> list[GitCommitInfo]`:
+     - Run: `cd /workspace/repo && git log <branch> -<limit> --format='%H|%h|%s|%an|%aI'`
+     - Parse pipe-delimited output
+     - Return list of `GitCommitInfo`
+
+   - `async check_conflicts(voyage_id, user_id, branch, target) -> GitConflictInfo`:
+     - Run: `cd /workspace/repo && git fetch origin && git checkout <branch>`
+     - Run: `git merge --no-commit --no-ff origin/<target> 2>&1; echo "EXIT:$?"`
+     - If exit code != 0: `git diff --name-only --diff-filter=U` to list conflicting files
+     - Run: `git merge --abort` to clean up
+     - Return `GitConflictInfo`
+
+   - `async cleanup_branches(voyage_id, user_id) -> None`:
+     - List remote branches matching `agent/*/<voyage_id_hex8>`
+     - Run: `git push origin --delete <branch>` for each
+     - Destroy sandbox: `backend.destroy(sandbox_id)`
+     - Remove from `_repos`
+
+   - `async cleanup_all() -> None`:
+     - Destroy all tracked sandboxes (for app shutdown)
+     - Log but don't raise on individual failures
+     - Clear `_repos`
+
+   **Error handling**: `GitError(Exception)` in `app/services/git_service.py` — follows `ExecutionError` pattern.
+
+   **Command safety**: All user-provided values (branch names, messages, URLs) passed through `shlex.quote()` before shell execution. Branch names validated: alphanumeric, hyphens, slashes, dots only.
+
+   **GitHub token injection**: For clone/push, the repo URL is rewritten as `https://x-access-token:<token>@github.com/owner/repo.git`. The token comes from `settings.github_api_token`. Never logged or returned in responses.
+
+3. **Config settings** (`app/core/config.py`):
+
+   Add under a `# Git Integration` comment block:
+   - `git_sandbox_image: str = "bitnami/git:latest"` — container image with git installed
+   - `git_sandbox_memory_limit: str = "512m"` — repos need more memory than code execution
+   - `git_default_branch: str = "main"`
+   - `git_author_name: str = "GrandLine Crew"`
+   - `git_author_email: str = "crew@grandline.dev"`
+   - `github_api_token: str = ""` — GitHub personal access token for push/PR operations
+
+4. **Factory update** (`app/execution/factory.py`):
+
+   Add `create_git_backend(settings) -> ExecutionBackend`:
+   - Creates a `GVisorContainerBackend` with git-specific settings:
+     - Image: `settings.git_sandbox_image`
+     - Network: **enabled** (git needs to reach remotes)
+     - Memory: `settings.git_sandbox_memory_limit`
+     - Other settings (runtime, cpu quota/period) inherited from main execution settings
+   - Uses `types.SimpleNamespace` to construct a settings-like object with overrides
+
+5. **REST API** (`app/api/v1/git.py`):
+
+   Router prefix: `/voyages/{voyage_id}/git`. Tags: `["git"]`.
+   All endpoints require auth (`get_current_user`) + voyage ownership (`get_authorized_voyage`).
+
+   - `POST /clone` -> `GitRepoInfo`:
+     - Body: `GitCloneRequest`
+     - Uses `voyage.target_repo` if `body.repo_url` is None; 400 if both are None
+     - Calls `git_service.clone_repo(voyage_id, user.id, repo_url)`
+
+   - `POST /branches` -> `GitBranchInfo`:
+     - Body: `GitBranchRequest`
+     - Calls `git_service.create_branch(...)`
+
+   - `GET /branches` -> `list[GitBranchInfo]`:
+     - Calls `git_service.list_branches(voyage_id, user.id)`
+
+   - `POST /commit` -> `GitCommitInfo`:
+     - Body: `GitCommitRequest`
+     - Calls `git_service.commit(...)`
+
+   - `POST /push` -> `GitPushInfo`:
+     - Body: `GitPushRequest`
+     - Calls `git_service.push(...)`
+
+   - `POST /pr` -> `GitPRInfo`:
+     - Body: `GitPRRequest`
+     - Calls `git_service.create_pr(...)`
+
+   - `GET /log` -> `list[GitCommitInfo]`:
+     - Query params: `branch: str = "main"`, `limit: int = 20`
+     - Calls `git_service.get_log(...)`
+
+   - `POST /conflicts` -> `GitConflictInfo`:
+     - Body: `GitConflictCheckRequest`
+     - Calls `git_service.check_conflicts(...)`
+
+   - `DELETE /branches` -> 204 No Content:
+     - Calls `git_service.cleanup_branches(voyage_id, user.id)`
+
+   **Error mapping**:
+   - `GitError("REPO_NOT_CLONED")` -> 409 Conflict
+   - `GitError("REPO_ALREADY_CLONED")` -> 409 Conflict
+   - `GitError("NO_TARGET_REPO")` -> 400 Bad Request
+   - `GitError("INVALID_BRANCH_NAME")` -> 400 Bad Request
+   - `GitError("GITHUB_API_ERROR")` -> 502 Bad Gateway
+   - Other `GitError` -> 500 Internal Server Error
+
+   **Dependencies** (`app/api/v1/dependencies.py`):
+   - Add `get_git_service(request: Request) -> GitService` — reads from `request.app.state.git_service`
+
+   Wire into `app/api/v1/router.py`.
+
+6. **App lifespan** (`app/main.py`):
+
+   In the `lifespan()` context manager:
+   ```python
+   git_backend = create_git_backend(settings)
+   app.state.git_service = GitService(git_backend, settings)
+   # ... yield ...
+   await app.state.git_service.cleanup_all()
+   await git_backend.close()
+   ```
+
+## Input
+
+- Existing `Voyage` model with `target_repo: str | None` at `app/models/voyage.py`
+- Existing `CrewAction` model at `app/models/crew_action.py` — for logging git operations (future)
+- Existing `ExecutionBackend` ABC at `app/execution/backend.py`
+- Existing `GVisorContainerBackend` at `app/execution/gvisor_backend.py`
+- Existing `create_backend` factory at `app/execution/factory.py`
+- Existing `get_current_user`, `get_authorized_voyage` at `app/api/v1/dependencies.py`
+- Existing `Settings` at `app/core/config.py` — GRANDLINE_ prefix, pydantic-settings
+- `httpx>=0.27.2` already in requirements (for GitHub API calls)
+
+## Output format
+
+- Python files following existing conventions (async, type-annotated, Pydantic v2)
+- GitService as a class (needs state for per-voyage sandbox tracking)
+- Unit tests with mocked ExecutionBackend (AsyncMock) — no Docker/git daemon required for CI
+- All new files under `src/backend/app/` and `src/backend/tests/`
+
+## Constraints
+
+- Git operations (clone, branch, commit, push) run inside sandboxed containers — never on the host
+- GitHub API operations (create PR) run from the backend via `httpx` — no `gh` CLI needed
+- GitHub token never exposed in logs, responses, or error messages
+- All user-provided values passed through `shlex.quote()` before shell execution
+- Branch names validated: `^[a-zA-Z0-9/_.-]+$` — no special shell characters
+- Repo URLs must be HTTPS only — no `file://`, `git://`, or `ssh://` protocols
+- Per-voyage sandboxes — one git sandbox per voyage, not per user
+- `Voyage.target_repo` is the default repo URL; clone request can override it
+- `create_git_backend()` creates a separate backend instance with network enabled and git image
+- No new database models in v1 — sandbox tracking is in-memory (like ExecutionService)
+- Factory only adds `create_git_backend()` — existing `create_backend()` unchanged
+
+## Edge Cases
+
+- `clone_repo()` when `voyage.target_repo` is None and no URL in request -> `GitError("NO_TARGET_REPO")`
+- `clone_repo()` when repo is already cloned for this voyage -> `GitError("REPO_ALREADY_CLONED")`
+- `create_branch()` before cloning -> `GitError("REPO_NOT_CLONED")`
+- `create_branch()` with duplicate branch name -> git returns non-zero exit code, wrapped in `GitError`
+- `commit()` with no changes -> git returns "nothing to commit", wrapped in `GitError`
+- `push()` when remote rejects (force push needed) -> `GitError` with git stderr
+- `push()` with invalid GitHub token -> authentication failure captured in exit code/stderr
+- `create_pr()` when GitHub API returns error (e.g., PR already exists) -> `GitError("GITHUB_API_ERROR")`
+- `create_pr()` when head branch has no new commits vs base -> GitHub returns 422, wrapped in error
+- `check_conflicts()` with no conflicts -> `GitConflictInfo(has_conflicts=False, conflicting_files=[])`
+- `check_conflicts()` with conflicts -> populated `conflicting_files` list
+- `cleanup_branches()` when no branches to clean -> succeeds silently
+- `cleanup_branches()` when sandbox already destroyed -> handle gracefully
+- Branch name with shell injection attempt (e.g., `; rm -rf /`) -> `shlex.quote()` neutralizes, validation rejects
+- Repo URL with embedded credentials -> URL validation rejects non-HTTPS schemes
+- Sandbox killed externally between operations -> backend raises `ExecutionError`, wrapped in `GitError`
+- `cleanup_all()` during shutdown with some sandboxes already gone -> log and continue
+
+## Test Plan
+
+### tests/test_git_schemas.py
+- `test_clone_request_defaults` — repo_url defaults to None
+- `test_clone_request_rejects_non_https` — `file://` and `ssh://` URLs rejected
+- `test_clone_request_accepts_https` — valid HTTPS URL accepted
+- `test_branch_request_defaults` — base_branch defaults to "main"
+- `test_commit_request_validation` — message min/max length
+- `test_commit_request_defaults` — files default to empty dict
+- `test_pr_request_validation` — title min/max length
+- `test_conflict_check_defaults` — target_branch defaults to "main"
+- `test_response_schemas_fields` — all response schemas construct correctly
+
+### tests/test_git_service.py (mocked ExecutionBackend)
+- `test_clone_creates_sandbox_and_runs_clone` — backend.create + backend.execute called
+- `test_clone_configures_git_author` — git config commands include author name/email
+- `test_clone_injects_github_token_in_url` — URL rewritten with token
+- `test_clone_already_cloned_raises` — second clone for same voyage -> REPO_ALREADY_CLONED
+- `test_create_branch_naming_convention` — branch name matches `agent/<member>/<hex8>`
+- `test_create_branch_before_clone_raises` — REPO_NOT_CLONED error
+- `test_create_branch_runs_checkout` — correct git commands
+- `test_list_branches_parses_output` — git branch output parsed into GitBranchInfo list
+- `test_commit_stages_and_commits` — git add + git commit with correct message/author
+- `test_commit_with_files_injects_files` — files dict passed in ExecutionRequest
+- `test_push_runs_push_command` — git push origin <branch>
+- `test_create_pr_calls_github_api` — httpx POST to correct endpoint
+- `test_create_pr_parses_response` — GitPRInfo from GitHub response
+- `test_create_pr_handles_api_error` — non-200 response -> GitError
+- `test_get_log_parses_output` — git log format parsed into GitCommitInfo list
+- `test_check_conflicts_no_conflicts` — clean merge -> has_conflicts=False
+- `test_check_conflicts_with_conflicts` — conflict detected, files listed
+- `test_check_conflicts_aborts_merge` — git merge --abort called after check
+- `test_cleanup_branches_destroys_sandbox` — backend.destroy called
+- `test_cleanup_all_destroys_all` — all tracked sandboxes destroyed
+- `test_cleanup_all_continues_on_error` — one failure doesn't block others
+- `test_branch_name_validation_rejects_injection` — shell chars rejected
+
+### tests/test_git_api.py (mocked GitService)
+- `test_clone_returns_repo_info` — POST /clone returns GitRepoInfo
+- `test_clone_uses_voyage_target_repo` — repo_url=None uses voyage.target_repo
+- `test_clone_no_target_repo_400` — no URL anywhere -> 400
+- `test_create_branch_returns_info` — POST /branches returns GitBranchInfo
+- `test_list_branches_returns_list` — GET /branches returns list
+- `test_commit_returns_commit_info` — POST /commit returns GitCommitInfo
+- `test_push_returns_push_info` — POST /push returns GitPushInfo
+- `test_create_pr_returns_pr_info` — POST /pr returns GitPRInfo
+- `test_get_log_returns_entries` — GET /log returns list
+- `test_check_conflicts_returns_info` — POST /conflicts returns GitConflictInfo
+- `test_cleanup_branches_204` — DELETE /branches returns 204
+- `test_repo_not_cloned_409` — REPO_NOT_CLONED -> 409
+- `test_github_api_error_502` — GITHUB_API_ERROR -> 502
+- `test_unauthorized_401` — no token -> 401

--- a/src/backend/app/api/v1/dependencies.py
+++ b/src/backend/app/api/v1/dependencies.py
@@ -20,6 +20,7 @@ from app.models.dial_config import DialConfig
 from app.models.user import User
 from app.models.voyage import Voyage
 from app.services.execution_service import ExecutionService
+from app.services.git_service import GitService
 
 bearer_scheme = HTTPBearer(auto_error=False)
 
@@ -103,6 +104,11 @@ async def get_authorized_voyage(
 
 def get_execution_service(request: Request) -> ExecutionService:
     svc: ExecutionService = request.app.state.execution_service
+    return svc
+
+
+def get_git_service(request: Request) -> GitService:
+    svc: GitService = request.app.state.git_service
     return svc
 
 

--- a/src/backend/app/api/v1/git.py
+++ b/src/backend/app/api/v1/git.py
@@ -35,6 +35,11 @@ def _handle_git_error(exc: GitError) -> HTTPException:
             status_code=status.HTTP_409_CONFLICT,
             detail={"error": {"code": msg.split(":")[0].strip(), "message": msg}},
         )
+    if "DISALLOWED_HOST" in msg:
+        return HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={"error": {"code": "DISALLOWED_HOST", "message": msg}},
+        )
     if "NO_TARGET_REPO" in msg or "INVALID_BRANCH_NAME" in msg:
         return HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,

--- a/src/backend/app/api/v1/git.py
+++ b/src/backend/app/api/v1/git.py
@@ -1,0 +1,200 @@
+"""Git Integration REST API endpoints."""
+
+from __future__ import annotations
+
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, Response, status
+
+from app.api.v1.dependencies import get_authorized_voyage, get_current_user, get_git_service
+from app.models.user import User
+from app.models.voyage import Voyage
+from app.schemas.git import (
+    GitBranchInfo,
+    GitBranchRequest,
+    GitCloneRequest,
+    GitCommitInfo,
+    GitCommitRequest,
+    GitConflictCheckRequest,
+    GitConflictInfo,
+    GitPRInfo,
+    GitPRRequest,
+    GitPushInfo,
+    GitPushRequest,
+    GitRepoInfo,
+)
+from app.services.git_service import GitError, GitService
+
+router = APIRouter(prefix="/voyages/{voyage_id}/git", tags=["git"])
+
+
+def _handle_git_error(exc: GitError) -> HTTPException:
+    msg = str(exc)
+    if "REPO_NOT_CLONED" in msg or "REPO_ALREADY_CLONED" in msg:
+        return HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={"error": {"code": msg.split(":")[0].strip(), "message": msg}},
+        )
+    if "NO_TARGET_REPO" in msg or "INVALID_BRANCH_NAME" in msg:
+        return HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={"error": {"code": msg.split(":")[0].strip(), "message": msg}},
+        )
+    if "GITHUB_API_ERROR" in msg:
+        return HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail={"error": {"code": "GITHUB_API_ERROR", "message": msg}},
+        )
+    return HTTPException(
+        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        detail={"error": {"code": "GIT_ERROR", "message": msg}},
+    )
+
+
+@router.post("/clone", response_model=GitRepoInfo, status_code=status.HTTP_201_CREATED)
+async def clone_repo(
+    voyage_id: uuid.UUID,
+    body: GitCloneRequest,
+    user: User = Depends(get_current_user),
+    voyage: Voyage = Depends(get_authorized_voyage),
+    git_service: GitService = Depends(get_git_service),
+) -> GitRepoInfo:
+    repo_url = body.repo_url or voyage.target_repo
+    if not repo_url:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={
+                "error": {
+                    "code": "NO_TARGET_REPO",
+                    "message": "No repo URL provided and voyage has no target_repo",
+                }
+            },
+        )
+    try:
+        return await git_service.clone_repo(voyage_id, user.id, repo_url)
+    except GitError as exc:
+        raise _handle_git_error(exc) from exc
+
+
+@router.post("/branches", response_model=GitBranchInfo, status_code=status.HTTP_201_CREATED)
+async def create_branch(
+    voyage_id: uuid.UUID,
+    body: GitBranchRequest,
+    user: User = Depends(get_current_user),
+    voyage: Voyage = Depends(get_authorized_voyage),
+    git_service: GitService = Depends(get_git_service),
+) -> GitBranchInfo:
+    try:
+        return await git_service.create_branch(
+            voyage_id, user.id, body.crew_member, body.base_branch
+        )
+    except GitError as exc:
+        raise _handle_git_error(exc) from exc
+
+
+@router.get("/branches", response_model=list[GitBranchInfo])
+async def list_branches(
+    voyage_id: uuid.UUID,
+    user: User = Depends(get_current_user),
+    voyage: Voyage = Depends(get_authorized_voyage),
+    git_service: GitService = Depends(get_git_service),
+) -> list[GitBranchInfo]:
+    try:
+        return await git_service.list_branches(voyage_id, user.id)
+    except GitError as exc:
+        raise _handle_git_error(exc) from exc
+
+
+@router.post("/commit", response_model=GitCommitInfo, status_code=status.HTTP_201_CREATED)
+async def commit_changes(
+    voyage_id: uuid.UUID,
+    body: GitCommitRequest,
+    user: User = Depends(get_current_user),
+    voyage: Voyage = Depends(get_authorized_voyage),
+    git_service: GitService = Depends(get_git_service),
+) -> GitCommitInfo:
+    try:
+        return await git_service.commit(
+            voyage_id, user.id, body.message, body.crew_member, body.files or None
+        )
+    except GitError as exc:
+        raise _handle_git_error(exc) from exc
+
+
+@router.post("/push", response_model=GitPushInfo)
+async def push_branch(
+    voyage_id: uuid.UUID,
+    body: GitPushRequest,
+    user: User = Depends(get_current_user),
+    voyage: Voyage = Depends(get_authorized_voyage),
+    git_service: GitService = Depends(get_git_service),
+) -> GitPushInfo:
+    try:
+        return await git_service.push(voyage_id, user.id, body.branch)
+    except GitError as exc:
+        raise _handle_git_error(exc) from exc
+
+
+@router.post("/pr", response_model=GitPRInfo, status_code=status.HTTP_201_CREATED)
+async def create_pull_request(
+    voyage_id: uuid.UUID,
+    body: GitPRRequest,
+    user: User = Depends(get_current_user),
+    voyage: Voyage = Depends(get_authorized_voyage),
+    git_service: GitService = Depends(get_git_service),
+) -> GitPRInfo:
+    try:
+        return await git_service.create_pr(
+            voyage_id, user.id, body.title, body.body, body.head_branch, body.base_branch
+        )
+    except GitError as exc:
+        raise _handle_git_error(exc) from exc
+
+
+@router.get("/log", response_model=list[GitCommitInfo])
+async def get_log(
+    voyage_id: uuid.UUID,
+    branch: str = "main",
+    limit: int = 20,
+    user: User = Depends(get_current_user),
+    voyage: Voyage = Depends(get_authorized_voyage),
+    git_service: GitService = Depends(get_git_service),
+) -> list[GitCommitInfo]:
+    try:
+        return await git_service.get_log(voyage_id, user.id, branch, limit)
+    except GitError as exc:
+        raise _handle_git_error(exc) from exc
+
+
+@router.post("/conflicts", response_model=GitConflictInfo)
+async def check_conflicts(
+    voyage_id: uuid.UUID,
+    body: GitConflictCheckRequest,
+    user: User = Depends(get_current_user),
+    voyage: Voyage = Depends(get_authorized_voyage),
+    git_service: GitService = Depends(get_git_service),
+) -> GitConflictInfo:
+    try:
+        return await git_service.check_conflicts(
+            voyage_id, user.id, body.branch, body.target_branch
+        )
+    except GitError as exc:
+        raise _handle_git_error(exc) from exc
+
+
+@router.delete(
+    "/branches",
+    status_code=status.HTTP_204_NO_CONTENT,
+    response_class=Response,
+)
+async def cleanup_branches(
+    voyage_id: uuid.UUID,
+    user: User = Depends(get_current_user),
+    voyage: Voyage = Depends(get_authorized_voyage),
+    git_service: GitService = Depends(get_git_service),
+) -> Response:
+    try:
+        await git_service.cleanup_branches(voyage_id, user.id)
+    except GitError as exc:
+        raise _handle_git_error(exc) from exc
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/src/backend/app/api/v1/git.py
+++ b/src/backend/app/api/v1/git.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import uuid
 
-from fastapi import APIRouter, Depends, HTTPException, Response, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
 
 from app.api.v1.dependencies import get_authorized_voyage, get_current_user, get_git_service
 from app.models.user import User
@@ -155,7 +155,7 @@ async def create_pull_request(
 async def get_log(
     voyage_id: uuid.UUID,
     branch: str = "main",
-    limit: int = 20,
+    limit: int = Query(default=20, ge=1, le=100),
     user: User = Depends(get_current_user),
     voyage: Voyage = Depends(get_authorized_voyage),
     git_service: GitService = Depends(get_git_service),

--- a/src/backend/app/api/v1/router.py
+++ b/src/backend/app/api/v1/router.py
@@ -3,6 +3,7 @@ from fastapi import APIRouter
 from app.api.v1.auth import router as auth_router
 from app.api.v1.dial import router as dial_router
 from app.api.v1.execution import router as execution_router
+from app.api.v1.git import router as git_router
 from app.api.v1.health import router as health_router
 from app.api.v1.vivre_cards import router as vivre_cards_router
 
@@ -12,3 +13,4 @@ v1_router.include_router(auth_router)
 v1_router.include_router(dial_router)
 v1_router.include_router(vivre_cards_router)
 v1_router.include_router(execution_router)
+v1_router.include_router(git_router)

--- a/src/backend/app/core/config.py
+++ b/src/backend/app/core/config.py
@@ -37,6 +37,14 @@ class Settings(BaseSettings):
     execution_network_enabled: bool = False
     execution_gvisor_runtime: str = "runsc"
 
+    # Git Integration
+    git_sandbox_image: str = "bitnami/git:latest"
+    git_sandbox_memory_limit: str = "512m"
+    git_default_branch: str = "main"
+    git_author_name: str = "GrandLine Crew"
+    git_author_email: str = "crew@grandline.dev"
+    github_api_token: str = ""
+
     # CORS
     cors_origins: list[str] = ["http://localhost:3000"]
 

--- a/src/backend/app/execution/factory.py
+++ b/src/backend/app/execution/factory.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from typing import Any
 
 from app.execution.backend import ExecutionBackend
@@ -13,4 +14,22 @@ def create_backend(settings: Any) -> ExecutionBackend:
         from app.execution.gvisor_backend import GVisorContainerBackend
 
         return GVisorContainerBackend(settings)
+    raise ValueError(f"Unknown execution backend: {name}")
+
+
+def create_git_backend(settings: Any) -> ExecutionBackend:
+    """Create a backend configured for git operations (network enabled, git image)."""
+    git_settings = SimpleNamespace(
+        execution_image=settings.git_sandbox_image,
+        execution_gvisor_runtime=settings.execution_gvisor_runtime,
+        execution_memory_limit=settings.git_sandbox_memory_limit,
+        execution_cpu_quota=settings.execution_cpu_quota,
+        execution_cpu_period=settings.execution_cpu_period,
+        execution_network_enabled=True,
+    )
+    name = getattr(settings, "execution_backend", "gvisor")
+    if name == "gvisor":
+        from app.execution.gvisor_backend import GVisorContainerBackend
+
+        return GVisorContainerBackend(git_settings)
     raise ValueError(f"Unknown execution backend: {name}")

--- a/src/backend/app/main.py
+++ b/src/backend/app/main.py
@@ -9,8 +9,9 @@ from app.api.v1.router import v1_router
 from app.core.config import settings
 from app.core.middleware import DefaultDenyMiddleware
 from app.den_den_mushi.mushi import DenDenMushi
-from app.execution.factory import create_backend
+from app.execution.factory import create_backend, create_git_backend
 from app.services.execution_service import ExecutionService
+from app.services.git_service import GitService
 
 
 @asynccontextmanager
@@ -22,8 +23,13 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     backend = create_backend(settings)
     app.state.execution_service = ExecutionService(backend)
 
+    git_backend = create_git_backend(settings)
+    app.state.git_service = GitService(git_backend, settings)
+
     yield
 
+    await app.state.git_service.cleanup_all()
+    await git_backend.close()
     await app.state.execution_service.cleanup_all()
     await backend.close()
     await pool.aclose()

--- a/src/backend/app/schemas/git.py
+++ b/src/backend/app/schemas/git.py
@@ -1,0 +1,83 @@
+"""Schemas for Git Integration Service."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class GitCloneRequest(BaseModel):
+    repo_url: str | None = None
+
+    @field_validator("repo_url")
+    @classmethod
+    def validate_https_url(cls, v: str | None) -> str | None:
+        if v is not None and not v.startswith("https://"):
+            raise ValueError("Only HTTPS URLs are allowed")
+        return v
+
+
+class GitBranchRequest(BaseModel):
+    crew_member: str
+    base_branch: str = "main"
+
+
+class GitCommitRequest(BaseModel):
+    message: str = Field(..., min_length=1, max_length=500)
+    crew_member: str
+    files: dict[str, str] = Field(default_factory=dict)
+
+
+class GitPushRequest(BaseModel):
+    branch: str
+
+
+class GitPRRequest(BaseModel):
+    title: str = Field(..., min_length=1, max_length=200)
+    body: str = ""
+    head_branch: str
+    base_branch: str = "main"
+
+
+class GitConflictCheckRequest(BaseModel):
+    branch: str
+    target_branch: str = "main"
+
+
+# --- Response schemas ---
+
+
+class GitRepoInfo(BaseModel):
+    sandbox_id: str
+    repo_url: str
+    default_branch: str
+
+
+class GitBranchInfo(BaseModel):
+    name: str
+    is_current: bool
+
+
+class GitCommitInfo(BaseModel):
+    sha: str
+    short_sha: str
+    message: str
+    author: str
+    timestamp: str
+
+
+class GitPushInfo(BaseModel):
+    branch: str
+    pushed: bool
+
+
+class GitPRInfo(BaseModel):
+    number: int
+    url: str
+    title: str
+    head: str
+    base: str
+
+
+class GitConflictInfo(BaseModel):
+    has_conflicts: bool
+    conflicting_files: list[str] = Field(default_factory=list)

--- a/src/backend/app/services/git_service.py
+++ b/src/backend/app/services/git_service.py
@@ -1,0 +1,332 @@
+"""Git Integration Service — manages per-voyage git sandboxes."""
+
+from __future__ import annotations
+
+import logging
+import re
+import shlex
+import uuid
+from typing import Any
+from urllib.parse import urlparse
+
+import httpx
+
+from app.execution.backend import ExecutionBackend
+from app.schemas.execution import ExecutionRequest
+from app.schemas.git import (
+    GitBranchInfo,
+    GitCommitInfo,
+    GitConflictInfo,
+    GitPRInfo,
+    GitPushInfo,
+    GitRepoInfo,
+)
+
+logger = logging.getLogger(__name__)
+
+REPO_PATH = "/workspace/repo"
+BRANCH_NAME_RE = re.compile(r"^[a-zA-Z0-9/_.\-]+$")
+
+
+class GitError(Exception):
+    """Raised when a git operation fails."""
+
+
+def _branch_name(crew_member: str, voyage_id: uuid.UUID) -> str:
+    return f"agent/{crew_member}/{voyage_id.hex[:8]}"
+
+
+def _validate_branch_component(value: str) -> None:
+    if not BRANCH_NAME_RE.match(value):
+        raise GitError(f"INVALID_BRANCH_NAME: {value!r} contains invalid characters")
+
+
+def _inject_token(repo_url: str, token: str) -> str:
+    """Rewrite HTTPS URL to include authentication token."""
+    parsed = urlparse(repo_url)
+    return f"https://x-access-token:{token}@{parsed.hostname}{parsed.path}"
+
+
+def _parse_owner_repo(repo_url: str) -> str:
+    """Extract owner/repo from a GitHub URL."""
+    parsed = urlparse(repo_url)
+    path = parsed.path.rstrip("/").removesuffix(".git")
+    return path.lstrip("/")
+
+
+class GitService:
+    def __init__(self, backend: ExecutionBackend, settings: Any) -> None:
+        self._backend = backend
+        self._settings = settings
+        self._repos: dict[uuid.UUID, str] = {}  # voyage_id -> sandbox_id
+        self._repo_urls: dict[uuid.UUID, str] = {}  # voyage_id -> original repo URL
+
+    async def _run(self, sandbox_id: str, command: str, **kwargs: Any) -> str:
+        """Execute a command in the sandbox and return stdout."""
+        request = ExecutionRequest(command=command, **kwargs)
+        result = await self._backend.execute(sandbox_id, request)
+        if result.exit_code != 0:
+            raise GitError(f"Git command failed (exit {result.exit_code}): {result.stderr.strip()}")
+        return result.stdout
+
+    async def _run_unchecked(self, sandbox_id: str, command: str, **kwargs: Any) -> tuple[str, int]:
+        """Execute a command and return (stdout, exit_code) without raising on non-zero."""
+        request = ExecutionRequest(command=command, **kwargs)
+        result = await self._backend.execute(sandbox_id, request)
+        return result.stdout, result.exit_code
+
+    def _get_sandbox(self, voyage_id: uuid.UUID) -> str:
+        if voyage_id not in self._repos:
+            raise GitError("REPO_NOT_CLONED")
+        return self._repos[voyage_id]
+
+    async def clone_repo(
+        self, voyage_id: uuid.UUID, user_id: uuid.UUID, repo_url: str
+    ) -> GitRepoInfo:
+        if voyage_id in self._repos:
+            raise GitError("REPO_ALREADY_CLONED")
+
+        sandbox_id = await self._backend.create(user_id)
+        self._repos[voyage_id] = sandbox_id
+        self._repo_urls[voyage_id] = repo_url
+
+        token = self._settings.github_api_token
+        auth_url = _inject_token(repo_url, token) if token else repo_url
+
+        await self._run(sandbox_id, f"git clone {shlex.quote(auth_url)} {REPO_PATH}")
+        await self._run(
+            sandbox_id,
+            f"cd {REPO_PATH} && git config user.name {shlex.quote(self._settings.git_author_name)}"
+            f" && git config user.email {shlex.quote(self._settings.git_author_email)}",
+        )
+
+        return GitRepoInfo(
+            sandbox_id=sandbox_id,
+            repo_url=repo_url,
+            default_branch=self._settings.git_default_branch,
+        )
+
+    async def create_branch(
+        self,
+        voyage_id: uuid.UUID,
+        user_id: uuid.UUID,
+        crew_member: str,
+        base_branch: str,
+    ) -> GitBranchInfo:
+        _validate_branch_component(crew_member)
+        sandbox_id = self._get_sandbox(voyage_id)
+        branch = _branch_name(crew_member, voyage_id)
+
+        await self._run(
+            sandbox_id,
+            f"cd {REPO_PATH} && git fetch origin"
+            f" && git checkout {shlex.quote(base_branch)}"
+            f" && git checkout -b {shlex.quote(branch)}",
+        )
+
+        return GitBranchInfo(name=branch, is_current=True)
+
+    async def list_branches(self, voyage_id: uuid.UUID, user_id: uuid.UUID) -> list[GitBranchInfo]:
+        sandbox_id = self._get_sandbox(voyage_id)
+
+        stdout = await self._run(
+            sandbox_id,
+            f"cd {REPO_PATH} && git branch --format='%(refname:short) %(HEAD)'",
+        )
+
+        branches: list[GitBranchInfo] = []
+        for line in stdout.strip().splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            is_current = line.endswith("*")
+            name = line.rstrip(" *").strip()
+            branches.append(GitBranchInfo(name=name, is_current=is_current))
+
+        return branches
+
+    async def commit(
+        self,
+        voyage_id: uuid.UUID,
+        user_id: uuid.UUID,
+        message: str,
+        crew_member: str,
+        files: dict[str, str] | None = None,
+    ) -> GitCommitInfo:
+        sandbox_id = self._get_sandbox(voyage_id)
+
+        if files:
+            await self._backend.execute(
+                sandbox_id,
+                ExecutionRequest(
+                    command=f"cd {REPO_PATH} && echo 'files injected'",
+                    files=files,
+                    working_dir=REPO_PATH,
+                ),
+            )
+
+        author = f"{crew_member} <{crew_member}@grandline.dev>"
+        await self._run(
+            sandbox_id,
+            f"cd {REPO_PATH} && git add -A"
+            f" && git commit -m {shlex.quote(message)} --author={shlex.quote(author)}",
+        )
+
+        stdout = await self._run(
+            sandbox_id,
+            f"cd {REPO_PATH} && git rev-parse HEAD",
+        )
+        sha = stdout.strip()
+        short_sha = sha[:7]
+
+        return GitCommitInfo(
+            sha=sha,
+            short_sha=short_sha,
+            message=message,
+            author=crew_member,
+            timestamp="",
+        )
+
+    async def push(self, voyage_id: uuid.UUID, user_id: uuid.UUID, branch: str) -> GitPushInfo:
+        sandbox_id = self._get_sandbox(voyage_id)
+
+        await self._run(
+            sandbox_id,
+            f"cd {REPO_PATH} && git push origin {shlex.quote(branch)}",
+        )
+
+        return GitPushInfo(branch=branch, pushed=True)
+
+    async def create_pr(
+        self,
+        voyage_id: uuid.UUID,
+        user_id: uuid.UUID,
+        title: str,
+        body: str,
+        head: str,
+        base: str,
+    ) -> GitPRInfo:
+        repo_url = self._repo_urls.get(voyage_id)
+        if not repo_url:
+            raise GitError("REPO_NOT_CLONED")
+
+        owner_repo = _parse_owner_repo(repo_url)
+        token = self._settings.github_api_token
+
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(
+                f"https://api.github.com/repos/{owner_repo}/pulls",
+                headers={
+                    "Authorization": f"Bearer {token}",
+                    "Accept": "application/vnd.github+json",
+                },
+                json={
+                    "title": title,
+                    "body": body,
+                    "head": head,
+                    "base": base,
+                },
+            )
+
+        if resp.status_code not in (200, 201):
+            raise GitError(f"GITHUB_API_ERROR: {resp.status_code} {resp.text}")
+
+        data = resp.json()
+        return GitPRInfo(
+            number=data["number"],
+            url=data["html_url"],
+            title=data["title"],
+            head=data["head"]["ref"],
+            base=data["base"]["ref"],
+        )
+
+    async def get_log(
+        self,
+        voyage_id: uuid.UUID,
+        user_id: uuid.UUID,
+        branch: str,
+        limit: int = 20,
+    ) -> list[GitCommitInfo]:
+        sandbox_id = self._get_sandbox(voyage_id)
+
+        stdout = await self._run(
+            sandbox_id,
+            f"cd {REPO_PATH} && git log {shlex.quote(branch)}"
+            f" -{limit} --format='%H|%h|%s|%an|%aI'",
+        )
+
+        entries: list[GitCommitInfo] = []
+        for line in stdout.strip().splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            parts = line.split("|", 4)
+            if len(parts) < 5:
+                continue
+            entries.append(
+                GitCommitInfo(
+                    sha=parts[0],
+                    short_sha=parts[1],
+                    message=parts[2],
+                    author=parts[3],
+                    timestamp=parts[4],
+                )
+            )
+
+        return entries
+
+    async def check_conflicts(
+        self,
+        voyage_id: uuid.UUID,
+        user_id: uuid.UUID,
+        branch: str,
+        target: str,
+    ) -> GitConflictInfo:
+        sandbox_id = self._get_sandbox(voyage_id)
+
+        await self._run(sandbox_id, f"cd {REPO_PATH} && git fetch origin")
+        await self._run(sandbox_id, f"cd {REPO_PATH} && git checkout {shlex.quote(branch)}")
+
+        merge_out, exit_code = await self._run_unchecked(
+            sandbox_id,
+            f"cd {REPO_PATH}"
+            f" && git merge --no-commit --no-ff origin/{shlex.quote(target)} 2>&1"
+            f'; echo "EXIT:$?"',
+        )
+
+        has_conflicts = "EXIT:0" not in merge_out
+        conflicting_files: list[str] = []
+
+        if has_conflicts:
+            diff_out = await self._run(
+                sandbox_id,
+                f"cd {REPO_PATH} && git diff --name-only --diff-filter=U",
+            )
+            conflicting_files = [f.strip() for f in diff_out.strip().splitlines() if f.strip()]
+
+        # Always abort the merge attempt
+        await self._run_unchecked(sandbox_id, f"cd {REPO_PATH} && git merge --abort")
+
+        return GitConflictInfo(
+            has_conflicts=has_conflicts,
+            conflicting_files=conflicting_files,
+        )
+
+    async def cleanup_branches(self, voyage_id: uuid.UUID, user_id: uuid.UUID) -> None:
+        sandbox_id = self._repos.pop(voyage_id, None)
+        self._repo_urls.pop(voyage_id, None)
+        if sandbox_id:
+            await self._backend.destroy(sandbox_id)
+
+    async def cleanup_all(self) -> None:
+        for voyage_id, sandbox_id in list(self._repos.items()):
+            try:
+                await self._backend.destroy(sandbox_id)
+            except Exception:
+                logger.warning(
+                    "Failed to destroy git sandbox %s for voyage %s",
+                    sandbox_id,
+                    voyage_id,
+                )
+        self._repos.clear()
+        self._repo_urls.clear()

--- a/src/backend/app/services/git_service.py
+++ b/src/backend/app/services/git_service.py
@@ -26,6 +26,7 @@ logger = logging.getLogger(__name__)
 
 REPO_PATH = "/workspace/repo"
 BRANCH_NAME_RE = re.compile(r"^[a-zA-Z0-9/_.\-]+$")
+ALLOWED_GIT_HOSTS = frozenset({"github.com", "gitlab.com", "bitbucket.org"})
 
 
 class GitError(Exception):
@@ -39,6 +40,14 @@ def _branch_name(crew_member: str, voyage_id: uuid.UUID) -> str:
 def _validate_branch_component(value: str) -> None:
     if not BRANCH_NAME_RE.match(value):
         raise GitError(f"INVALID_BRANCH_NAME: {value!r} contains invalid characters")
+
+
+def _validate_repo_host(repo_url: str, allowed_hosts: frozenset[str]) -> None:
+    """Reject repo URLs whose host is not in the allowlist."""
+    parsed = urlparse(repo_url)
+    hostname = (parsed.hostname or "").lower()
+    if hostname not in allowed_hosts:
+        raise GitError(f"DISALLOWED_HOST: {hostname!r} is not an allowed git host")
 
 
 def _inject_token(repo_url: str, token: str) -> str:
@@ -88,6 +97,10 @@ class GitService:
         if voyage_id in self._repos:
             raise GitError("REPO_ALREADY_CLONED")
 
+        allowed = getattr(self._settings, "git_allowed_hosts", None)
+        allowed_hosts = frozenset(allowed) if allowed else ALLOWED_GIT_HOSTS
+        _validate_repo_host(repo_url, allowed_hosts)
+
         sandbox_id = await self._backend.create(user_id)
 
         try:
@@ -133,8 +146,8 @@ class GitService:
         await self._run(
             sandbox_id,
             f"cd {REPO_PATH} && git fetch origin"
-            f" && git checkout {shlex.quote(base_branch)}"
-            f" && git checkout -b {shlex.quote(branch)}",
+            f" && git checkout -b {shlex.quote(branch)}"
+            f" origin/{shlex.quote(base_branch)}",
         )
 
         return GitBranchInfo(name=branch, is_current=True)

--- a/src/backend/app/services/git_service.py
+++ b/src/backend/app/services/git_service.py
@@ -44,7 +44,9 @@ def _validate_branch_component(value: str) -> None:
 def _inject_token(repo_url: str, token: str) -> str:
     """Rewrite HTTPS URL to include authentication token."""
     parsed = urlparse(repo_url)
-    return f"https://x-access-token:{token}@{parsed.hostname}{parsed.path}"
+    host = parsed.hostname or ""
+    port = f":{parsed.port}" if parsed.port else ""
+    return f"https://x-access-token:{token}@{host}{port}{parsed.path}"
 
 
 def _parse_owner_repo(repo_url: str) -> str:
@@ -87,18 +89,29 @@ class GitService:
             raise GitError("REPO_ALREADY_CLONED")
 
         sandbox_id = await self._backend.create(user_id)
+
+        try:
+            token = self._settings.github_api_token
+            auth_url = _inject_token(repo_url, token) if token else repo_url
+
+            await self._run(sandbox_id, f"git clone {shlex.quote(auth_url)} {REPO_PATH}")
+            author_name = shlex.quote(self._settings.git_author_name)
+            author_email = shlex.quote(self._settings.git_author_email)
+            await self._run(
+                sandbox_id,
+                f"cd {REPO_PATH} && git config user.name {author_name}"
+                f" && git config user.email {author_email}",
+            )
+        except (GitError, Exception):
+            # Rollback: destroy sandbox so retry doesn't hit REPO_ALREADY_CLONED
+            try:
+                await self._backend.destroy(sandbox_id)
+            except Exception:
+                logger.warning("Failed to destroy sandbox %s during clone rollback", sandbox_id)
+            raise
+
         self._repos[voyage_id] = sandbox_id
         self._repo_urls[voyage_id] = repo_url
-
-        token = self._settings.github_api_token
-        auth_url = _inject_token(repo_url, token) if token else repo_url
-
-        await self._run(sandbox_id, f"git clone {shlex.quote(auth_url)} {REPO_PATH}")
-        await self._run(
-            sandbox_id,
-            f"cd {REPO_PATH} && git config user.name {shlex.quote(self._settings.git_author_name)}"
-            f" && git config user.email {shlex.quote(self._settings.git_author_email)}",
-        )
 
         return GitRepoInfo(
             sandbox_id=sandbox_id,
@@ -156,12 +169,13 @@ class GitService:
         sandbox_id = self._get_sandbox(voyage_id)
 
         if files:
+            # put_archive targets /workspace, so prefix paths with repo/
+            prefixed = {f"repo/{path}": content for path, content in files.items()}
             await self._backend.execute(
                 sandbox_id,
                 ExecutionRequest(
                     command=f"cd {REPO_PATH} && echo 'files injected'",
-                    files=files,
-                    working_dir=REPO_PATH,
+                    files=prefixed,
                 ),
             )
 
@@ -174,20 +188,23 @@ class GitService:
 
         stdout = await self._run(
             sandbox_id,
-            f"cd {REPO_PATH} && git rev-parse HEAD",
+            f"cd {REPO_PATH} && git log -1 --format='%H %h %aI'",
         )
-        sha = stdout.strip()
-        short_sha = sha[:7]
+        parts = stdout.strip().split(" ", 2)
+        sha = parts[0]
+        short_sha = parts[1] if len(parts) > 1 else sha[:7]
+        timestamp = parts[2] if len(parts) > 2 else ""
 
         return GitCommitInfo(
             sha=sha,
             short_sha=short_sha,
             message=message,
             author=crew_member,
-            timestamp="",
+            timestamp=timestamp,
         )
 
     async def push(self, voyage_id: uuid.UUID, user_id: uuid.UUID, branch: str) -> GitPushInfo:
+        _validate_branch_component(branch)
         sandbox_id = self._get_sandbox(voyage_id)
 
         await self._run(
@@ -247,12 +264,13 @@ class GitService:
         branch: str,
         limit: int = 20,
     ) -> list[GitCommitInfo]:
+        _validate_branch_component(branch)
         sandbox_id = self._get_sandbox(voyage_id)
 
         stdout = await self._run(
             sandbox_id,
             f"cd {REPO_PATH} && git log {shlex.quote(branch)}"
-            f" -{limit} --format='%H|%h|%s|%an|%aI'",
+            f" -{limit} --format='%H%x00%h%x00%s%x00%an%x00%aI'",
         )
 
         entries: list[GitCommitInfo] = []
@@ -260,7 +278,7 @@ class GitService:
             line = line.strip()
             if not line:
                 continue
-            parts = line.split("|", 4)
+            parts = line.split("\x00", 4)
             if len(parts) < 5:
                 continue
             entries.append(
@@ -282,6 +300,8 @@ class GitService:
         branch: str,
         target: str,
     ) -> GitConflictInfo:
+        _validate_branch_component(branch)
+        _validate_branch_component(target)
         sandbox_id = self._get_sandbox(voyage_id)
 
         await self._run(sandbox_id, f"cd {REPO_PATH} && git fetch origin")

--- a/src/backend/tests/test_execution_factory.py
+++ b/src/backend/tests/test_execution_factory.py
@@ -27,3 +27,33 @@ class TestCreateBackend:
 
         with pytest.raises(ValueError, match="Unknown execution backend"):
             create_backend(settings)
+
+
+class TestCreateGitBackend:
+    def test_creates_backend_with_network_enabled(self) -> None:
+        from app.execution.factory import create_git_backend
+        from app.execution.gvisor_backend import GVisorContainerBackend
+
+        settings = MagicMock()
+        settings.execution_backend = "gvisor"
+        settings.git_sandbox_image = "bitnami/git:latest"
+        settings.execution_gvisor_runtime = "runsc"
+        settings.git_sandbox_memory_limit = "512m"
+        settings.execution_cpu_quota = 100000
+        settings.execution_cpu_period = 100000
+
+        with patch("app.execution.gvisor_backend.aiodocker.Docker"):
+            backend = create_git_backend(settings)
+
+        assert isinstance(backend, GVisorContainerBackend)
+        assert backend._settings.execution_network_enabled is True
+        assert backend._settings.execution_image == "bitnami/git:latest"
+
+    def test_raises_for_unknown_backend(self) -> None:
+        from app.execution.factory import create_git_backend
+
+        settings = MagicMock()
+        settings.execution_backend = "unknown"
+
+        with pytest.raises(ValueError, match="Unknown execution backend"):
+            create_git_backend(settings)

--- a/src/backend/tests/test_git_api.py
+++ b/src/backend/tests/test_git_api.py
@@ -1,0 +1,266 @@
+"""Tests for Git Integration REST API endpoints."""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+from app.schemas.git import (
+    GitBranchInfo,
+    GitCommitInfo,
+    GitConflictInfo,
+    GitPRInfo,
+    GitPushInfo,
+    GitRepoInfo,
+)
+from app.services.git_service import GitError
+
+VOYAGE_ID = uuid.uuid4()
+USER_ID = uuid.uuid4()
+
+
+def _mock_user() -> MagicMock:
+    user = MagicMock()
+    user.id = USER_ID
+    return user
+
+
+def _mock_voyage(target_repo: str | None = "https://github.com/owner/repo.git") -> MagicMock:
+    voyage = MagicMock()
+    voyage.id = VOYAGE_ID
+    voyage.target_repo = target_repo
+    return voyage
+
+
+def _mock_git_service() -> AsyncMock:
+    svc = AsyncMock()
+    svc.clone_repo = AsyncMock(
+        return_value=GitRepoInfo(
+            sandbox_id="sandbox-git-1",
+            repo_url="https://github.com/owner/repo.git",
+            default_branch="main",
+        )
+    )
+    svc.create_branch = AsyncMock(
+        return_value=GitBranchInfo(name="agent/shipwright/abc12345", is_current=True)
+    )
+    svc.list_branches = AsyncMock(
+        return_value=[
+            GitBranchInfo(name="main", is_current=False),
+            GitBranchInfo(name="agent/shipwright/abc12345", is_current=True),
+        ]
+    )
+    svc.commit = AsyncMock(
+        return_value=GitCommitInfo(
+            sha="abc123def456",
+            short_sha="abc123d",
+            message="feat: add login",
+            author="shipwright",
+            timestamp="2026-04-12T10:00:00+00:00",
+        )
+    )
+    svc.push = AsyncMock(return_value=GitPushInfo(branch="agent/shipwright/abc12345", pushed=True))
+    svc.create_pr = AsyncMock(
+        return_value=GitPRInfo(
+            number=42,
+            url="https://github.com/owner/repo/pull/42",
+            title="Add login",
+            head="agent/shipwright/abc12345",
+            base="main",
+        )
+    )
+    svc.get_log = AsyncMock(
+        return_value=[
+            GitCommitInfo(
+                sha="abc123def456",
+                short_sha="abc123d",
+                message="feat: add login",
+                author="shipwright",
+                timestamp="2026-04-12T10:00:00+00:00",
+            )
+        ]
+    )
+    svc.check_conflicts = AsyncMock(
+        return_value=GitConflictInfo(has_conflicts=False, conflicting_files=[])
+    )
+    svc.cleanup_branches = AsyncMock()
+    return svc
+
+
+class TestCloneEndpoint:
+    @pytest.mark.asyncio
+    async def test_clone_returns_repo_info(self) -> None:
+        from app.api.v1.git import clone_repo
+        from app.schemas.git import GitCloneRequest
+
+        svc = _mock_git_service()
+        body = GitCloneRequest(repo_url="https://github.com/owner/repo.git")
+        result = await clone_repo(VOYAGE_ID, body, _mock_user(), _mock_voyage(), svc)
+
+        assert result.sandbox_id == "sandbox-git-1"
+        svc.clone_repo.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_clone_uses_voyage_target_repo(self) -> None:
+        from app.api.v1.git import clone_repo
+        from app.schemas.git import GitCloneRequest
+
+        svc = _mock_git_service()
+        body = GitCloneRequest()  # repo_url=None
+        voyage = _mock_voyage(target_repo="https://github.com/owner/other.git")
+        await clone_repo(VOYAGE_ID, body, _mock_user(), voyage, svc)
+
+        call_args = svc.clone_repo.call_args
+        assert call_args.args[2] == "https://github.com/owner/other.git"
+
+    @pytest.mark.asyncio
+    async def test_clone_no_target_repo_400(self) -> None:
+        from app.api.v1.git import clone_repo
+        from app.schemas.git import GitCloneRequest
+
+        svc = _mock_git_service()
+        body = GitCloneRequest()  # repo_url=None
+        voyage = _mock_voyage(target_repo=None)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await clone_repo(VOYAGE_ID, body, _mock_user(), voyage, svc)
+
+        assert exc_info.value.status_code == 400
+
+
+class TestBranchEndpoints:
+    @pytest.mark.asyncio
+    async def test_create_branch_returns_info(self) -> None:
+        from app.api.v1.git import create_branch
+        from app.schemas.git import GitBranchRequest
+
+        svc = _mock_git_service()
+        body = GitBranchRequest(crew_member="shipwright")
+        result = await create_branch(VOYAGE_ID, body, _mock_user(), _mock_voyage(), svc)
+
+        assert result.name == "agent/shipwright/abc12345"
+        assert result.is_current is True
+
+    @pytest.mark.asyncio
+    async def test_list_branches_returns_list(self) -> None:
+        from app.api.v1.git import list_branches
+
+        svc = _mock_git_service()
+        result = await list_branches(VOYAGE_ID, _mock_user(), _mock_voyage(), svc)
+
+        assert len(result) == 2
+
+
+class TestCommitEndpoint:
+    @pytest.mark.asyncio
+    async def test_commit_returns_info(self) -> None:
+        from app.api.v1.git import commit_changes
+        from app.schemas.git import GitCommitRequest
+
+        svc = _mock_git_service()
+        body = GitCommitRequest(message="feat: add login", crew_member="shipwright")
+        result = await commit_changes(VOYAGE_ID, body, _mock_user(), _mock_voyage(), svc)
+
+        assert result.sha == "abc123def456"
+
+
+class TestPushEndpoint:
+    @pytest.mark.asyncio
+    async def test_push_returns_info(self) -> None:
+        from app.api.v1.git import push_branch
+        from app.schemas.git import GitPushRequest
+
+        svc = _mock_git_service()
+        body = GitPushRequest(branch="agent/shipwright/abc12345")
+        result = await push_branch(VOYAGE_ID, body, _mock_user(), _mock_voyage(), svc)
+
+        assert result.pushed is True
+
+
+class TestPREndpoint:
+    @pytest.mark.asyncio
+    async def test_create_pr_returns_info(self) -> None:
+        from app.api.v1.git import create_pull_request
+        from app.schemas.git import GitPRRequest
+
+        svc = _mock_git_service()
+        body = GitPRRequest(title="Add login", head_branch="agent/shipwright/abc12345")
+        result = await create_pull_request(VOYAGE_ID, body, _mock_user(), _mock_voyage(), svc)
+
+        assert result.number == 42
+
+
+class TestLogEndpoint:
+    @pytest.mark.asyncio
+    async def test_get_log_returns_entries(self) -> None:
+        from app.api.v1.git import get_log
+
+        svc = _mock_git_service()
+        result = await get_log(VOYAGE_ID, "main", 20, _mock_user(), _mock_voyage(), svc)
+
+        assert len(result) == 1
+        assert result[0].sha == "abc123def456"
+
+
+class TestConflictsEndpoint:
+    @pytest.mark.asyncio
+    async def test_check_conflicts_returns_info(self) -> None:
+        from app.api.v1.git import check_conflicts
+        from app.schemas.git import GitConflictCheckRequest
+
+        svc = _mock_git_service()
+        body = GitConflictCheckRequest(branch="feat/test")
+        result = await check_conflicts(VOYAGE_ID, body, _mock_user(), _mock_voyage(), svc)
+
+        assert result.has_conflicts is False
+
+
+class TestCleanupEndpoint:
+    @pytest.mark.asyncio
+    async def test_cleanup_branches_204(self) -> None:
+        from app.api.v1.git import cleanup_branches
+
+        svc = _mock_git_service()
+        await cleanup_branches(VOYAGE_ID, _mock_user(), _mock_voyage(), svc)
+
+        svc.cleanup_branches.assert_awaited_once_with(VOYAGE_ID, USER_ID)
+
+
+class TestErrorMapping:
+    @pytest.mark.asyncio
+    async def test_repo_not_cloned_409(self) -> None:
+        from app.api.v1.git import list_branches
+
+        svc = _mock_git_service()
+        svc.list_branches.side_effect = GitError("REPO_NOT_CLONED")
+
+        with pytest.raises(HTTPException) as exc_info:
+            await list_branches(VOYAGE_ID, _mock_user(), _mock_voyage(), svc)
+
+        assert exc_info.value.status_code == 409
+
+    @pytest.mark.asyncio
+    async def test_github_api_error_502(self) -> None:
+        from app.api.v1.git import create_pull_request
+        from app.schemas.git import GitPRRequest
+
+        svc = _mock_git_service()
+        svc.create_pr.side_effect = GitError("GITHUB_API_ERROR: 422 Validation Failed")
+
+        body = GitPRRequest(title="Add login", head_branch="feat/test")
+        with pytest.raises(HTTPException) as exc_info:
+            await create_pull_request(VOYAGE_ID, body, _mock_user(), _mock_voyage(), svc)
+
+        assert exc_info.value.status_code == 502
+
+    @pytest.mark.asyncio
+    async def test_unauthorized_401(self) -> None:
+        from app.api.v1.dependencies import get_current_user
+
+        with pytest.raises(HTTPException) as exc_info:
+            await get_current_user(credentials=None, session=AsyncMock())
+
+        assert exc_info.value.status_code == 401

--- a/src/backend/tests/test_git_api.py
+++ b/src/backend/tests/test_git_api.py
@@ -257,6 +257,22 @@ class TestErrorMapping:
         assert exc_info.value.status_code == 502
 
     @pytest.mark.asyncio
+    async def test_disallowed_host_400(self) -> None:
+        from app.api.v1.git import clone_repo
+        from app.schemas.git import GitCloneRequest
+
+        svc = _mock_git_service()
+        svc.clone_repo.side_effect = GitError(
+            "DISALLOWED_HOST: 'evil.com' is not an allowed git host"
+        )
+        body = GitCloneRequest(repo_url="https://evil.com/repo.git")
+
+        with pytest.raises(HTTPException) as exc_info:
+            await clone_repo(VOYAGE_ID, body, _mock_user(), _mock_voyage(), svc)
+
+        assert exc_info.value.status_code == 400
+
+    @pytest.mark.asyncio
     async def test_unauthorized_401(self) -> None:
         from app.api.v1.dependencies import get_current_user
 

--- a/src/backend/tests/test_git_schemas.py
+++ b/src/backend/tests/test_git_schemas.py
@@ -1,0 +1,140 @@
+"""Tests for Git Integration schemas."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from app.schemas.git import (
+    GitBranchInfo,
+    GitBranchRequest,
+    GitCloneRequest,
+    GitCommitInfo,
+    GitCommitRequest,
+    GitConflictCheckRequest,
+    GitConflictInfo,
+    GitPRInfo,
+    GitPRRequest,
+    GitPushInfo,
+    GitPushRequest,
+    GitRepoInfo,
+)
+
+
+class TestGitCloneRequest:
+    def test_defaults(self) -> None:
+        req = GitCloneRequest()
+        assert req.repo_url is None
+
+    def test_rejects_non_https(self) -> None:
+        with pytest.raises(ValidationError):
+            GitCloneRequest(repo_url="file:///tmp/repo")
+
+    def test_rejects_ssh(self) -> None:
+        with pytest.raises(ValidationError):
+            GitCloneRequest(repo_url="ssh://git@github.com/owner/repo.git")
+
+    def test_rejects_git_protocol(self) -> None:
+        with pytest.raises(ValidationError):
+            GitCloneRequest(repo_url="git://github.com/owner/repo.git")
+
+    def test_accepts_https(self) -> None:
+        req = GitCloneRequest(repo_url="https://github.com/owner/repo.git")
+        assert req.repo_url == "https://github.com/owner/repo.git"
+
+
+class TestGitBranchRequest:
+    def test_defaults(self) -> None:
+        req = GitBranchRequest(crew_member="shipwright")
+        assert req.base_branch == "main"
+        assert req.crew_member == "shipwright"
+
+
+class TestGitCommitRequest:
+    def test_defaults(self) -> None:
+        req = GitCommitRequest(message="feat: add login", crew_member="shipwright")
+        assert req.files == {}
+
+    def test_message_min_length(self) -> None:
+        with pytest.raises(ValidationError):
+            GitCommitRequest(message="", crew_member="shipwright")
+
+    def test_message_max_length(self) -> None:
+        with pytest.raises(ValidationError):
+            GitCommitRequest(message="x" * 501, crew_member="shipwright")
+
+
+class TestGitPRRequest:
+    def test_title_min_length(self) -> None:
+        with pytest.raises(ValidationError):
+            GitPRRequest(title="", head_branch="feat/test")
+
+    def test_title_max_length(self) -> None:
+        with pytest.raises(ValidationError):
+            GitPRRequest(title="x" * 201, head_branch="feat/test")
+
+    def test_defaults(self) -> None:
+        req = GitPRRequest(title="Add login", head_branch="agent/shipwright/abc12345")
+        assert req.body == ""
+        assert req.base_branch == "main"
+
+
+class TestGitPushRequest:
+    def test_fields(self) -> None:
+        req = GitPushRequest(branch="agent/shipwright/abc12345")
+        assert req.branch == "agent/shipwright/abc12345"
+
+
+class TestGitConflictCheckRequest:
+    def test_defaults(self) -> None:
+        req = GitConflictCheckRequest(branch="agent/shipwright/abc12345")
+        assert req.target_branch == "main"
+
+
+class TestResponseSchemas:
+    def test_repo_info(self) -> None:
+        info = GitRepoInfo(
+            sandbox_id="abc123",
+            repo_url="https://github.com/owner/repo.git",
+            default_branch="main",
+        )
+        assert info.sandbox_id == "abc123"
+
+    def test_branch_info(self) -> None:
+        info = GitBranchInfo(name="agent/shipwright/abc12345", is_current=True)
+        assert info.is_current is True
+
+    def test_commit_info(self) -> None:
+        info = GitCommitInfo(
+            sha="abc123def456",
+            short_sha="abc123d",
+            message="feat: add login",
+            author="shipwright",
+            timestamp="2026-04-12T10:00:00+00:00",
+        )
+        assert info.sha == "abc123def456"
+
+    def test_push_info(self) -> None:
+        info = GitPushInfo(branch="main", pushed=True)
+        assert info.pushed is True
+
+    def test_pr_info(self) -> None:
+        info = GitPRInfo(
+            number=42,
+            url="https://github.com/owner/repo/pull/42",
+            title="Add login",
+            head="agent/shipwright/abc12345",
+            base="main",
+        )
+        assert info.number == 42
+
+    def test_conflict_info_no_conflicts(self) -> None:
+        info = GitConflictInfo(has_conflicts=False)
+        assert info.conflicting_files == []
+
+    def test_conflict_info_with_conflicts(self) -> None:
+        info = GitConflictInfo(
+            has_conflicts=True,
+            conflicting_files=["src/main.py", "README.md"],
+        )
+        assert len(info.conflicting_files) == 2

--- a/src/backend/tests/test_git_service.py
+++ b/src/backend/tests/test_git_service.py
@@ -1,0 +1,386 @@
+"""Tests for GitService (mocked ExecutionBackend)."""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.schemas.execution import ExecutionResult
+from app.services.git_service import GitError, GitService
+
+VOYAGE_ID = uuid.uuid4()
+USER_ID = uuid.uuid4()
+VOYAGE_HEX8 = VOYAGE_ID.hex[:8]
+REPO_URL = "https://github.com/owner/repo.git"
+
+
+def _exec_result(
+    stdout: str = "", stderr: str = "", exit_code: int = 0, sandbox_id: str = "sandbox-git-1"
+) -> ExecutionResult:
+    return ExecutionResult(
+        exit_code=exit_code,
+        stdout=stdout,
+        stderr=stderr,
+        timed_out=False,
+        duration_seconds=0.1,
+        sandbox_id=sandbox_id,
+    )
+
+
+@pytest.fixture
+def mock_backend() -> AsyncMock:
+    backend = AsyncMock()
+    backend.create = AsyncMock(return_value="sandbox-git-1")
+    backend.execute = AsyncMock(return_value=_exec_result())
+    backend.destroy = AsyncMock()
+    backend.status = AsyncMock()
+    return backend
+
+
+@pytest.fixture
+def mock_settings() -> MagicMock:
+    s = MagicMock()
+    s.github_api_token = "ghp_test_token_123"
+    s.git_default_branch = "main"
+    s.git_author_name = "GrandLine Crew"
+    s.git_author_email = "crew@grandline.dev"
+    return s
+
+
+@pytest.fixture
+def service(mock_backend: AsyncMock, mock_settings: MagicMock) -> GitService:
+    return GitService(mock_backend, mock_settings)
+
+
+class TestCloneRepo:
+    @pytest.mark.asyncio
+    async def test_clone_creates_sandbox_and_runs_clone(
+        self, service: GitService, mock_backend: AsyncMock
+    ) -> None:
+        result = await service.clone_repo(VOYAGE_ID, USER_ID, REPO_URL)
+
+        mock_backend.create.assert_awaited_once_with(USER_ID)
+        assert mock_backend.execute.await_count >= 1
+        assert result.sandbox_id == "sandbox-git-1"
+        assert result.repo_url == REPO_URL
+
+    @pytest.mark.asyncio
+    async def test_clone_configures_git_author(
+        self, service: GitService, mock_backend: AsyncMock
+    ) -> None:
+        await service.clone_repo(VOYAGE_ID, USER_ID, REPO_URL)
+
+        commands = [call.args[1].command for call in mock_backend.execute.call_args_list]
+        config_cmds = " ".join(commands)
+        assert "user.name" in config_cmds
+        assert "user.email" in config_cmds
+
+    @pytest.mark.asyncio
+    async def test_clone_injects_github_token_in_url(
+        self, service: GitService, mock_backend: AsyncMock
+    ) -> None:
+        await service.clone_repo(VOYAGE_ID, USER_ID, REPO_URL)
+
+        clone_call = mock_backend.execute.call_args_list[0]
+        clone_cmd = clone_call.args[1].command
+        assert "ghp_test_token_123" in clone_cmd
+        assert "x-access-token" in clone_cmd
+
+    @pytest.mark.asyncio
+    async def test_clone_already_cloned_raises(
+        self, service: GitService, mock_backend: AsyncMock
+    ) -> None:
+        await service.clone_repo(VOYAGE_ID, USER_ID, REPO_URL)
+
+        with pytest.raises(GitError, match="REPO_ALREADY_CLONED"):
+            await service.clone_repo(VOYAGE_ID, USER_ID, REPO_URL)
+
+
+class TestCreateBranch:
+    @pytest.mark.asyncio
+    async def test_naming_convention(self, service: GitService, mock_backend: AsyncMock) -> None:
+        await service.clone_repo(VOYAGE_ID, USER_ID, REPO_URL)
+
+        result = await service.create_branch(VOYAGE_ID, USER_ID, "shipwright", "main")
+
+        expected_name = f"agent/shipwright/{VOYAGE_HEX8}"
+        assert result.name == expected_name
+        assert result.is_current is True
+
+    @pytest.mark.asyncio
+    async def test_before_clone_raises(self, service: GitService) -> None:
+        with pytest.raises(GitError, match="REPO_NOT_CLONED"):
+            await service.create_branch(VOYAGE_ID, USER_ID, "shipwright", "main")
+
+    @pytest.mark.asyncio
+    async def test_runs_checkout(self, service: GitService, mock_backend: AsyncMock) -> None:
+        await service.clone_repo(VOYAGE_ID, USER_ID, REPO_URL)
+        mock_backend.execute.reset_mock()
+
+        await service.create_branch(VOYAGE_ID, USER_ID, "shipwright", "main")
+
+        cmd = mock_backend.execute.call_args.args[1].command
+        assert "checkout -b" in cmd
+        assert f"agent/shipwright/{VOYAGE_HEX8}" in cmd
+
+
+class TestListBranches:
+    @pytest.mark.asyncio
+    async def test_parses_output(self, service: GitService, mock_backend: AsyncMock) -> None:
+        await service.clone_repo(VOYAGE_ID, USER_ID, REPO_URL)
+        mock_backend.execute.reset_mock()
+        mock_backend.execute.return_value = _exec_result(
+            stdout="main \nagent/shipwright/abc12345 *\n"
+        )
+
+        branches = await service.list_branches(VOYAGE_ID, USER_ID)
+
+        assert len(branches) == 2
+        assert branches[0].name == "main"
+        assert branches[0].is_current is False
+        assert branches[1].name == "agent/shipwright/abc12345"
+        assert branches[1].is_current is True
+
+
+class TestCommit:
+    @pytest.mark.asyncio
+    async def test_stages_and_commits(self, service: GitService, mock_backend: AsyncMock) -> None:
+        await service.clone_repo(VOYAGE_ID, USER_ID, REPO_URL)
+        mock_backend.execute.reset_mock()
+        mock_backend.execute.return_value = _exec_result(stdout="abc123def456\n")
+
+        await service.commit(VOYAGE_ID, USER_ID, "feat: add login", "shipwright")
+
+        commands = [call.args[1].command for call in mock_backend.execute.call_args_list]
+        full_cmds = " ".join(commands)
+        assert "git add" in full_cmds
+        assert "git commit" in full_cmds
+        assert "feat: add login" in full_cmds
+
+    @pytest.mark.asyncio
+    async def test_with_files_injects_files(
+        self, service: GitService, mock_backend: AsyncMock
+    ) -> None:
+        await service.clone_repo(VOYAGE_ID, USER_ID, REPO_URL)
+        mock_backend.execute.reset_mock()
+        mock_backend.execute.return_value = _exec_result(stdout="abc123def456\n")
+
+        files = {"main.py": "print('hello')"}
+        await service.commit(VOYAGE_ID, USER_ID, "feat: add main", "shipwright", files)
+
+        # The files should be passed in the ExecutionRequest
+        file_inject_call = mock_backend.execute.call_args_list[0]
+        assert file_inject_call.args[1].files == files
+
+
+class TestPush:
+    @pytest.mark.asyncio
+    async def test_runs_push_command(self, service: GitService, mock_backend: AsyncMock) -> None:
+        await service.clone_repo(VOYAGE_ID, USER_ID, REPO_URL)
+        mock_backend.execute.reset_mock()
+
+        result = await service.push(VOYAGE_ID, USER_ID, "agent/shipwright/abc12345")
+
+        cmd = mock_backend.execute.call_args.args[1].command
+        assert "git push" in cmd
+        assert "agent/shipwright/abc12345" in cmd
+        assert result.pushed is True
+
+
+class TestCreatePR:
+    @pytest.mark.asyncio
+    async def test_calls_github_api(self, service: GitService, mock_backend: AsyncMock) -> None:
+        await service.clone_repo(VOYAGE_ID, USER_ID, REPO_URL)
+
+        mock_response = MagicMock()
+        mock_response.status_code = 201
+        mock_response.json.return_value = {
+            "number": 42,
+            "html_url": "https://github.com/owner/repo/pull/42",
+            "title": "Add login",
+            "head": {"ref": "agent/shipwright/abc12345"},
+            "base": {"ref": "main"},
+        }
+
+        with patch("app.services.git_service.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.post = AsyncMock(return_value=mock_response)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            result = await service.create_pr(
+                VOYAGE_ID, USER_ID, "Add login", "PR body", "agent/shipwright/abc12345", "main"
+            )
+
+        assert result.number == 42
+        assert result.url == "https://github.com/owner/repo/pull/42"
+
+    @pytest.mark.asyncio
+    async def test_parses_response(self, service: GitService, mock_backend: AsyncMock) -> None:
+        await service.clone_repo(VOYAGE_ID, USER_ID, REPO_URL)
+
+        mock_response = MagicMock()
+        mock_response.status_code = 201
+        mock_response.json.return_value = {
+            "number": 7,
+            "html_url": "https://github.com/owner/repo/pull/7",
+            "title": "feat: test",
+            "head": {"ref": "feat/test"},
+            "base": {"ref": "main"},
+        }
+
+        with patch("app.services.git_service.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.post = AsyncMock(return_value=mock_response)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            result = await service.create_pr(
+                VOYAGE_ID, USER_ID, "feat: test", "", "feat/test", "main"
+            )
+
+        assert result.title == "feat: test"
+        assert result.head == "feat/test"
+        assert result.base == "main"
+
+    @pytest.mark.asyncio
+    async def test_handles_api_error(self, service: GitService, mock_backend: AsyncMock) -> None:
+        await service.clone_repo(VOYAGE_ID, USER_ID, REPO_URL)
+
+        mock_response = MagicMock()
+        mock_response.status_code = 422
+        mock_response.text = "Validation Failed"
+        mock_response.json.return_value = {"message": "Validation Failed"}
+
+        with patch("app.services.git_service.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.post = AsyncMock(return_value=mock_response)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            with pytest.raises(GitError, match="GITHUB_API_ERROR"):
+                await service.create_pr(VOYAGE_ID, USER_ID, "title", "", "feat/test", "main")
+
+
+class TestGetLog:
+    @pytest.mark.asyncio
+    async def test_parses_output(self, service: GitService, mock_backend: AsyncMock) -> None:
+        await service.clone_repo(VOYAGE_ID, USER_ID, REPO_URL)
+        mock_backend.execute.reset_mock()
+        mock_backend.execute.return_value = _exec_result(
+            stdout="abc123def456|abc123d|feat: add login|shipwright|2026-04-12T10:00:00+00:00\n"
+            "def789abc012|def789a|fix: typo|doctor|2026-04-12T09:00:00+00:00\n"
+        )
+
+        log = await service.get_log(VOYAGE_ID, USER_ID, "main", limit=20)
+
+        assert len(log) == 2
+        assert log[0].sha == "abc123def456"
+        assert log[0].short_sha == "abc123d"
+        assert log[0].message == "feat: add login"
+        assert log[0].author == "shipwright"
+        assert log[1].sha == "def789abc012"
+
+
+class TestCheckConflicts:
+    @pytest.mark.asyncio
+    async def test_no_conflicts(self, service: GitService, mock_backend: AsyncMock) -> None:
+        await service.clone_repo(VOYAGE_ID, USER_ID, REPO_URL)
+        mock_backend.execute.reset_mock()
+        # Simulate: fetch succeeds, merge succeeds (exit 0), abort
+        mock_backend.execute.side_effect = [
+            _exec_result(),  # git fetch
+            _exec_result(),  # git checkout
+            _exec_result(stdout="EXIT:0\n"),  # git merge --no-commit --no-ff
+            _exec_result(),  # git merge --abort
+        ]
+
+        result = await service.check_conflicts(VOYAGE_ID, USER_ID, "feat/test", "main")
+
+        assert result.has_conflicts is False
+        assert result.conflicting_files == []
+
+    @pytest.mark.asyncio
+    async def test_with_conflicts(self, service: GitService, mock_backend: AsyncMock) -> None:
+        await service.clone_repo(VOYAGE_ID, USER_ID, REPO_URL)
+        mock_backend.execute.reset_mock()
+        mock_backend.execute.side_effect = [
+            _exec_result(),  # git fetch
+            _exec_result(),  # git checkout
+            _exec_result(stdout="CONFLICT (content): Merge conflict in src/main.py\nEXIT:1\n"),
+            _exec_result(stdout="src/main.py\nREADME.md\n"),  # git diff --name-only
+            _exec_result(),  # git merge --abort
+        ]
+
+        result = await service.check_conflicts(VOYAGE_ID, USER_ID, "feat/test", "main")
+
+        assert result.has_conflicts is True
+        assert "src/main.py" in result.conflicting_files
+
+    @pytest.mark.asyncio
+    async def test_aborts_merge(self, service: GitService, mock_backend: AsyncMock) -> None:
+        await service.clone_repo(VOYAGE_ID, USER_ID, REPO_URL)
+        mock_backend.execute.reset_mock()
+        mock_backend.execute.side_effect = [
+            _exec_result(),  # git fetch
+            _exec_result(),  # git checkout
+            _exec_result(stdout="EXIT:0\n"),  # no conflicts
+            _exec_result(),  # git merge --abort
+        ]
+
+        await service.check_conflicts(VOYAGE_ID, USER_ID, "feat/test", "main")
+
+        commands = [call.args[1].command for call in mock_backend.execute.call_args_list]
+        assert any("merge --abort" in cmd for cmd in commands)
+
+
+class TestCleanupBranches:
+    @pytest.mark.asyncio
+    async def test_destroys_sandbox(self, service: GitService, mock_backend: AsyncMock) -> None:
+        await service.clone_repo(VOYAGE_ID, USER_ID, REPO_URL)
+        mock_backend.execute.reset_mock()
+        mock_backend.execute.return_value = _exec_result()
+
+        await service.cleanup_branches(VOYAGE_ID, USER_ID)
+
+        mock_backend.destroy.assert_awaited_once_with("sandbox-git-1")
+
+
+class TestCleanupAll:
+    @pytest.mark.asyncio
+    async def test_destroys_all(self, service: GitService, mock_backend: AsyncMock) -> None:
+        other_voyage = uuid.uuid4()
+        mock_backend.create.side_effect = ["sandbox-git-1", "sandbox-git-2"]
+        await service.clone_repo(VOYAGE_ID, USER_ID, REPO_URL)
+        await service.clone_repo(other_voyage, USER_ID, REPO_URL)
+
+        await service.cleanup_all()
+
+        assert mock_backend.destroy.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_continues_on_error(self, service: GitService, mock_backend: AsyncMock) -> None:
+        other_voyage = uuid.uuid4()
+        mock_backend.create.side_effect = ["sandbox-git-1", "sandbox-git-2"]
+        await service.clone_repo(VOYAGE_ID, USER_ID, REPO_URL)
+        await service.clone_repo(other_voyage, USER_ID, REPO_URL)
+
+        mock_backend.destroy.side_effect = [Exception("fail"), None]
+
+        await service.cleanup_all()
+
+        assert mock_backend.destroy.await_count == 2
+
+
+class TestBranchNameValidation:
+    @pytest.mark.asyncio
+    async def test_rejects_injection(self, service: GitService, mock_backend: AsyncMock) -> None:
+        await service.clone_repo(VOYAGE_ID, USER_ID, REPO_URL)
+
+        with pytest.raises(GitError, match="INVALID_BRANCH_NAME"):
+            await service.create_branch(VOYAGE_ID, USER_ID, "; rm -rf /", "main")

--- a/src/backend/tests/test_git_service.py
+++ b/src/backend/tests/test_git_service.py
@@ -46,6 +46,7 @@ def mock_settings() -> MagicMock:
     s.git_default_branch = "main"
     s.git_author_name = "GrandLine Crew"
     s.git_author_email = "crew@grandline.dev"
+    s.git_allowed_hosts = None  # use default ALLOWED_GIT_HOSTS
     return s
 
 
@@ -97,6 +98,24 @@ class TestCloneRepo:
         with pytest.raises(GitError, match="REPO_ALREADY_CLONED"):
             await service.clone_repo(VOYAGE_ID, USER_ID, REPO_URL)
 
+    @pytest.mark.asyncio
+    async def test_clone_rejects_disallowed_host(
+        self, service: GitService, mock_backend: AsyncMock
+    ) -> None:
+        with pytest.raises(GitError, match="DISALLOWED_HOST"):
+            await service.clone_repo(VOYAGE_ID, USER_ID, "https://evil.com/repo.git")
+        mock_backend.create.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_clone_accepts_allowed_hosts(
+        self, service: GitService, mock_backend: AsyncMock
+    ) -> None:
+        for host in ("github.com", "gitlab.com", "bitbucket.org"):
+            svc = GitService(mock_backend, service._settings)
+            vid = uuid.uuid4()
+            result = await svc.clone_repo(vid, USER_ID, f"https://{host}/owner/repo.git")
+            assert result.sandbox_id == "sandbox-git-1"
+
 
 class TestCreateBranch:
     @pytest.mark.asyncio
@@ -124,6 +143,18 @@ class TestCreateBranch:
         cmd = mock_backend.execute.call_args.args[1].command
         assert "checkout -b" in cmd
         assert f"agent/shipwright/{VOYAGE_HEX8}" in cmd
+
+    @pytest.mark.asyncio
+    async def test_branches_from_remote_tracking(
+        self, service: GitService, mock_backend: AsyncMock
+    ) -> None:
+        await service.clone_repo(VOYAGE_ID, USER_ID, REPO_URL)
+        mock_backend.execute.reset_mock()
+
+        await service.create_branch(VOYAGE_ID, USER_ID, "shipwright", "main")
+
+        cmd = mock_backend.execute.call_args.args[1].command
+        assert "origin/main" in cmd
 
 
 class TestListBranches:

--- a/src/backend/tests/test_git_service.py
+++ b/src/backend/tests/test_git_service.py
@@ -149,7 +149,9 @@ class TestCommit:
     async def test_stages_and_commits(self, service: GitService, mock_backend: AsyncMock) -> None:
         await service.clone_repo(VOYAGE_ID, USER_ID, REPO_URL)
         mock_backend.execute.reset_mock()
-        mock_backend.execute.return_value = _exec_result(stdout="abc123def456\n")
+        mock_backend.execute.return_value = _exec_result(
+            stdout="abc123def456 abc123d 2026-04-12T10:00:00+00:00\n"
+        )
 
         await service.commit(VOYAGE_ID, USER_ID, "feat: add login", "shipwright")
 
@@ -165,14 +167,16 @@ class TestCommit:
     ) -> None:
         await service.clone_repo(VOYAGE_ID, USER_ID, REPO_URL)
         mock_backend.execute.reset_mock()
-        mock_backend.execute.return_value = _exec_result(stdout="abc123def456\n")
+        mock_backend.execute.return_value = _exec_result(
+            stdout="abc123def456 abc123d 2026-04-12T10:00:00+00:00\n"
+        )
 
         files = {"main.py": "print('hello')"}
         await service.commit(VOYAGE_ID, USER_ID, "feat: add main", "shipwright", files)
 
-        # The files should be passed in the ExecutionRequest
+        # Files should be prefixed with repo/ for put_archive at /workspace
         file_inject_call = mock_backend.execute.call_args_list[0]
-        assert file_inject_call.args[1].files == files
+        assert file_inject_call.args[1].files == {"repo/main.py": "print('hello')"}
 
 
 class TestPush:
@@ -273,8 +277,12 @@ class TestGetLog:
         await service.clone_repo(VOYAGE_ID, USER_ID, REPO_URL)
         mock_backend.execute.reset_mock()
         mock_backend.execute.return_value = _exec_result(
-            stdout="abc123def456|abc123d|feat: add login|shipwright|2026-04-12T10:00:00+00:00\n"
-            "def789abc012|def789a|fix: typo|doctor|2026-04-12T09:00:00+00:00\n"
+            stdout=(
+                "abc123def456\x00abc123d\x00feat: add login"
+                "\x00shipwright\x002026-04-12T10:00:00+00:00\n"
+                "def789abc012\x00def789a\x00fix: typo"
+                "\x00doctor\x002026-04-12T09:00:00+00:00\n"
+            )
         )
 
         log = await service.get_log(VOYAGE_ID, USER_ID, "main", limit=20)
@@ -384,3 +392,44 @@ class TestBranchNameValidation:
 
         with pytest.raises(GitError, match="INVALID_BRANCH_NAME"):
             await service.create_branch(VOYAGE_ID, USER_ID, "; rm -rf /", "main")
+
+    @pytest.mark.asyncio
+    async def test_push_validates_branch(
+        self, service: GitService, mock_backend: AsyncMock
+    ) -> None:
+        await service.clone_repo(VOYAGE_ID, USER_ID, REPO_URL)
+
+        with pytest.raises(GitError, match="INVALID_BRANCH_NAME"):
+            await service.push(VOYAGE_ID, USER_ID, "; rm -rf /")
+
+    @pytest.mark.asyncio
+    async def test_get_log_validates_branch(
+        self, service: GitService, mock_backend: AsyncMock
+    ) -> None:
+        await service.clone_repo(VOYAGE_ID, USER_ID, REPO_URL)
+
+        with pytest.raises(GitError, match="INVALID_BRANCH_NAME"):
+            await service.get_log(VOYAGE_ID, USER_ID, "$(whoami)")
+
+    @pytest.mark.asyncio
+    async def test_check_conflicts_validates_branches(
+        self, service: GitService, mock_backend: AsyncMock
+    ) -> None:
+        await service.clone_repo(VOYAGE_ID, USER_ID, REPO_URL)
+
+        with pytest.raises(GitError, match="INVALID_BRANCH_NAME"):
+            await service.check_conflicts(VOYAGE_ID, USER_ID, "; cat /etc/passwd", "main")
+
+
+class TestInjectToken:
+    def test_preserves_port(self) -> None:
+        from app.services.git_service import _inject_token
+
+        result = _inject_token("https://github.example.com:8443/owner/repo.git", "tok123")
+        assert result == "https://x-access-token:tok123@github.example.com:8443/owner/repo.git"
+
+    def test_standard_url(self) -> None:
+        from app.services.git_service import _inject_token
+
+        result = _inject_token("https://github.com/owner/repo.git", "tok123")
+        assert result == "https://x-access-token:tok123@github.com/owner/repo.git"


### PR DESCRIPTION
## Summary
- **GitService** with full git lifecycle: clone, branch, commit, push via sandboxed containers (network-enabled git backend)
- **PR creation** via GitHub REST API (`httpx`) — keeps GitHub token server-side
- **Per-agent branch naming**: `agent/<crew_member>/<voyage_hex8>` convention
- **Conflict detection**: `git merge --no-commit --no-ff` with abort cleanup
- **9 REST API endpoints** under `/voyages/{voyage_id}/git` with error differentiation (400/409/502/500)
- **Factory update**: `create_git_backend()` creates separate backend with network enabled + git image
- **Config**: `git_sandbox_image`, `git_sandbox_memory_limit`, `github_api_token`, author settings
- **Security**: `shlex.quote()` for all user inputs, HTTPS-only URLs, branch name validation, token never in logs
- **57 new tests** (317 total passing), mypy clean, ruff clean

Closes #10

## Test plan
- [ ] All 317 tests pass (`pytest`)
- [ ] Ruff lint + format clean
- [ ] Mypy clean (pre-existing `jose` stubs issue only)
- [ ] Schema validation: HTTPS-only URLs, branch name injection rejected, message length limits
- [ ] Service: clone/branch/commit/push commands verified, GitHub API mocked, conflict detection tested
- [ ] API: error mapping (409 REPO_NOT_CLONED, 400 NO_TARGET_REPO, 502 GITHUB_API_ERROR)
- [ ] Cleanup: sandbox destroyed on branch cleanup and app shutdown