### PR TITLE
docs: update PDD context for Phase 9-10

### DIFF
--- a/pdd/context/conventions.md
+++ b/pdd/context/conventions.md
@@ -1,6 +1,6 @@
 # GrandLine Conventions
 
-**Last updated**: 2026-04-05
+**Last updated**: 2026-04-14
 
 ## Philosophy
 - **Local-first**: Docker Compose is the primary dev environment. Everything runs locally.
@@ -50,12 +50,12 @@ src/
     api/                    — Route handlers (REST, SSE, WebSocket)
       v1/                   — Versioned API routes
     core/                   — Config, security, dependencies
-    crew/                   — Agent persona definitions
-      captain.py            — PM agent (task decomposition)
-      navigator.py          — Architect agent (Poneglyph drafting)
-      shipwright.py         — Developer agent (code generation)
-      doctor.py             — QA agent (test writing + validation)
-      helmsman.py           — DevOps agent (deployment)
+    crew/                   — Agent LangGraph definitions
+      captain_graph.py      — Captain two-node graph (decompose → validate)
+      navigator.py          — Architect agent (Poneglyph drafting) [planned]
+      shipwright.py         — Developer agent (code generation) [planned]
+      doctor.py             — QA agent (test writing + validation) [planned]
+      helmsman.py           — DevOps agent (deployment) [planned]
     dial_system/            — LLM gateway
       router.py             — DialSystemRouter (role routing + failover)
       factory.py            — Adapter factory (create_adapter, build_router_from_config)
@@ -155,6 +155,16 @@ src/
 - Parameterized queries only (SQLAlchemy handles this)
 - CORS configured explicitly — no wildcard in production
 - Agent execution in sandboxed containers — no host access
+
+## Crew agent pattern
+Each crew agent follows a consistent three-layer structure:
+- **Graph** (`crew/<agent>_graph.py`): LangGraph `StateGraph` with typed state dict. Contains LLM interaction nodes and validation nodes. Compiled once and cached by the service.
+- **Service** (`services/<agent>_service.py`): Business logic layer. Owns the DB session, manages voyage status transitions, persists results + VivreCard checkpoints in a single atomic commit, publishes events best-effort after commit.
+- **API** (`api/v1/<agent>.py`): FastAPI router with dependency injection. Separate dependencies for write operations (requires dial_router + mushi) and read operations (session-only via `Service.reader()`).
+
+Error pattern: each agent defines a structured `<Agent>Error(code, message)` exception. The API layer catches it and returns 422 with `{"error": {"code": ..., "message": ...}}`.
+
+Status lifecycle: voyage moves to a transient status (e.g., PLANNING) during processing, resets to CHARTED on failure, and restores to CHARTED on success so re-invocation is possible.
 
 ## Message bus (Den Den Mushi)
 - Built on **Redis Streams** — not Celery

--- a/pdd/context/decisions.md
+++ b/pdd/context/decisions.md
@@ -1,6 +1,6 @@
 # GrandLine — Architectural Decisions
 
-**Last updated**: 2026-04-05
+**Last updated**: 2026-04-14
 
 ---
 
@@ -129,3 +129,35 @@
 **What was decided**: Plan phases become GitHub issues. Each issue is worked on in a separate branch/PR. PRs must pass tests and PDD review before merge. User approves all PRs.
 **Why**: Clean git history, traceable work, and human-in-the-loop for quality control. Each PR is a reviewable, revertable unit of work.
 **Don't suggest**: Batching multiple issues into one PR, auto-merging without user approval, committing directly to main
+
+---
+
+## Decision: Git host allowlist for token safety
+**Date**: 2026-04-13
+**What was decided**: Git operations that receive a URL (clone) validate the host against `ALLOWED_GIT_HOSTS` (default: `github.com`, `gitlab.com`). If the config key is absent, host validation is skipped (open by default for self-hosted setups).
+**Why**: Git clone URLs are user-supplied. An attacker could point a clone URL at a server they control to exfiltrate the bearer token injected into the credential helper. The allowlist bounds the blast radius.
+**Don't suggest**: Disabling host validation, embedding tokens in the URL itself, trusting all hosts unconditionally
+
+---
+
+## Decision: LangGraph two-node graph for Captain Agent
+**Date**: 2026-04-14
+**What was decided**: The Captain Agent uses a compiled LangGraph `StateGraph` with two nodes — `decompose` (LLM call) → `validate` (JSON parse + Pydantic validation). The graph is compiled once per `CaptainService` instance and cached as `self._graph`.
+**Why**: The graph is intentionally minimal for v1. Decompose calls the Dial System via `CrewRole.CAPTAIN`, validate strips markdown fences and runs `VoyagePlanSpec.model_validate()`. No retry loops yet — that's future work. Caching the compiled graph avoids per-request recompilation overhead.
+**Don't suggest**: Retry loops in the graph (premature), raw LLM calls without the Dial System, building a new graph per request
+
+---
+
+## Decision: CaptainService.reader() for read-only operations
+**Date**: 2026-04-14
+**What was decided**: `CaptainService` has a `reader(session)` classmethod that creates a lightweight instance with only a DB session — no dial_router, mushi, or compiled graph. Used by `GET /plan`.
+**Why**: The GET endpoint is a simple DB read. Requiring a `DialSystemRouter` dependency means that if the voyage's DialConfig is deleted, the plan becomes unreadable even though it's already persisted. Decoupling read from write dependencies keeps the read path robust.
+**Don't suggest**: Sharing the full `get_captain_service` dependency for read endpoints, creating a separate PlanReadService (over-abstraction for one method)
+
+---
+
+## Decision: Best-effort event publishing after DB commit
+**Date**: 2026-04-14
+**What was decided**: `chart_course` commits plan + VivreCard to PostgreSQL first, then publishes the `VoyagePlanCreatedEvent` to Den Den Mushi in a try/except. If Redis is down, the event is logged as a warning and the request succeeds.
+**Why**: The plan is the source of truth, not the event. If publish fails after a successful commit, the caller gets a successful response and can retry the event later. Failing the request after the plan is already committed leaves the caller with a 500 for a successful write and no safe retry path (the voyage status has moved out of CHARTED).
+**Don't suggest**: Publishing before commit (data loss risk), failing the request on publish failure, transactional outbox (premature for current scale)

--- a/pdd/context/project.md
+++ b/pdd/context/project.md
@@ -1,6 +1,6 @@
 # Project: GrandLine
 
-**Last updated**: 2026-04-12
+**Last updated**: 2026-04-14
 
 ## What we're building
 A web-based multi-agent orchestration platform where a crew of persona-based AI agents voyage together through a structured pipeline to build, test, and deploy software solutions. Themed after One Piece — the crew, the voyage, and the platform vocabulary are all drawn from that world.
@@ -143,7 +143,7 @@ Users can intervene at any point — pause an agent, redirect work, inject conte
 - Never lose work — Vivre Card checkpointing is mandatory for provider failover
 
 ## Current state
-Phases 1-8 complete. The backend is functional with:
+Phases 1-10 complete. The backend is functional with:
 - **Phase 1-2**: Docker infrastructure, PostgreSQL + Redis, SQLAlchemy models (Voyage, VoyagePlan, Poneglyph, VivreCard, CrewAction, DialConfig)
 - **Phase 3**: Pydantic schemas for all models, DialConfig with JSONB role_mapping/fallback_chain
 - **Phase 4**: JWT auth (register, login, refresh, logout) with default-deny middleware
@@ -151,6 +151,8 @@ Phases 1-8 complete. The backend is functional with:
 - **Phase 6**: Dial System LLM gateway — provider adapters (Anthropic, OpenAI, Ollama), adapter factory, role-based routing with failover, Redis sliding-window rate limiter, SSE streaming endpoint
 - **Phase 7**: Vivre Card state checkpointing — service, API, and Dial System hook for provider failover
 - **Phase 8**: Execution Service — containerized sandbox with gVisor/Docker backend (aiodocker), swappable ExecutionBackend ABC, per-user sandbox lifecycle, path traversal sanitization, file size limits, app lifespan wiring
+- **Phase 9**: Git Integration Service — per-voyage sandboxed git operations (clone, branch, commit, diff, log), host allowlist to prevent token exfiltration, NUL-delimited git output parsing, branch creation from `origin/<base>` for freshness
+- **Phase 10**: Captain Agent — first crew member implemented. LangGraph two-node graph (decompose → validate) for task-to-plan decomposition via Dial System. CaptainService with atomic plan + VivreCard persistence, replannable status lifecycle, best-effort event publishing. VoyagePlanSpec with dependency graph validation (unique phases, valid references, cycle detection via topological sort). REST endpoints: POST/GET `/voyages/{id}/plan`
 
 Frontend not yet started.
 


### PR DESCRIPTION
## Summary
- Update `pdd/context/project.md` with Phase 9 (Git Integration) and Phase 10 (Captain Agent) in current state
- Add 4 architectural decisions to `pdd/context/decisions.md`: git host allowlist, LangGraph two-node graph, `CaptainService.reader()`, best-effort event publishing
- Add crew agent pattern conventions to `pdd/context/conventions.md` documenting the three-layer structure (graph → service → API)

## Test plan
- [x] No code changes — context docs only