### PR TITLE
feat: add Doctor Agent with TDD health checks and validation (Phase 12) #13

### DIFF
--- a/pdd/prompts/features/crew/PLAN-doctor-agent.md
+++ b/pdd/prompts/features/crew/PLAN-doctor-agent.md
@@ -1,0 +1,89 @@
+# Implementation Plan: Doctor Agent (Phase 12)
+
+**Created**: 2026-04-16
+**Issue**: #13
+**Complexity**: High — two distinct operating modes, new DB model, git write path
+**Estimated prompts**: 1 (single PDD prompt, matching Captain/Navigator precedent)
+
+## Summary
+
+The Doctor is a two-mode QA agent:
+
+1. **Pre-build (TDD)**: reads a voyage's Poneglyphs, asks the Dial System to generate failing tests per phase, persists them as `HealthCheck` rows, and publishes `HealthCheckWrittenEvent`. Tests are optionally committed to a Doctor git branch via the existing `GitService`.
+2. **Post-build (Validate)**: takes a set of Shipwright-produced files, materializes them alongside the stored health-check tests in a sandbox, runs pytest, persists the result, and publishes either `ValidationPassedEvent` or a new `ValidationFailedEvent`.
+
+Both modes go through the existing crew agent three-layer pattern (`graph → service → API`) with `reader()` factory, atomic commits (HealthCheck + VivreCard), and best-effort event publishing. Follows Navigator/Captain precedent exactly.
+
+## Phases
+
+### Phase 1 (single prompt): Doctor Agent end-to-end
+
+**Produces**:
+- `alembic/versions/<rev>_health_checks.py` — migration adding the `health_checks` table
+- `app/models/health_check.py` — SQLAlchemy model (`HealthCheck`)
+- `app/schemas/doctor.py` — Pydantic schemas
+- `app/schemas/health_check.py` — `HealthCheckRead` (separate file, mirrors `schemas/poneglyph.py`)
+- `app/crew/doctor_graph.py` — LangGraph two-node graph for test generation
+- `app/services/doctor_service.py` — `DoctorService` with `write_health_checks` and `validate_code`
+- `app/api/v1/doctor.py` — `POST /voyages/{id}/health-checks`, `GET /voyages/{id}/health-checks`, `POST /voyages/{id}/validation`
+- `app/den_den_mushi/events.py` — add `ValidationFailedEvent` (symmetric with `ValidationPassedEvent`)
+- `app/api/v1/router.py` — wire the new router
+- Tests: `tests/test_doctor_schemas.py`, `tests/test_doctor_graph.py`, `tests/test_doctor_service.py`, `tests/test_doctor_api.py`
+
+**Depends on**: Navigator (Poneglyphs must exist), GitService (for the optional commit path), ExecutionService (for pytest execution). All three are already in place after PR #31 merge.
+
+**Risk**: Medium — running pytest inside a sandbox is the novel piece; everything else is a direct analogue of Captain/Navigator.
+
+**Prompt**: `pdd/prompts/features/crew/grandline-12-doctor.md`
+
+## Key design decisions (locked before prompt)
+
+1. **New HealthCheck model** — mirror the `Poneglyph` shape:
+   ```
+   id (UUID PK)
+   voyage_id (UUID FK, indexed)
+   poneglyph_id (UUID FK nullable, indexed)  # links back to the Poneglyph that produced it
+   phase_number (int)
+   file_path (String(500))                    # relative path inside the target repo, e.g. "tests/test_auth.py"
+   content (Text)                             # the test source code
+   framework (String(20))                     # "pytest" | "vitest"
+   last_run_status (String(20) nullable)      # "passed" | "failed" | null (never run)
+   last_run_output (Text nullable)            # raw captured stdout/stderr from the last run
+   last_run_at (DateTime nullable)
+   metadata_ (JSONB nullable)
+   created_by (String(50), default="doctor")
+   created_at (DateTime)
+   ```
+   Why: separating `HealthCheck` from `Poneglyph` keeps Doctor's lifecycle fields (`last_run_status`, `last_run_output`) independent and lets us query validation state per file without JSONB gymnastics.
+
+2. **Two service methods, one graph** — the graph is the pre-build test-generation graph only. The post-build `validate_code` method does *not* run a graph; it shells out to pytest via `ExecutionService` and parses the exit code. Generating tests is an LLM task; running them is not.
+
+3. **Transient statuses reuse existing enum values** — `VoyageStatus.TDD` during `write_health_checks`, `VoyageStatus.REVIEWING` during `validate_code`. Both restore to `CHARTED` on success *and* failure (replannable lifecycle). No new enum values needed.
+
+4. **LLM prompt produces one JSON batch** — same pattern as Navigator: one Dial System call per voyage, returns `{"health_checks": [{"phase_number": N, "file_path": "...", "content": "..."}]}`. Single call keeps cost predictable and is consistent with the established pattern. Framework selection (`pytest` vs `vitest`) is inferred from the Poneglyph's `file_paths` (`.py` → pytest, `.ts`/`.tsx` → vitest, default pytest).
+
+5. **Re-draft replaces (Fix #1 lesson from Navigator)** — `write_health_checks` deletes existing `HealthCheck` rows for the voyage before inserting new ones, so re-invocation replaces instead of duplicating.
+
+6. **Phase alignment check (Fix #5 lesson)** — validate that every LLM-returned `phase_number` exists in the current Poneglyph set; if not, raise `DoctorError("HEALTH_CHECK_PHASE_MISMATCH", ...)`.
+
+7. **Git commit is opt-in and best-effort** — Doctor is an LLM agent in this phase; the git branch commit is only attempted when a `GitService` + `user_id` are supplied and the voyage has a `target_repo`. When `target_repo` is absent, skip the commit path entirely and log it. This matches how the issue is scoped: "Tests written to Doctor's git branch" — the row in the DB is the source of truth; the git commit is the externalization, and the integration test for it is mocked.
+
+8. **Validation input contract** — `validate_code(voyage, shipwright_files: dict[str, str])` takes a dict of `{file_path: content}`. The DoctorService layers the shipwright files + the stored `HealthCheck` files into the sandbox (via `ExecutionService.run`), invokes `python -m pytest -x --tb=short --json-report --json-report-file=/tmp/doctor.json`, and parses the JSON report. Pass/fail is decided by pytest's exit code; the raw output is stored on each `HealthCheck.last_run_output` for observability.
+
+9. **`ValidationFailedEvent`** — add it to `events.py` + `AnyEvent` union. Symmetric with `ValidationPassedEvent`. Payload includes `failed_count`, `total_count`, and a truncated error summary.
+
+10. **Doctor system prompt tells the LLM to write *failing* tests** — explicit requirement in the system prompt: "The implementation does not exist yet. Your tests should reference functions, classes, and files that will only exist after the Shipwrights implement them. Tests must fail when run now; this is by design (TDD)."
+
+## Risks & Unknowns
+
+- **Running real pytest inside the sandbox**: `ExecutionService` already exists and works; the piece we haven't exercised is `files=` injection + a python binary with pytest installed. The sandbox image may not have pytest installed out of the box. **Mitigation**: mock `ExecutionService` in tests; include a TODO note that a real end-to-end voyage run is Phase 15's responsibility.
+- **vitest vs pytest framework inference**: if a Poneglyph has mixed `.py` and `.ts` files, we pick the dominant one. Rare enough in practice that a deterministic rule is fine.
+- **Concurrent write/validate**: if a user triggers `validate_code` while `write_health_checks` is still running, both will try to flush status transitions. **Mitigation**: the 409 check at the API layer (status must be `CHARTED`) prevents this, same pattern as Navigator.
+
+## Decisions Needed
+
+All resolved above — proceeding to prompt generation.
+
+## Next step
+
+Run `/pdd-skill:pdd-prompts` with this plan in hand, producing `pdd/prompts/features/crew/grandline-12-doctor.md`.

--- a/pdd/prompts/features/crew/grandline-12-doctor.md
+++ b/pdd/prompts/features/crew/grandline-12-doctor.md
@@ -47,11 +47,28 @@ publishing after commit. Reuse the shared `strip_fences` helper in `app/crew/uti
 
 ## Deliverables
 
-### 1. Database — new `HealthCheck` model + migration
+### 1. Database — new `HealthCheck` + `ValidationRun` models + migration
 
-New table `health_checks` (migration file under `src/backend/alembic/versions/`):
+Two new tables in a single migration file under `src/backend/alembic/versions/`.
+`validation_runs` is created first so the `health_checks.last_validation_run_id` FK
+can reference it.
 
 ```python
+op.create_table(
+    "validation_runs",
+    sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+    sa.Column("voyage_id", postgresql.UUID(as_uuid=True),
+              sa.ForeignKey("voyages.id"), nullable=False, index=True),
+    sa.Column("status", sa.String(20), nullable=False),
+    sa.Column("exit_code", sa.Integer(), nullable=False),
+    sa.Column("passed_count", sa.Integer(), nullable=False, server_default="0"),
+    sa.Column("failed_count", sa.Integer(), nullable=False, server_default="0"),
+    sa.Column("total_count", sa.Integer(), nullable=False, server_default="0"),
+    sa.Column("output", sa.Text(), nullable=True),
+    sa.Column("created_at", sa.DateTime(timezone=True), nullable=False,
+              server_default=sa.func.now()),
+)
+
 op.create_table(
     "health_checks",
     sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
@@ -64,19 +81,47 @@ op.create_table(
     sa.Column("content", sa.Text(), nullable=False),
     sa.Column("framework", sa.String(20), nullable=False, server_default="pytest"),
     sa.Column("last_run_status", sa.String(20), nullable=True),
-    sa.Column("last_run_output", sa.Text(), nullable=True),
     sa.Column("last_run_at", sa.DateTime(timezone=True), nullable=True),
-    sa.Column("metadata", postgresql.JSONB(), nullable=True),
+    sa.Column("last_validation_run_id", postgresql.UUID(as_uuid=True),
+              sa.ForeignKey("validation_runs.id"), nullable=True, index=True),
     sa.Column("created_by", sa.String(50), nullable=False, server_default="doctor"),
     sa.Column("created_at", sa.DateTime(timezone=True), nullable=False,
               server_default=sa.func.now()),
 )
 ```
 
-Downgrade drops the table. Set `revision` to a new random hex; `down_revision` to the
-current head (`00b24ef2f7d8`).
+Downgrade drops both tables in reverse order (`health_checks` first). Set
+`revision` to a new random hex; `down_revision` to the current head.
 
-SQLAlchemy model — `app/models/health_check.py`:
+**No `metadata` JSONB column on `HealthCheck`** — `framework` is a first-class
+column, and per-run output lives on `ValidationRun`. Do not add a bag-of-extras
+column until a real second field is needed.
+
+SQLAlchemy models:
+
+`app/models/validation_run.py`:
+
+```python
+class ValidationRun(Base):
+    __tablename__ = "validation_runs"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True,
+                                          default=uuid.uuid4)
+    voyage_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("voyages.id"), index=True, nullable=False
+    )
+    status: Mapped[str] = mapped_column(String(20), nullable=False)
+    exit_code: Mapped[int] = mapped_column(Integer, nullable=False)
+    passed_count: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
+    failed_count: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
+    total_count: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
+    output: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+```
+
+`app/models/health_check.py`:
 
 ```python
 class HealthCheck(Base):
@@ -95,23 +140,25 @@ class HealthCheck(Base):
     content: Mapped[str] = mapped_column(Text, nullable=False)
     framework: Mapped[str] = mapped_column(String(20), default="pytest", nullable=False)
     last_run_status: Mapped[str | None] = mapped_column(String(20), nullable=True)
-    last_run_output: Mapped[str | None] = mapped_column(Text, nullable=True)
     last_run_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True), nullable=True
     )
-    metadata_: Mapped[dict[str, Any] | None] = mapped_column("metadata", JSONB,
-                                                              nullable=True)
+    last_validation_run_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("validation_runs.id"),
+        index=True, nullable=True
+    )
     created_by: Mapped[str] = mapped_column(String(50), default="doctor", nullable=False)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )
 ```
 
-Export from `app/models/__init__.py`.
+Export both from `app/models/__init__.py`.
 
 ### 2. Pydantic Schemas
 
-`app/schemas/health_check.py` — read model (mirrors `schemas/poneglyph.py`):
+`app/schemas/health_check.py` — read model (mirrors `schemas/poneglyph.py`).
+No `last_run_output` or `metadata_` fields — output lives on `ValidationRun`.
 
 ```python
 class HealthCheckRead(BaseModel):
@@ -124,22 +171,46 @@ class HealthCheckRead(BaseModel):
     content: str
     framework: str
     last_run_status: str | None
-    last_run_output: str | None
     last_run_at: datetime | None
-    metadata_: dict[str, Any] | None
+    last_validation_run_id: uuid.UUID | None
     created_by: str
     created_at: datetime
 ```
 
-`app/schemas/doctor.py`:
+`app/schemas/doctor.py` — includes **path-safety validators** on every user- or
+LLM-supplied path. Sandboxed execution is not a substitute for input validation:
+traversal in `file_path` would let the Doctor clobber arbitrary repo files on
+the best-effort git commit, and traversal in `ValidateCodeRequest.files` would
+layer attacker-chosen filenames next to the real test files.
 
 ```python
+import posixpath
+
+def _validate_relative_path(path: str) -> str:
+    if path.startswith("/") or path.startswith("\\"):
+        raise ValueError(f"Path must be relative, got {path!r}")
+    # Reject drive letters / URL schemes in the first segment
+    if ":" in path.split("/")[0]:
+        raise ValueError(f"Path must not be a drive/scheme, got {path!r}")
+    normalized = posixpath.normpath(path)
+    if normalized.startswith("..") or "/../" in f"/{normalized}/":
+        raise ValueError(f"Path traversal not allowed in {path!r}")
+    if normalized in (".", ""):
+        raise ValueError(f"Path must not be empty, got {path!r}")
+    return path
+
+
 class HealthCheckSpec(BaseModel):
     """What the LLM emits for one phase's test file."""
     phase_number: int = Field(ge=1)
     file_path: str = Field(min_length=1, max_length=500)
     content: str = Field(min_length=1)
     framework: Literal["pytest", "vitest"] = "pytest"
+
+    @field_validator("file_path")
+    @classmethod
+    def _validate_file_path(cls, v: str) -> str:
+        return _validate_relative_path(v)
 
 
 class DoctorOutputSpec(BaseModel):
@@ -168,6 +239,13 @@ class HealthCheckListResponse(BaseModel):
 class ValidateCodeRequest(BaseModel):
     """Caller supplies the Shipwright-produced files to test against."""
     files: dict[str, str] = Field(min_length=1)
+
+    @field_validator("files")
+    @classmethod
+    def _validate_file_paths(cls, v: dict[str, str]) -> dict[str, str]:
+        for path in v:
+            _validate_relative_path(path)
+        return v
 
 
 class ValidationResultResponse(BaseModel):
@@ -335,22 +413,34 @@ class DoctorService:
 
 **`validate_code` flow:**
 1. Set `voyage.status = REVIEWING`, flush.
-2. Load existing health checks via a SELECT (raise `DoctorError("NO_HEALTH_CHECKS",
-   ...)` if none). Reset status first.
+2. Load existing health checks via a SELECT. If empty, the service can assume the
+   API layer pre-checked (see API rules); still safe to raise `DoctorError` for
+   the rare race. Reset status first.
 3. Combine `shipwright_files | {hc.file_path: hc.content for hc in hcs}` into a
    single `files` dict.
 4. Run via `ExecutionService.run(user_id, ExecutionRequest(
      command="cd /workspace && python -m pytest -x --tb=short",
      files=files, timeout_seconds=300))`.
 5. Decide pass/fail by `exit_code == 0`.
-6. Parse a simple `passed_count` / `failed_count` from the stdout (count lines
-   matching `PASSED`/`FAILED` from pytest's short summary; fallback to
-   `exit_code == 0` → `passed_count = total`, else `failed_count = total`).
-7. Update each health check row: set `last_run_status = "passed"` or `"failed"`,
-   `last_run_at = utcnow()`, `last_run_output = result.stdout[-4000:]` (truncated).
-8. Restore `voyage.status = CHARTED`, commit.
-9. Publish `ValidationPassedEvent` or `ValidationFailedEvent` best-effort.
-10. Return a `ValidationResultResponse`.
+6. Parse `passed_count` / `failed_count` from the stdout (count lines matching
+   `PASSED`/`FAILED`; fallback to `exit_code == 0` → `passed_count = total`,
+   else `failed_count = total`).
+7. **Persist one `ValidationRun` row** with `status`, `exit_code`,
+   `passed_count`, `failed_count`, `total_count = len(health_checks)`, and
+   `output = result.stdout[-4000:]` (truncated). Flush to get `run.id`.
+8. Update each health check row: set `last_run_status = "passed"|"failed"`,
+   `last_run_at = utcnow()`, `last_validation_run_id = run.id`. Do **not**
+   duplicate the stdout onto each health check.
+9. Restore `voyage.status = CHARTED`, commit.
+10. Publish `ValidationPassedEvent` or `ValidationFailedEvent` best-effort.
+11. Return a `ValidationResultResponse`.
+
+**Graph-input helper — `_poneglyphs_to_graph_input`:**
+Parsing `Poneglyph.content` must tolerate corrupt legacy rows. On
+`json.JSONDecodeError`, log a warning with `poneglyph_id` and `phase_number`
+and fall back to an empty dict — do not swallow silently and do not raise.
+The LLM then sees the phase with only its `phase_number`, which is a recoverable
+degradation.
 
 ### 6. REST API — `app/api/v1/doctor.py`
 
@@ -369,10 +459,26 @@ Router with prefix `/voyages/{voyage_id}`, tag `doctor`.
 - `DoctorError` → 422 `{"error": {"code": exc.code, "message": exc.message}}`.
 
 **POST `/validation` rules:**
-- Body: `ValidateCodeRequest` (non-empty `files`).
-- Voyage must be in status `CHARTED` → else 409 `VOYAGE_NOT_TESTABLE`.
-- Must have at least one `HealthCheck` → else 404 `NO_HEALTH_CHECKS`.
-- `DoctorError` → 422.
+- Body: `ValidateCodeRequest` (non-empty `files`, path-validated by the schema).
+- Voyage must be in status `CHARTED` → else 409 `VOYAGE_NOT_CHARTABLE`.
+- **The handler pre-checks for health checks via `doctor_reader.get_health_checks(
+  voyage_id)` and returns 404 `NO_HEALTH_CHECKS` if empty**. Do not let this
+  bubble up as a `DoctorError` → 422 would be wrong; "resource missing" is 404.
+- `DoctorError` raised from `validate_code` → 422.
+
+Inject two dependencies so the 404 check reuses the lightweight reader:
+
+```python
+async def run_validation(
+    voyage_id: uuid.UUID,
+    body: ValidateCodeRequest,
+    user: User = Depends(get_current_user),
+    voyage: Voyage = Depends(get_authorized_voyage),
+    doctor_service: DoctorService = Depends(get_doctor_service),
+    doctor_reader: DoctorService = Depends(get_doctor_reader),
+) -> ValidationResultResponse:
+    ...
+```
 
 **GET `/health-checks`**: 200 with list (empty list is OK).
 
@@ -422,6 +528,12 @@ All tests use mocked dependencies (no real LLM, DB, sandbox, or git).
 8. `DoctorOutputSpec` rejects duplicate `file_path`.
 9. `DoctorOutputSpec` accepts multi-phase output.
 10. `ValidateCodeRequest` rejects empty `files`.
+11. `HealthCheckSpec` rejects absolute `file_path` (`/etc/passwd`).
+12. `HealthCheckSpec` rejects traversal (`../../etc/passwd`).
+13. `HealthCheckSpec` rejects nested traversal (`tests/../../etc/passwd`).
+14. `HealthCheckSpec` accepts nested relative path (`tests/unit/test_auth.py`).
+15. `ValidateCodeRequest` rejects absolute path keys in `files`.
+16. `ValidateCodeRequest` rejects traversal keys in `files`.
 
 ### Graph Tests — `tests/test_doctor_graph.py`
 
@@ -477,12 +589,16 @@ string of a valid `PoneglyphContentSpec`.
 19. Calls `ExecutionService.run` with a pytest command.
 20. Returns `status="passed"` with updated counts when `exit_code=0`.
 21. Returns `status="failed"` with updated counts when `exit_code!=0`.
-22. Updates each `HealthCheck.last_run_status`, `.last_run_output`, `.last_run_at`.
+22. Updates each `HealthCheck.last_run_status`, `.last_run_at`,
+    `.last_validation_run_id`.
 23. Commits DB changes exactly once.
 24. Restores voyage status to `CHARTED` after success.
 25. Publishes `ValidationPassedEvent` on pass.
 26. Publishes `ValidationFailedEvent` on fail.
 27. Raises `DoctorError("NO_HEALTH_CHECKS", ...)` when no rows exist; status reset.
+28. Persists exactly one `ValidationRun` row per call with `status`, `exit_code`,
+    counts, and truncated `output`. Each linked `HealthCheck.last_validation_run_id`
+    matches that row's `id`.
 
 **`get_health_checks`:**
 
@@ -501,7 +617,8 @@ string of a valid `PoneglyphContentSpec`.
 7. POST `/validation` returns 200 with `status="passed"`.
 8. POST `/validation` returns 200 with `status="failed"`.
 9. POST `/validation` returns 409 when voyage not `CHARTED`.
-10. POST `/validation` returns 404 when no health checks exist.
+10. POST `/validation` returns 404 when no health checks exist (asserts
+    `doctor_service.validate_code` was **not** awaited).
 11. POST `/validation` returns 422 on `DoctorError`.
 
 ## Constraints
@@ -524,7 +641,22 @@ string of a valid `PoneglyphContentSpec`.
 - Single Dial System call per `write_health_checks` (one JSON batch for all
   phases). Validation failures of the batch fail the whole call — no partial
   writes.
-- `last_run_output` is truncated to the last 4000 chars to keep rows small.
+- `ValidationRun.output` is truncated to the last 4000 chars to keep rows small.
+  `HealthCheck` rows never store stdout — they point to a `ValidationRun` via
+  `last_validation_run_id`.
 - Pytest invocation is `python -m pytest -x --tb=short`. Counting pass/fail is
   best-effort from stdout; when parsing fails, fall back to `exit_code == 0` →
   `passed_count = total_count`, else `failed_count = total_count`.
+- **Path safety is non-negotiable** — validate at the schema layer. LLM-emitted
+  `file_path` values and caller-supplied `files` keys are untrusted input. Sandboxed
+  execution does not protect the best-effort git commit (which runs on the host)
+  from absolute paths or traversal.
+- **Do not add a `metadata_` JSONB on `HealthCheck`.** `framework` is a real
+  column; do not re-serialize it into a schemaless blob. Add a real column when a
+  second field is actually needed.
+- **Malformed Poneglyph content → warn, degrade gracefully.** Log the offending
+  `poneglyph_id` and `phase_number` and fall back to an empty dict; do not raise
+  and do not silently swallow.
+- **404 for NO_HEALTH_CHECKS** is an API-layer pre-check via `doctor_reader`.
+  "Missing prerequisite resource" is not the same semantic as a service-layer
+  invariant violation (which maps to 422).

--- a/pdd/prompts/features/crew/grandline-12-doctor.md
+++ b/pdd/prompts/features/crew/grandline-12-doctor.md
@@ -1,0 +1,530 @@
+# Phase 12: Doctor Agent (QA)
+
+## Context
+
+The Doctor is the third crew agent. It operates in **two distinct modes**:
+
+- **Pre-build (TDD)**: consumes the Navigator's Poneglyphs, asks the Dial System to
+  write failing tests for each phase, persists them as `HealthCheck` rows, and emits
+  `HealthCheckWrittenEvent`.
+- **Post-build (Validate)**: takes a set of Shipwright-produced source files, layers
+  them alongside the stored health-check tests in a sandbox, runs pytest, updates the
+  `HealthCheck` rows with the run result, and emits `ValidationPassedEvent` or
+  `ValidationFailedEvent`.
+
+This follows the **crew agent pattern** established by Captain (Phase 10) and Navigator
+(Phase 11): three layers (graph → service → API), `reader()` factory for read-only
+operations, atomic commits that include a `VivreCard` checkpoint, best-effort event
+publishing after commit. Reuse the shared `strip_fences` helper in `app/crew/utils.py`.
+
+### Existing Infrastructure
+
+| System | Module | Key Interfaces |
+|--------|--------|----------------|
+| **Navigator** | `app.services.navigator_service.NavigatorService` | `get_poneglyphs(voyage_id) -> list[Poneglyph]` |
+| **Dial System** | `app.dial_system.router.DialSystemRouter` | `route(role, CompletionRequest) -> CompletionResult` |
+| **Den Den Mushi** | `app.den_den_mushi.mushi.DenDenMushi` | `publish(stream, event)` |
+| **Execution Service** | `app.services.execution_service.ExecutionService` | `run(user_id, ExecutionRequest) -> ExecutionResult` |
+| **Git Service** | `app.services.git_service.GitService` | `create_branch(voyage_id, user_id, crew_member, base)`, `commit(voyage_id, user_id, message, crew_member, files={path: content})`, `push(voyage_id, user_id, branch)` |
+| **Models** | `app.models.poneglyph.Poneglyph` | `id, voyage_id, phase_number, content (Text), metadata_` |
+| **Events** | `app.den_den_mushi.events` | `HealthCheckWrittenEvent`, `ValidationPassedEvent` (already defined); `ValidationFailedEvent` needs to be added |
+| **Enums** | `app.models.enums` | `CrewRole.DOCTOR`, `VoyageStatus.TDD`, `VoyageStatus.REVIEWING` |
+| **Constants** | `app.den_den_mushi.constants` | `stream_key(voyage_id)` |
+| **Shared helpers** | `app.crew.utils` | `strip_fences(text)` |
+| **Navigator Graph** | `app.crew.navigator_graph` | Reference pattern: two-node StateGraph (generate → validate) |
+
+`Poneglyph.content` is a JSON string holding a `PoneglyphContentSpec` (from
+`app.schemas.navigator`). The Doctor parses it to extract `test_criteria`,
+`file_paths`, and `task_description`, which become the context for test generation.
+
+`CompletionRequest` takes `messages: list[dict[str,str]]`, `role: CrewRole`,
+`voyage_id`, `max_tokens`, `temperature`.
+
+`ExecutionRequest` takes `command: str`, `files: dict[str, str] | None = None`,
+`timeout_seconds: int | None = None`. `ExecutionResult` has
+`stdout, stderr, exit_code, duration_ms`. Paths in `files=` are relative to
+`/workspace/` in the sandbox.
+
+## Deliverables
+
+### 1. Database — new `HealthCheck` model + migration
+
+New table `health_checks` (migration file under `src/backend/alembic/versions/`):
+
+```python
+op.create_table(
+    "health_checks",
+    sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+    sa.Column("voyage_id", postgresql.UUID(as_uuid=True),
+              sa.ForeignKey("voyages.id"), nullable=False, index=True),
+    sa.Column("poneglyph_id", postgresql.UUID(as_uuid=True),
+              sa.ForeignKey("poneglyphs.id"), nullable=True, index=True),
+    sa.Column("phase_number", sa.Integer(), nullable=False),
+    sa.Column("file_path", sa.String(500), nullable=False),
+    sa.Column("content", sa.Text(), nullable=False),
+    sa.Column("framework", sa.String(20), nullable=False, server_default="pytest"),
+    sa.Column("last_run_status", sa.String(20), nullable=True),
+    sa.Column("last_run_output", sa.Text(), nullable=True),
+    sa.Column("last_run_at", sa.DateTime(timezone=True), nullable=True),
+    sa.Column("metadata", postgresql.JSONB(), nullable=True),
+    sa.Column("created_by", sa.String(50), nullable=False, server_default="doctor"),
+    sa.Column("created_at", sa.DateTime(timezone=True), nullable=False,
+              server_default=sa.func.now()),
+)
+```
+
+Downgrade drops the table. Set `revision` to a new random hex; `down_revision` to the
+current head (`00b24ef2f7d8`).
+
+SQLAlchemy model — `app/models/health_check.py`:
+
+```python
+class HealthCheck(Base):
+    __tablename__ = "health_checks"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True,
+                                          default=uuid.uuid4)
+    voyage_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("voyages.id"), index=True, nullable=False
+    )
+    poneglyph_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("poneglyphs.id"), index=True, nullable=True
+    )
+    phase_number: Mapped[int] = mapped_column(Integer, nullable=False)
+    file_path: Mapped[str] = mapped_column(String(500), nullable=False)
+    content: Mapped[str] = mapped_column(Text, nullable=False)
+    framework: Mapped[str] = mapped_column(String(20), default="pytest", nullable=False)
+    last_run_status: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    last_run_output: Mapped[str | None] = mapped_column(Text, nullable=True)
+    last_run_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    metadata_: Mapped[dict[str, Any] | None] = mapped_column("metadata", JSONB,
+                                                              nullable=True)
+    created_by: Mapped[str] = mapped_column(String(50), default="doctor", nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+```
+
+Export from `app/models/__init__.py`.
+
+### 2. Pydantic Schemas
+
+`app/schemas/health_check.py` — read model (mirrors `schemas/poneglyph.py`):
+
+```python
+class HealthCheckRead(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+    id: uuid.UUID
+    voyage_id: uuid.UUID
+    poneglyph_id: uuid.UUID | None
+    phase_number: int
+    file_path: str
+    content: str
+    framework: str
+    last_run_status: str | None
+    last_run_output: str | None
+    last_run_at: datetime | None
+    metadata_: dict[str, Any] | None
+    created_by: str
+    created_at: datetime
+```
+
+`app/schemas/doctor.py`:
+
+```python
+class HealthCheckSpec(BaseModel):
+    """What the LLM emits for one phase's test file."""
+    phase_number: int = Field(ge=1)
+    file_path: str = Field(min_length=1, max_length=500)
+    content: str = Field(min_length=1)
+    framework: Literal["pytest", "vitest"] = "pytest"
+
+
+class DoctorOutputSpec(BaseModel):
+    """Full LLM output — one test file per phase minimum."""
+    health_checks: list[HealthCheckSpec] = Field(min_length=1)
+
+    @model_validator(mode="after")
+    def validate_unique_file_paths(self) -> DoctorOutputSpec:
+        paths = [hc.file_path for hc in self.health_checks]
+        if len(paths) != len(set(paths)):
+            raise ValueError("Duplicate file_path values in health_checks")
+        return self
+
+
+class WriteHealthChecksResponse(BaseModel):
+    voyage_id: uuid.UUID
+    health_check_ids: list[uuid.UUID]
+    count: int
+
+
+class HealthCheckListResponse(BaseModel):
+    voyage_id: uuid.UUID
+    health_checks: list[HealthCheckRead]
+
+
+class ValidateCodeRequest(BaseModel):
+    """Caller supplies the Shipwright-produced files to test against."""
+    files: dict[str, str] = Field(min_length=1)
+
+
+class ValidationResultResponse(BaseModel):
+    voyage_id: uuid.UUID
+    status: Literal["passed", "failed"]
+    passed_count: int
+    failed_count: int
+    total_count: int
+    summary: str
+```
+
+### 3. LangGraph Graph — `app/crew/doctor_graph.py`
+
+A minimal **two-node** StateGraph (same pattern as Navigator). The graph only
+handles the pre-build test-generation path; post-build validation is not an LLM call.
+
+```
+[generate] → [validate]
+```
+
+**State schema:**
+
+```python
+class DoctorState(TypedDict):
+    poneglyphs: list[dict[str, Any]]  # serialized PoneglyphContentSpec dicts + phase_number
+    raw_output: str
+    health_checks: list[HealthCheckSpec] | None
+    error: str | None
+```
+
+**Nodes:**
+
+- `generate`: builds a user message containing each Poneglyph's `phase_number`,
+  `title`, `task_description`, `test_criteria`, and `file_paths`. Calls
+  `DialSystemRouter.route(CrewRole.DOCTOR, ...)`.
+- `validate`: runs `strip_fences(state["raw_output"])`, `json.loads(...)`, then
+  `DoctorOutputSpec.model_validate(...)`. On any `json.JSONDecodeError`, `ValueError`,
+  or `KeyError`, stores the error string and sets `health_checks=None`.
+
+**System prompt** (constant `DOCTOR_SYSTEM_PROMPT`):
+
+```
+You are the Doctor of a software engineering crew. Your job is to write failing
+health-check tests (TDD) for each phase of the voyage — BEFORE any implementation
+code exists. Your tests should import and reference the modules, classes, and
+functions that the Shipwrights will build from the Poneglyphs; those symbols do
+not exist yet, and that is intentional. A well-written failing test is the
+specification for the implementation.
+
+For each Poneglyph, produce ONE test file. Decide the framework:
+- pytest if the phase's file_paths include .py files (or default when unclear)
+- vitest if the phase's file_paths are .ts/.tsx/.js/.jsx
+
+Each health check must include:
+- phase_number (must match the Poneglyph's phase_number)
+- file_path (where to write the test, e.g., "tests/test_auth.py")
+- content (the complete test source code)
+- framework ("pytest" or "vitest")
+
+Respond with ONLY a JSON object: {"health_checks": [...]}
+Do not include any other text, markdown formatting, or explanation.
+```
+
+**Build function:**
+
+```python
+def build_doctor_graph(dial_router: DialSystemRouter) -> CompiledStateGraph: ...
+```
+
+### 4. Events — add `ValidationFailedEvent`
+
+Add to `app/den_den_mushi/events.py`, symmetric with `ValidationPassedEvent`:
+
+```python
+class ValidationFailedEvent(DenDenMushiEvent):
+    event_type: Literal["validation_failed"] = "validation_failed"
+```
+
+Include it in the `AnyEvent` discriminated union.
+
+### 5. DoctorService — `app/services/doctor_service.py`
+
+```python
+class DoctorError(Exception):
+    def __init__(self, code: str, message: str) -> None:
+        self.code = code
+        self.message = message
+        super().__init__(message)
+
+
+class DoctorService:
+    def __init__(
+        self,
+        dial_router: DialSystemRouter,
+        mushi: DenDenMushi,
+        session: AsyncSession,
+        execution_service: ExecutionService,
+        git_service: GitService | None = None,  # optional
+    ) -> None:
+        self._dial_router = dial_router
+        self._mushi = mushi
+        self._session = session
+        self._execution = execution_service
+        self._git = git_service
+        self._graph = build_doctor_graph(dial_router)
+
+    @classmethod
+    def reader(cls, session: AsyncSession) -> DoctorService:
+        inst = cls.__new__(cls)
+        inst._session = session
+        inst._dial_router = None  # type: ignore[assignment]
+        inst._mushi = None        # type: ignore[assignment]
+        inst._execution = None    # type: ignore[assignment]
+        inst._git = None          # type: ignore[assignment]
+        inst._graph = None        # type: ignore[assignment]
+        return inst
+
+    async def write_health_checks(
+        self,
+        voyage: Voyage,
+        poneglyphs: list[Poneglyph],
+        user_id: uuid.UUID,
+    ) -> list[HealthCheck]: ...
+
+    async def validate_code(
+        self,
+        voyage: Voyage,
+        user_id: uuid.UUID,
+        shipwright_files: dict[str, str],
+    ) -> ValidationResultResponse: ...
+
+    async def get_health_checks(
+        self,
+        voyage_id: uuid.UUID,
+    ) -> list[HealthCheck]: ...
+```
+
+**`write_health_checks` flow:**
+1. Set `voyage.status = TDD`, flush.
+2. Build `graph_input = [{"phase_number": p.phase_number, **json.loads(p.content)}
+   for p in poneglyphs]`. Invoke the graph.
+3. On graph raise: reset status to `CHARTED`, flush, re-raise.
+4. On `health_checks is None`: reset status to `CHARTED`, flush, raise
+   `DoctorError("HEALTH_CHECK_PARSE_FAILED", ...)`.
+5. **Phase alignment check** (Fix #5 lesson from Navigator): every returned
+   `phase_number` must exist in the Poneglyph set. If not, reset status and raise
+   `DoctorError("HEALTH_CHECK_PHASE_MISMATCH", ...)`.
+6. **Replace mode** (Fix #1 lesson): `await session.execute(delete(HealthCheck)
+   .where(HealthCheck.voyage_id == voyage.id))`.
+7. Insert one `HealthCheck` row per spec, linking `poneglyph_id` by matching
+   `phase_number`.
+8. Create a `VivreCard` checkpoint inline (`crew_member="doctor"`,
+   `state_data={"health_check_count": N, "phase_numbers": [...]}`,
+   `checkpoint_reason="health_checks_written"`).
+9. Set `voyage.status = CHARTED`, `await session.commit()`, refresh rows.
+10. **Best-effort git commit** (all in one try/except, after the DB commit):
+    if `self._git is not None` and `voyage.target_repo` is set:
+    - `create_branch(voyage.id, user_id, "doctor", base_branch="main")`
+    - `commit(voyage.id, user_id, "test: add Doctor health checks",
+      crew_member="doctor", files={hc.file_path: hc.content for hc in hcs})`
+    - `push(voyage.id, user_id, branch)`
+    Log warnings on failure — do not fail the request.
+11. **Best-effort event publish** — one `HealthCheckWrittenEvent` per row.
+12. Return persisted health checks.
+
+**`validate_code` flow:**
+1. Set `voyage.status = REVIEWING`, flush.
+2. Load existing health checks via a SELECT (raise `DoctorError("NO_HEALTH_CHECKS",
+   ...)` if none). Reset status first.
+3. Combine `shipwright_files | {hc.file_path: hc.content for hc in hcs}` into a
+   single `files` dict.
+4. Run via `ExecutionService.run(user_id, ExecutionRequest(
+     command="cd /workspace && python -m pytest -x --tb=short",
+     files=files, timeout_seconds=300))`.
+5. Decide pass/fail by `exit_code == 0`.
+6. Parse a simple `passed_count` / `failed_count` from the stdout (count lines
+   matching `PASSED`/`FAILED` from pytest's short summary; fallback to
+   `exit_code == 0` → `passed_count = total`, else `failed_count = total`).
+7. Update each health check row: set `last_run_status = "passed"` or `"failed"`,
+   `last_run_at = utcnow()`, `last_run_output = result.stdout[-4000:]` (truncated).
+8. Restore `voyage.status = CHARTED`, commit.
+9. Publish `ValidationPassedEvent` or `ValidationFailedEvent` best-effort.
+10. Return a `ValidationResultResponse`.
+
+### 6. REST API — `app/api/v1/doctor.py`
+
+Router with prefix `/voyages/{voyage_id}`, tag `doctor`.
+
+| Method | Path | Handler | Response |
+|--------|------|---------|----------|
+| POST | `/health-checks` | `write_health_checks` | 201 → `WriteHealthChecksResponse` |
+| GET  | `/health-checks` | `get_health_checks` | 200 → `HealthCheckListResponse` |
+| POST | `/validation` | `run_validation` | 200 → `ValidationResultResponse` |
+
+**POST `/health-checks` rules:**
+- Voyage must be owned by user and have status `CHARTED` → else 409 `VOYAGE_NOT_TESTABLE`.
+- Must have at least one Poneglyph → else 404 `PONEGLYPHS_NOT_FOUND` (fetch via
+  `NavigatorService.reader(session).get_poneglyphs(voyage_id)`).
+- `DoctorError` → 422 `{"error": {"code": exc.code, "message": exc.message}}`.
+
+**POST `/validation` rules:**
+- Body: `ValidateCodeRequest` (non-empty `files`).
+- Voyage must be in status `CHARTED` → else 409 `VOYAGE_NOT_TESTABLE`.
+- Must have at least one `HealthCheck` → else 404 `NO_HEALTH_CHECKS`.
+- `DoctorError` → 422.
+
+**GET `/health-checks`**: 200 with list (empty list is OK).
+
+**Dependencies:**
+
+```python
+async def get_doctor_service(
+    voyage_id: uuid.UUID,
+    dial_router: DialSystemRouter = Depends(get_dial_router),
+    mushi: DenDenMushi = Depends(get_den_den_mushi),
+    session: AsyncSession = Depends(get_db),
+    execution_service: ExecutionService = Depends(get_execution_service),
+    git_service: GitService = Depends(get_git_service),
+) -> DoctorService:
+    return DoctorService(dial_router, mushi, session, execution_service, git_service)
+
+async def get_doctor_reader(
+    session: AsyncSession = Depends(get_db),
+) -> DoctorService:
+    return DoctorService.reader(session)
+```
+
+Reuse existing dependencies `get_execution_service` and `get_git_service` from
+`app/api/v1/dependencies.py` if present; otherwise add them there (check first).
+Reuse `get_navigator_reader` from `app/api/v1/navigator.py` to fetch Poneglyphs.
+
+### 7. Wiring
+
+- Register `HealthCheck` in `app/models/__init__.py` imports.
+- Add `doctor.router` include in `app/api/v1/router.py`.
+- Add `ValidationFailedEvent` to the `AnyEvent` union in
+  `app/den_den_mushi/events.py`.
+
+## Test Plan
+
+All tests use mocked dependencies (no real LLM, DB, sandbox, or git).
+
+### Schema Tests — `tests/test_doctor_schemas.py`
+
+1. `HealthCheckSpec` accepts valid pytest data.
+2. `HealthCheckSpec` accepts valid vitest data.
+3. `HealthCheckSpec` rejects `phase_number < 1`.
+4. `HealthCheckSpec` rejects empty `file_path`.
+5. `HealthCheckSpec` rejects empty `content`.
+6. `HealthCheckSpec` rejects framework other than pytest/vitest.
+7. `DoctorOutputSpec` rejects empty `health_checks`.
+8. `DoctorOutputSpec` rejects duplicate `file_path`.
+9. `DoctorOutputSpec` accepts multi-phase output.
+10. `ValidateCodeRequest` rejects empty `files`.
+
+### Graph Tests — `tests/test_doctor_graph.py`
+
+1. `generate` node sends `CrewRole.DOCTOR` and stores `raw_output`.
+2. `generate` node includes Poneglyph phase titles and test_criteria in the user
+   message.
+3. `validate` node parses valid JSON.
+4. `validate` node sets error on malformed JSON.
+5. `validate` node sets error on empty `health_checks`.
+6. `validate` node strips ` ```json ... ``` ` fences.
+7. `validate` node strips bare fences.
+8. Full graph success: returns parsed `HealthCheckSpec` list.
+9. Full graph invalid LLM output: sets error, `health_checks=None`.
+
+### Service Tests — `tests/test_doctor_service.py`
+
+Fixtures: mock session (with `.add`, `.flush`, `.commit`, `.execute`), mock
+dial_router, mock mushi (with `.publish`), mock execution_service (with `.run`),
+mock git_service (with `.create_branch`, `.commit`, `.push`). Build a
+`_mock_poneglyph(phase_number, file_paths)` helper whose `.content` is a JSON
+string of a valid `PoneglyphContentSpec`.
+
+**`write_health_checks`:**
+
+1. Sets voyage status to `TDD` during the call.
+2. Invokes dial router with `CrewRole.DOCTOR`.
+3. Persists one `HealthCheck` row per returned spec.
+4. Links `poneglyph_id` by matching `phase_number`.
+5. Stores `content` and `file_path` verbatim from the spec.
+6. Creates one `VivreCard` with `crew_member="doctor"`.
+7. Calls `session.commit()` exactly once.
+8. Restores voyage status to `CHARTED` after success.
+9. Publishes one `HealthCheckWrittenEvent` per health check.
+10. Succeeds even when publish raises (best-effort).
+11. Deletes existing `HealthCheck` rows before inserting new ones (Fix #1 pattern —
+    assert a `Delete` statement is executed).
+12. Raises `DoctorError` with code `HEALTH_CHECK_PARSE_FAILED` on invalid LLM output;
+    status is reset to `CHARTED`.
+13. Raises `DoctorError` with code `HEALTH_CHECK_PHASE_MISMATCH` when an LLM-returned
+    `phase_number` isn't in the Poneglyph set; status reset.
+14. When `git_service` is supplied and `voyage.target_repo` is set, calls
+    `create_branch`, `commit`, `push` once each (best-effort).
+15. When `git_service` is `None`, does not attempt git operations, and the call
+    still succeeds.
+16. When `git_service.commit` raises, the service still returns successfully and
+    logs a warning (best-effort).
+
+**`validate_code`:**
+
+17. Sets voyage status to `REVIEWING` during the call.
+18. Layers `shipwright_files` and stored `HealthCheck.content` into
+    `ExecutionRequest.files`.
+19. Calls `ExecutionService.run` with a pytest command.
+20. Returns `status="passed"` with updated counts when `exit_code=0`.
+21. Returns `status="failed"` with updated counts when `exit_code!=0`.
+22. Updates each `HealthCheck.last_run_status`, `.last_run_output`, `.last_run_at`.
+23. Commits DB changes exactly once.
+24. Restores voyage status to `CHARTED` after success.
+25. Publishes `ValidationPassedEvent` on pass.
+26. Publishes `ValidationFailedEvent` on fail.
+27. Raises `DoctorError("NO_HEALTH_CHECKS", ...)` when no rows exist; status reset.
+
+**`get_health_checks`:**
+
+28. Returns rows ordered by `phase_number`.
+29. Returns empty list when none exist.
+30. Reader instance can call it (no dial_router required).
+
+### API Tests — `tests/test_doctor_api.py`
+
+1. POST `/health-checks` returns 201 with IDs.
+2. POST `/health-checks` returns 409 when voyage not `CHARTED`.
+3. POST `/health-checks` returns 404 when no Poneglyphs exist.
+4. POST `/health-checks` returns 422 on `DoctorError`.
+5. GET `/health-checks` returns 200 with list.
+6. GET `/health-checks` returns 200 with empty list.
+7. POST `/validation` returns 200 with `status="passed"`.
+8. POST `/validation` returns 200 with `status="failed"`.
+9. POST `/validation` returns 409 when voyage not `CHARTED`.
+10. POST `/validation` returns 404 when no health checks exist.
+11. POST `/validation` returns 422 on `DoctorError`.
+
+## Constraints
+
+- Mock every external: no real LLM, no real DB, no real sandbox, no real git.
+- Keep the graph minimal (2 nodes). No retry loops.
+- Follow Navigator/Captain patterns exactly: `strip_fences` from
+  `app/crew/utils.py`, `reader()` factory, atomic DB commit before events,
+  best-effort publish.
+- **Delete-before-insert** for `write_health_checks` — re-draft replaces.
+- **Phase alignment** — LLM-returned `phase_number` must be a subset of the
+  Poneglyph set; otherwise `HEALTH_CHECK_PHASE_MISMATCH`.
+- **Status lifecycle** — transient `TDD` or `REVIEWING`, restored to `CHARTED` on
+  both success and failure so the voyage remains actionable.
+- Git commit path is **best-effort and opt-in** — wrapped in a single try/except,
+  logs a warning on failure, never fails the request.
+- Reuse `Poneglyph` rows via `NavigatorService.reader(session).get_poneglyphs(...)`.
+- Reuse `HealthCheckWrittenEvent` and `ValidationPassedEvent`; add
+  `ValidationFailedEvent` to `events.py` + `AnyEvent` union.
+- Single Dial System call per `write_health_checks` (one JSON batch for all
+  phases). Validation failures of the batch fail the whole call — no partial
+  writes.
+- `last_run_output` is truncated to the last 4000 chars to keep rows small.
+- Pytest invocation is `python -m pytest -x --tb=short`. Counting pass/fail is
+  best-effort from stdout; when parsing fails, fall back to `exit_code == 0` →
+  `passed_count = total_count`, else `failed_count = total_count`.

--- a/src/backend/alembic/versions/a1b2c3d4e5f6_health_checks.py
+++ b/src/backend/alembic/versions/a1b2c3d4e5f6_health_checks.py
@@ -1,4 +1,4 @@
-"""health_checks
+"""health_checks and validation_runs
 
 Revision ID: a1b2c3d4e5f6
 Revises: 00b24ef2f7d8
@@ -21,6 +21,30 @@ depends_on: str | Sequence[str] | None = None
 
 def upgrade() -> None:
     op.create_table(
+        "validation_runs",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "voyage_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("voyages.id"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column("status", sa.String(20), nullable=False),
+        sa.Column("exit_code", sa.Integer(), nullable=False),
+        sa.Column("passed_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("failed_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("total_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("output", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+
+    op.create_table(
         "health_checks",
         sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
         sa.Column(
@@ -42,9 +66,13 @@ def upgrade() -> None:
         sa.Column("content", sa.Text(), nullable=False),
         sa.Column("framework", sa.String(20), nullable=False, server_default="pytest"),
         sa.Column("last_run_status", sa.String(20), nullable=True),
-        sa.Column("last_run_output", sa.Text(), nullable=True),
         sa.Column("last_run_at", sa.DateTime(timezone=True), nullable=True),
-        sa.Column("metadata", postgresql.JSONB(), nullable=True),
+        sa.Column(
+            "last_validation_run_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("validation_runs.id"),
+            nullable=True,
+        ),
         sa.Column("created_by", sa.String(50), nullable=False, server_default="doctor"),
         sa.Column(
             "created_at",
@@ -57,3 +85,4 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     op.drop_table("health_checks")
+    op.drop_table("validation_runs")

--- a/src/backend/alembic/versions/a1b2c3d4e5f6_health_checks.py
+++ b/src/backend/alembic/versions/a1b2c3d4e5f6_health_checks.py
@@ -1,0 +1,59 @@
+"""health_checks
+
+Revision ID: a1b2c3d4e5f6
+Revises: 00b24ef2f7d8
+Create Date: 2026-04-16
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "a1b2c3d4e5f6"
+down_revision: str | None = "00b24ef2f7d8"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "health_checks",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "voyage_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("voyages.id"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column(
+            "poneglyph_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("poneglyphs.id"),
+            nullable=True,
+            index=True,
+        ),
+        sa.Column("phase_number", sa.Integer(), nullable=False),
+        sa.Column("file_path", sa.String(500), nullable=False),
+        sa.Column("content", sa.Text(), nullable=False),
+        sa.Column("framework", sa.String(20), nullable=False, server_default="pytest"),
+        sa.Column("last_run_status", sa.String(20), nullable=True),
+        sa.Column("last_run_output", sa.Text(), nullable=True),
+        sa.Column("last_run_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("metadata", postgresql.JSONB(), nullable=True),
+        sa.Column("created_by", sa.String(50), nullable=False, server_default="doctor"),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("health_checks")

--- a/src/backend/app/api/v1/doctor.py
+++ b/src/backend/app/api/v1/doctor.py
@@ -1,0 +1,157 @@
+"""Doctor Agent REST API endpoints."""
+
+from __future__ import annotations
+
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.v1.dependencies import (
+    get_authorized_voyage,
+    get_current_user,
+    get_den_den_mushi,
+    get_dial_router,
+    get_execution_service,
+    get_git_service,
+)
+from app.api.v1.navigator import get_navigator_reader
+from app.den_den_mushi.mushi import DenDenMushi
+from app.dial_system.router import DialSystemRouter
+from app.models import get_db
+from app.models.enums import VoyageStatus
+from app.models.user import User
+from app.models.voyage import Voyage
+from app.schemas.doctor import (
+    HealthCheckListResponse,
+    ValidateCodeRequest,
+    ValidationResultResponse,
+    WriteHealthChecksResponse,
+)
+from app.schemas.health_check import HealthCheckRead
+from app.services.doctor_service import DoctorError, DoctorService
+from app.services.execution_service import ExecutionService
+from app.services.git_service import GitService
+from app.services.navigator_service import NavigatorService
+
+router = APIRouter(prefix="/voyages/{voyage_id}", tags=["doctor"])
+
+
+async def get_doctor_service(
+    voyage_id: uuid.UUID,
+    dial_router: DialSystemRouter = Depends(get_dial_router),
+    mushi: DenDenMushi = Depends(get_den_den_mushi),
+    session: AsyncSession = Depends(get_db),
+    execution_service: ExecutionService = Depends(get_execution_service),
+    git_service: GitService = Depends(get_git_service),
+) -> DoctorService:
+    return DoctorService(
+        dial_router,
+        mushi,
+        session,
+        execution_service=execution_service,
+        git_service=git_service,
+    )
+
+
+async def get_doctor_reader(
+    session: AsyncSession = Depends(get_db),
+) -> DoctorService:
+    """Lightweight dependency for read-only doctor operations."""
+    return DoctorService.reader(session)
+
+
+@router.post(
+    "/health-checks",
+    response_model=WriteHealthChecksResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def write_health_checks(
+    voyage_id: uuid.UUID,
+    user: User = Depends(get_current_user),
+    voyage: Voyage = Depends(get_authorized_voyage),
+    doctor_service: DoctorService = Depends(get_doctor_service),
+    navigator_reader: NavigatorService = Depends(get_navigator_reader),
+) -> WriteHealthChecksResponse:
+    if voyage.status != VoyageStatus.CHARTED.value:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "error": {
+                    "code": "VOYAGE_NOT_CHARTABLE",
+                    "message": f"Voyage status is {voyage.status}, expected CHARTED",
+                }
+            },
+        )
+
+    poneglyphs = await navigator_reader.get_poneglyphs(voyage_id)
+    if not poneglyphs:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={
+                "error": {
+                    "code": "PONEGLYPHS_NOT_FOUND",
+                    "message": "No Poneglyphs exist — run Navigator first",
+                }
+            },
+        )
+
+    try:
+        health_checks = await doctor_service.write_health_checks(voyage, poneglyphs, user.id)
+    except DoctorError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail={"error": {"code": exc.code, "message": exc.message}},
+        ) from exc
+
+    return WriteHealthChecksResponse(
+        voyage_id=voyage_id,
+        health_check_ids=[hc.id for hc in health_checks],
+        count=len(health_checks),
+    )
+
+
+@router.get("/health-checks", response_model=HealthCheckListResponse)
+async def get_health_checks(
+    voyage_id: uuid.UUID,
+    user: User = Depends(get_current_user),
+    voyage: Voyage = Depends(get_authorized_voyage),
+    doctor_service: DoctorService = Depends(get_doctor_reader),
+) -> HealthCheckListResponse:
+    health_checks = await doctor_service.get_health_checks(voyage_id)
+    return HealthCheckListResponse(
+        voyage_id=voyage_id,
+        health_checks=[HealthCheckRead.model_validate(hc) for hc in health_checks],
+    )
+
+
+@router.post(
+    "/validation",
+    response_model=ValidationResultResponse,
+    status_code=status.HTTP_200_OK,
+)
+async def run_validation(
+    voyage_id: uuid.UUID,
+    body: ValidateCodeRequest,
+    user: User = Depends(get_current_user),
+    voyage: Voyage = Depends(get_authorized_voyage),
+    doctor_service: DoctorService = Depends(get_doctor_service),
+) -> ValidationResultResponse:
+    if voyage.status != VoyageStatus.CHARTED.value:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "error": {
+                    "code": "VOYAGE_NOT_CHARTABLE",
+                    "message": f"Voyage status is {voyage.status}, expected CHARTED",
+                }
+            },
+        )
+
+    try:
+        return await doctor_service.validate_code(voyage, user.id, body.files)
+    except DoctorError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail={"error": {"code": exc.code, "message": exc.message}},
+        ) from exc

--- a/src/backend/app/api/v1/doctor.py
+++ b/src/backend/app/api/v1/doctor.py
@@ -136,6 +136,7 @@ async def run_validation(
     user: User = Depends(get_current_user),
     voyage: Voyage = Depends(get_authorized_voyage),
     doctor_service: DoctorService = Depends(get_doctor_service),
+    doctor_reader: DoctorService = Depends(get_doctor_reader),
 ) -> ValidationResultResponse:
     if voyage.status != VoyageStatus.CHARTED.value:
         raise HTTPException(
@@ -144,6 +145,18 @@ async def run_validation(
                 "error": {
                     "code": "VOYAGE_NOT_CHARTABLE",
                     "message": f"Voyage status is {voyage.status}, expected CHARTED",
+                }
+            },
+        )
+
+    existing = await doctor_reader.get_health_checks(voyage_id)
+    if not existing:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={
+                "error": {
+                    "code": "NO_HEALTH_CHECKS",
+                    "message": "No health checks exist — run Doctor (write) first",
                 }
             },
         )

--- a/src/backend/app/api/v1/router.py
+++ b/src/backend/app/api/v1/router.py
@@ -3,6 +3,7 @@ from fastapi import APIRouter
 from app.api.v1.auth import router as auth_router
 from app.api.v1.captain import router as captain_router
 from app.api.v1.dial import router as dial_router
+from app.api.v1.doctor import router as doctor_router
 from app.api.v1.execution import router as execution_router
 from app.api.v1.git import router as git_router
 from app.api.v1.health import router as health_router
@@ -18,3 +19,4 @@ v1_router.include_router(execution_router)
 v1_router.include_router(git_router)
 v1_router.include_router(captain_router)
 v1_router.include_router(navigator_router)
+v1_router.include_router(doctor_router)

--- a/src/backend/app/crew/doctor_graph.py
+++ b/src/backend/app/crew/doctor_graph.py
@@ -1,0 +1,90 @@
+"""Doctor Agent LangGraph — generates failing health-check tests from Poneglyphs."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, TypedDict
+
+from langgraph.graph import END, StateGraph
+from langgraph.graph.state import CompiledStateGraph
+
+from app.crew.utils import strip_fences
+from app.dial_system.router import DialSystemRouter
+from app.models.enums import CrewRole
+from app.schemas.dial_system import CompletionRequest
+from app.schemas.doctor import DoctorOutputSpec, HealthCheckSpec
+
+DOCTOR_SYSTEM_PROMPT = """\
+You are the Doctor of a software engineering crew. Your job is to write failing \
+health-check tests (TDD) for each phase of the voyage — BEFORE any implementation \
+code exists. Your tests should import and reference the modules, classes, and \
+functions that the Shipwrights will build from the Poneglyphs; those symbols do \
+not exist yet, and that is intentional. A well-written failing test is the \
+specification for the implementation.
+
+For each Poneglyph, produce ONE test file. Decide the framework:
+- pytest if the phase's file_paths include .py files (or default when unclear)
+- vitest if the phase's file_paths are .ts/.tsx/.js/.jsx
+
+Each health check must include:
+- phase_number (must match the Poneglyph's phase_number)
+- file_path (where to write the test, e.g., "tests/test_auth.py")
+- content (the complete test source code)
+- framework ("pytest" or "vitest")
+
+Respond with ONLY a JSON object: {"health_checks": [...]}
+Do not include any other text, markdown formatting, or explanation."""
+
+
+class DoctorState(TypedDict):
+    poneglyphs: list[dict[str, Any]]
+    raw_output: str
+    health_checks: list[HealthCheckSpec] | None
+    error: str | None
+
+
+async def generate(
+    state: DoctorState,
+    dial_router: DialSystemRouter,
+) -> dict[str, Any]:
+    """Call the LLM to generate health checks for each Poneglyph."""
+    poneglyphs_json = json.dumps(state["poneglyphs"], indent=2)
+    request = CompletionRequest(
+        messages=[
+            {"role": "system", "content": DOCTOR_SYSTEM_PROMPT},
+            {"role": "user", "content": poneglyphs_json},
+        ],
+        role=CrewRole.DOCTOR,
+    )
+    result = await dial_router.route(CrewRole.DOCTOR, request)
+    return {"raw_output": result.content}
+
+
+def validate(state: DoctorState) -> dict[str, Any]:
+    """Parse raw LLM output into validated HealthCheckSpec list."""
+    try:
+        raw = strip_fences(state["raw_output"])
+        data = json.loads(raw)
+        spec = DoctorOutputSpec.model_validate(data)
+        return {"health_checks": spec.health_checks, "error": None}
+    except (json.JSONDecodeError, ValueError, KeyError) as exc:
+        return {"health_checks": None, "error": str(exc)}
+
+
+def build_doctor_graph(
+    dial_router: DialSystemRouter,
+) -> CompiledStateGraph:  # type: ignore[type-arg]
+    """Build and compile the Doctor's two-node graph."""
+    graph = StateGraph(DoctorState)
+
+    async def _generate(state: DoctorState) -> dict[str, Any]:
+        return await generate(state, dial_router)
+
+    graph.add_node("generate", _generate)
+    graph.add_node("validate", validate)
+
+    graph.set_entry_point("generate")
+    graph.add_edge("generate", "validate")
+    graph.add_edge("validate", END)
+
+    return graph.compile()

--- a/src/backend/app/den_den_mushi/events.py
+++ b/src/backend/app/den_den_mushi/events.py
@@ -40,6 +40,10 @@ class ValidationPassedEvent(DenDenMushiEvent):
     event_type: Literal["validation_passed"] = "validation_passed"
 
 
+class ValidationFailedEvent(DenDenMushiEvent):
+    event_type: Literal["validation_failed"] = "validation_failed"
+
+
 class DeploymentCompletedEvent(DenDenMushiEvent):
     event_type: Literal["deployment_completed"] = "deployment_completed"
 
@@ -58,6 +62,7 @@ AnyEvent = Annotated[
     | HealthCheckWrittenEvent
     | CodeGeneratedEvent
     | ValidationPassedEvent
+    | ValidationFailedEvent
     | DeploymentCompletedEvent
     | ProviderSwitchedEvent
     | CheckpointCreatedEvent,

--- a/src/backend/app/models/__init__.py
+++ b/src/backend/app/models/__init__.py
@@ -19,6 +19,7 @@ async def get_db() -> AsyncSession:  # type: ignore[misc]
 # Import all models so Alembic can detect them
 from app.models.crew_action import CrewAction  # noqa: E402, F401
 from app.models.dial_config import DialConfig  # noqa: E402, F401
+from app.models.health_check import HealthCheck  # noqa: E402, F401
 from app.models.poneglyph import Poneglyph  # noqa: E402, F401
 from app.models.user import User  # noqa: E402, F401
 from app.models.vivre_card import VivreCard  # noqa: E402, F401

--- a/src/backend/app/models/__init__.py
+++ b/src/backend/app/models/__init__.py
@@ -22,5 +22,6 @@ from app.models.dial_config import DialConfig  # noqa: E402, F401
 from app.models.health_check import HealthCheck  # noqa: E402, F401
 from app.models.poneglyph import Poneglyph  # noqa: E402, F401
 from app.models.user import User  # noqa: E402, F401
+from app.models.validation_run import ValidationRun  # noqa: E402, F401
 from app.models.vivre_card import VivreCard  # noqa: E402, F401
 from app.models.voyage import Voyage, VoyagePlan  # noqa: E402, F401

--- a/src/backend/app/models/health_check.py
+++ b/src/backend/app/models/health_check.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import DateTime, ForeignKey, Integer, String, Text, func
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models import Base
+
+
+class HealthCheck(Base):
+    __tablename__ = "health_checks"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    voyage_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("voyages.id"), index=True, nullable=False
+    )
+    poneglyph_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("poneglyphs.id"), index=True, nullable=True
+    )
+    phase_number: Mapped[int] = mapped_column(Integer, nullable=False)
+    file_path: Mapped[str] = mapped_column(String(500), nullable=False)
+    content: Mapped[str] = mapped_column(Text, nullable=False)
+    framework: Mapped[str] = mapped_column(String(20), default="pytest", nullable=False)
+    last_run_status: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    last_run_output: Mapped[str | None] = mapped_column(Text, nullable=True)
+    last_run_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    metadata_: Mapped[dict[str, Any] | None] = mapped_column("metadata", JSONB, nullable=True)
+    created_by: Mapped[str] = mapped_column(String(50), default="doctor", nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )

--- a/src/backend/app/models/health_check.py
+++ b/src/backend/app/models/health_check.py
@@ -2,10 +2,9 @@ from __future__ import annotations
 
 import uuid
 from datetime import datetime
-from typing import Any
 
 from sqlalchemy import DateTime, ForeignKey, Integer, String, Text, func
-from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.models import Base
@@ -26,9 +25,10 @@ class HealthCheck(Base):
     content: Mapped[str] = mapped_column(Text, nullable=False)
     framework: Mapped[str] = mapped_column(String(20), default="pytest", nullable=False)
     last_run_status: Mapped[str | None] = mapped_column(String(20), nullable=True)
-    last_run_output: Mapped[str | None] = mapped_column(Text, nullable=True)
     last_run_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
-    metadata_: Mapped[dict[str, Any] | None] = mapped_column("metadata", JSONB, nullable=True)
+    last_validation_run_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("validation_runs.id"), nullable=True
+    )
     created_by: Mapped[str] = mapped_column(String(50), default="doctor", nullable=False)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False

--- a/src/backend/app/models/validation_run.py
+++ b/src/backend/app/models/validation_run.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, Integer, String, Text, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models import Base
+
+
+class ValidationRun(Base):
+    __tablename__ = "validation_runs"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    voyage_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("voyages.id"), index=True, nullable=False
+    )
+    status: Mapped[str] = mapped_column(String(20), nullable=False)
+    exit_code: Mapped[int] = mapped_column(Integer, nullable=False)
+    passed_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    failed_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    total_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    output: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )

--- a/src/backend/app/schemas/doctor.py
+++ b/src/backend/app/schemas/doctor.py
@@ -2,12 +2,27 @@
 
 from __future__ import annotations
 
+import posixpath
 import uuid
 from typing import Literal
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 from app.schemas.health_check import HealthCheckRead
+
+
+def _validate_relative_path(path: str) -> str:
+    """Reject absolute paths and path-traversal segments."""
+    if path.startswith("/") or path.startswith("\\"):
+        raise ValueError(f"Path must be relative, got {path!r}")
+    if ":" in path.split("/")[0]:
+        raise ValueError(f"Path must not be a drive/scheme, got {path!r}")
+    normalized = posixpath.normpath(path)
+    if normalized.startswith("..") or "/../" in f"/{normalized}/":
+        raise ValueError(f"Path traversal not allowed in {path!r}")
+    if normalized in (".", ""):
+        raise ValueError(f"Path must not be empty, got {path!r}")
+    return path
 
 
 class HealthCheckSpec(BaseModel):
@@ -17,6 +32,11 @@ class HealthCheckSpec(BaseModel):
     file_path: str = Field(min_length=1, max_length=500)
     content: str = Field(min_length=1)
     framework: Literal["pytest", "vitest"] = "pytest"
+
+    @field_validator("file_path")
+    @classmethod
+    def _validate_file_path(cls, v: str) -> str:
+        return _validate_relative_path(v)
 
 
 class DoctorOutputSpec(BaseModel):
@@ -50,6 +70,13 @@ class HealthCheckListResponse(BaseModel):
 
 class ValidateCodeRequest(BaseModel):
     files: dict[str, str] = Field(min_length=1)
+
+    @field_validator("files")
+    @classmethod
+    def _validate_file_paths(cls, v: dict[str, str]) -> dict[str, str]:
+        for path in v:
+            _validate_relative_path(path)
+        return v
 
 
 class ValidationResultResponse(BaseModel):

--- a/src/backend/app/schemas/doctor.py
+++ b/src/backend/app/schemas/doctor.py
@@ -1,0 +1,61 @@
+"""Schemas for Doctor Agent (QA)."""
+
+from __future__ import annotations
+
+import uuid
+from typing import Literal
+
+from pydantic import BaseModel, Field, model_validator
+
+from app.schemas.health_check import HealthCheckRead
+
+
+class HealthCheckSpec(BaseModel):
+    """Structured content the LLM generates for one health check test file."""
+
+    phase_number: int = Field(ge=1)
+    file_path: str = Field(min_length=1, max_length=500)
+    content: str = Field(min_length=1)
+    framework: Literal["pytest", "vitest"] = "pytest"
+
+
+class DoctorOutputSpec(BaseModel):
+    """Full LLM output: health checks for all phases."""
+
+    health_checks: list[HealthCheckSpec] = Field(min_length=1)
+
+    @model_validator(mode="after")
+    def validate_unique_file_paths(self) -> DoctorOutputSpec:
+        """Reject duplicate file_path values."""
+        paths = [hc.file_path for hc in self.health_checks]
+        if len(paths) != len(set(paths)):
+            seen: set[str] = set()
+            for p in paths:
+                if p in seen:
+                    raise ValueError(f"Duplicate file_path {p!r}")
+                seen.add(p)
+        return self
+
+
+class WriteHealthChecksResponse(BaseModel):
+    voyage_id: uuid.UUID
+    health_check_ids: list[uuid.UUID]
+    count: int
+
+
+class HealthCheckListResponse(BaseModel):
+    voyage_id: uuid.UUID
+    health_checks: list[HealthCheckRead]
+
+
+class ValidateCodeRequest(BaseModel):
+    files: dict[str, str] = Field(min_length=1)
+
+
+class ValidationResultResponse(BaseModel):
+    voyage_id: uuid.UUID
+    status: Literal["passed", "failed"]
+    passed_count: int
+    failed_count: int
+    total_count: int
+    summary: str

--- a/src/backend/app/schemas/health_check.py
+++ b/src/backend/app/schemas/health_check.py
@@ -1,6 +1,5 @@
 import uuid
 from datetime import datetime
-from typing import Any
 
 from pydantic import BaseModel, ConfigDict
 
@@ -16,8 +15,7 @@ class HealthCheckRead(BaseModel):
     content: str
     framework: str
     last_run_status: str | None
-    last_run_output: str | None
     last_run_at: datetime | None
-    metadata_: dict[str, Any] | None
+    last_validation_run_id: uuid.UUID | None
     created_by: str
     created_at: datetime

--- a/src/backend/app/schemas/health_check.py
+++ b/src/backend/app/schemas/health_check.py
@@ -1,0 +1,23 @@
+import uuid
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict
+
+
+class HealthCheckRead(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    voyage_id: uuid.UUID
+    poneglyph_id: uuid.UUID | None
+    phase_number: int
+    file_path: str
+    content: str
+    framework: str
+    last_run_status: str | None
+    last_run_output: str | None
+    last_run_at: datetime | None
+    metadata_: dict[str, Any] | None
+    created_by: str
+    created_at: datetime

--- a/src/backend/app/services/doctor_service.py
+++ b/src/backend/app/services/doctor_service.py
@@ -1,0 +1,349 @@
+"""DoctorService — orchestrates health-check generation and code validation."""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.crew.doctor_graph import build_doctor_graph
+from app.den_den_mushi.constants import stream_key
+from app.den_den_mushi.events import (
+    HealthCheckWrittenEvent,
+    ValidationFailedEvent,
+    ValidationPassedEvent,
+)
+from app.den_den_mushi.mushi import DenDenMushi
+from app.dial_system.router import DialSystemRouter
+from app.models.enums import CrewRole, VoyageStatus
+from app.models.health_check import HealthCheck
+from app.models.poneglyph import Poneglyph
+from app.models.vivre_card import VivreCard
+from app.models.voyage import Voyage
+from app.schemas.doctor import HealthCheckSpec, ValidationResultResponse
+from app.schemas.execution import ExecutionRequest
+from app.services.execution_service import ExecutionService
+from app.services.git_service import GitService
+
+logger = logging.getLogger(__name__)
+
+_PYTEST_SUMMARY_RE = re.compile(
+    r"(?P<passed>\d+)\s+passed|(?P<failed>\d+)\s+failed",
+    re.IGNORECASE,
+)
+_OUTPUT_TRUNCATE = 4000
+
+
+class DoctorError(Exception):
+    """Raised when Doctor agent operations fail."""
+
+    def __init__(self, code: str, message: str) -> None:
+        self.code = code
+        self.message = message
+        super().__init__(message)
+
+
+class DoctorService:
+    def __init__(
+        self,
+        dial_router: DialSystemRouter,
+        mushi: DenDenMushi,
+        session: AsyncSession,
+        execution_service: ExecutionService,
+        git_service: GitService | None = None,
+    ) -> None:
+        self._dial_router = dial_router
+        self._mushi = mushi
+        self._session = session
+        self._execution = execution_service
+        self._git = git_service
+        self._graph = build_doctor_graph(dial_router)
+
+    @classmethod
+    def reader(cls, session: AsyncSession) -> DoctorService:
+        """Create a read-only instance that only needs a DB session."""
+        inst = cls.__new__(cls)
+        inst._session = session
+        inst._dial_router = None  # type: ignore[assignment]
+        inst._mushi = None  # type: ignore[assignment]
+        inst._execution = None  # type: ignore[assignment]
+        inst._git = None
+        inst._graph = None  # type: ignore[assignment]
+        return inst
+
+    async def write_health_checks(
+        self,
+        voyage: Voyage,
+        poneglyphs: list[Poneglyph],
+        user_id: uuid.UUID,
+    ) -> list[HealthCheck]:
+        voyage.status = VoyageStatus.TDD.value
+        await self._session.flush()
+
+        graph_input = _poneglyphs_to_graph_input(poneglyphs)
+
+        try:
+            result = await self._graph.ainvoke(
+                {
+                    "poneglyphs": graph_input,
+                    "raw_output": "",
+                    "health_checks": None,
+                    "error": None,
+                }
+            )
+        except Exception:
+            voyage.status = VoyageStatus.CHARTED.value
+            await self._session.flush()
+            raise
+
+        specs: list[HealthCheckSpec] | None = result.get("health_checks")
+        if specs is None:
+            voyage.status = VoyageStatus.CHARTED.value
+            await self._session.flush()
+            error = result.get("error", "Unknown error")
+            raise DoctorError(
+                "HEALTH_CHECK_PARSE_FAILED",
+                f"Failed to parse health checks: {error}",
+            )
+
+        poneglyph_phase_numbers = {p.phase_number for p in poneglyphs}
+        spec_phase_numbers = {s.phase_number for s in specs}
+        if not spec_phase_numbers.issubset(poneglyph_phase_numbers):
+            voyage.status = VoyageStatus.CHARTED.value
+            await self._session.flush()
+            raise DoctorError(
+                "HEALTH_CHECK_PHASE_MISMATCH",
+                (
+                    f"Health-check phases {sorted(spec_phase_numbers)} are not a subset"
+                    f" of Poneglyph phases {sorted(poneglyph_phase_numbers)}"
+                ),
+            )
+
+        await self._session.execute(delete(HealthCheck).where(HealthCheck.voyage_id == voyage.id))
+
+        poneglyph_by_phase: dict[int, Poneglyph] = {p.phase_number: p for p in poneglyphs}
+        health_checks: list[HealthCheck] = []
+        for spec in specs:
+            linked = poneglyph_by_phase.get(spec.phase_number)
+            hc = HealthCheck(
+                voyage_id=voyage.id,
+                poneglyph_id=linked.id if linked else None,
+                phase_number=spec.phase_number,
+                file_path=spec.file_path,
+                content=spec.content,
+                framework=spec.framework,
+                metadata_={"framework": spec.framework},
+                created_by="doctor",
+            )
+            self._session.add(hc)
+            health_checks.append(hc)
+
+        card = VivreCard(
+            voyage_id=voyage.id,
+            crew_member="doctor",
+            state_data={
+                "health_check_count": len(health_checks),
+                "phase_numbers": [s.phase_number for s in specs],
+            },
+            checkpoint_reason="health_checks_written",
+        )
+        self._session.add(card)
+
+        voyage.status = VoyageStatus.CHARTED.value
+
+        await self._session.commit()
+        for hc in health_checks:
+            await self._session.refresh(hc)
+
+        await self._maybe_commit_to_git(voyage, user_id, health_checks)
+
+        try:
+            for hc in health_checks:
+                event = HealthCheckWrittenEvent(
+                    voyage_id=voyage.id,
+                    source_role=CrewRole.DOCTOR,
+                    payload={
+                        "health_check_id": str(hc.id),
+                        "phase_number": hc.phase_number,
+                        "file_path": hc.file_path,
+                    },
+                )
+                await self._mushi.publish(stream_key(voyage.id), event)
+        except Exception:
+            logger.warning(
+                "Failed to publish health_check_written events for voyage %s",
+                voyage.id,
+                exc_info=True,
+            )
+
+        return health_checks
+
+    async def _maybe_commit_to_git(
+        self,
+        voyage: Voyage,
+        user_id: uuid.UUID,
+        health_checks: list[HealthCheck],
+    ) -> None:
+        """Best-effort: push the health checks to the Doctor's git branch."""
+        if self._git is None or not voyage.target_repo:
+            return
+        try:
+            await self._git.create_branch(voyage.id, user_id, "doctor", "main")
+            files = {hc.file_path: hc.content for hc in health_checks}
+            await self._git.commit(
+                voyage.id,
+                user_id,
+                "test: add Doctor health checks",
+                crew_member="doctor",
+                files=files,
+            )
+            branch = f"agent/doctor/{voyage.id.hex[:8]}"
+            await self._git.push(voyage.id, user_id, branch)
+        except Exception:
+            logger.warning(
+                "Git commit failed for Doctor health checks on voyage %s",
+                voyage.id,
+                exc_info=True,
+            )
+
+    async def validate_code(
+        self,
+        voyage: Voyage,
+        user_id: uuid.UUID,
+        shipwright_files: dict[str, str],
+    ) -> ValidationResultResponse:
+        voyage.status = VoyageStatus.REVIEWING.value
+        await self._session.flush()
+
+        result = await self._session.execute(
+            select(HealthCheck)
+            .where(HealthCheck.voyage_id == voyage.id)
+            .order_by(HealthCheck.phase_number)
+        )
+        health_checks = list(result.scalars().all())
+
+        if not health_checks:
+            voyage.status = VoyageStatus.CHARTED.value
+            await self._session.flush()
+            raise DoctorError(
+                "NO_HEALTH_CHECKS",
+                "No health checks found for voyage — run Doctor (write) first",
+            )
+
+        layered_files = dict(shipwright_files)
+        for hc in health_checks:
+            layered_files[hc.file_path] = hc.content
+
+        exec_request = ExecutionRequest(
+            command="cd /workspace && python -m pytest -x --tb=short",
+            files=layered_files,
+            timeout_seconds=300,
+        )
+        exec_result = await self._execution.run(user_id, exec_request)
+
+        passed = exec_result.exit_code == 0
+        status_str = "passed" if passed else "failed"
+        passed_count, failed_count = _parse_counts(
+            exec_result.stdout, passed=passed, total=len(health_checks)
+        )
+        truncated = (exec_result.stdout or "")[-_OUTPUT_TRUNCATE:]
+        now = datetime.now(UTC)
+        for hc in health_checks:
+            hc.last_run_status = status_str
+            hc.last_run_output = truncated
+            hc.last_run_at = now
+
+        voyage.status = VoyageStatus.CHARTED.value
+        await self._session.commit()
+
+        response = ValidationResultResponse(
+            voyage_id=voyage.id,
+            status=status_str,
+            passed_count=passed_count,
+            failed_count=failed_count,
+            total_count=len(health_checks),
+            summary=truncated[-500:],
+        )
+
+        try:
+            payload = {
+                "passed_count": passed_count,
+                "failed_count": failed_count,
+                "total_count": len(health_checks),
+            }
+            event: ValidationPassedEvent | ValidationFailedEvent
+            if passed:
+                event = ValidationPassedEvent(
+                    voyage_id=voyage.id,
+                    source_role=CrewRole.DOCTOR,
+                    payload=payload,
+                )
+            else:
+                event = ValidationFailedEvent(
+                    voyage_id=voyage.id,
+                    source_role=CrewRole.DOCTOR,
+                    payload=payload,
+                )
+            await self._mushi.publish(stream_key(voyage.id), event)
+        except Exception:
+            logger.warning(
+                "Failed to publish validation event for voyage %s",
+                voyage.id,
+                exc_info=True,
+            )
+
+        return response
+
+    async def get_health_checks(
+        self,
+        voyage_id: uuid.UUID,
+    ) -> list[HealthCheck]:
+        result = await self._session.execute(
+            select(HealthCheck)
+            .where(HealthCheck.voyage_id == voyage_id)
+            .order_by(HealthCheck.phase_number)
+        )
+        return list(result.scalars().all())
+
+
+def _poneglyphs_to_graph_input(poneglyphs: list[Poneglyph]) -> list[dict[str, Any]]:
+    """Flatten each Poneglyph's persisted content for the graph input."""
+    out: list[dict[str, Any]] = []
+    for p in poneglyphs:
+        try:
+            content = json.loads(p.content)
+        except (json.JSONDecodeError, TypeError):
+            content = {}
+        out.append(
+            {
+                "phase_number": p.phase_number,
+                "title": content.get("title"),
+                "task_description": content.get("task_description"),
+                "test_criteria": content.get("test_criteria", []),
+                "file_paths": content.get("file_paths", []),
+            }
+        )
+    return out
+
+
+def _parse_counts(stdout: str, passed: bool, total: int) -> tuple[int, int]:
+    """Best-effort parse pytest summary for passed/failed counts."""
+    passed_count = 0
+    failed_count = 0
+    for match in _PYTEST_SUMMARY_RE.finditer(stdout or ""):
+        if match.group("passed"):
+            passed_count += int(match.group("passed"))
+        elif match.group("failed"):
+            failed_count += int(match.group("failed"))
+    if passed_count == 0 and failed_count == 0:
+        if passed:
+            passed_count = total
+        else:
+            failed_count = total
+    return passed_count, failed_count

--- a/src/backend/app/services/doctor_service.py
+++ b/src/backend/app/services/doctor_service.py
@@ -24,6 +24,7 @@ from app.dial_system.router import DialSystemRouter
 from app.models.enums import CrewRole, VoyageStatus
 from app.models.health_check import HealthCheck
 from app.models.poneglyph import Poneglyph
+from app.models.validation_run import ValidationRun
 from app.models.vivre_card import VivreCard
 from app.models.voyage import Voyage
 from app.schemas.doctor import HealthCheckSpec, ValidationResultResponse
@@ -138,7 +139,6 @@ class DoctorService:
                 file_path=spec.file_path,
                 content=spec.content,
                 framework=spec.framework,
-                metadata_={"framework": spec.framework},
                 created_by="doctor",
             )
             self._session.add(hc)
@@ -253,11 +253,24 @@ class DoctorService:
             exec_result.stdout, passed=passed, total=len(health_checks)
         )
         truncated = (exec_result.stdout or "")[-_OUTPUT_TRUNCATE:]
+
+        run = ValidationRun(
+            voyage_id=voyage.id,
+            status=status_str,
+            exit_code=exec_result.exit_code,
+            passed_count=passed_count,
+            failed_count=failed_count,
+            total_count=len(health_checks),
+            output=truncated,
+        )
+        self._session.add(run)
+        await self._session.flush()
+
         now = datetime.now(UTC)
         for hc in health_checks:
             hc.last_run_status = status_str
-            hc.last_run_output = truncated
             hc.last_run_at = now
+            hc.last_validation_run_id = run.id
 
         voyage.status = VoyageStatus.CHARTED.value
         await self._session.commit()
@@ -319,6 +332,11 @@ def _poneglyphs_to_graph_input(poneglyphs: list[Poneglyph]) -> list[dict[str, An
         try:
             content = json.loads(p.content)
         except (json.JSONDecodeError, TypeError):
+            logger.warning(
+                "Poneglyph %s (phase %s) has malformed content — using empty fallback",
+                p.id,
+                p.phase_number,
+            )
             content = {}
         out.append(
             {

--- a/src/backend/tests/test_doctor_api.py
+++ b/src/backend/tests/test_doctor_api.py
@@ -1,0 +1,249 @@
+"""Tests for Doctor Agent REST API endpoints."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+from app.models.enums import VoyageStatus
+from app.schemas.doctor import ValidateCodeRequest, ValidationResultResponse
+from app.services.doctor_service import DoctorError
+
+VOYAGE_ID = uuid.uuid4()
+USER_ID = uuid.uuid4()
+HC_ID_1 = uuid.uuid4()
+HC_ID_2 = uuid.uuid4()
+PONEGLYPH_ID_1 = uuid.uuid4()
+PONEGLYPH_ID_2 = uuid.uuid4()
+
+
+def _mock_user() -> MagicMock:
+    user = MagicMock()
+    user.id = USER_ID
+    return user
+
+
+def _mock_voyage(status: str = VoyageStatus.CHARTED.value) -> MagicMock:
+    voyage = MagicMock()
+    voyage.id = VOYAGE_ID
+    voyage.user_id = USER_ID
+    voyage.status = status
+    return voyage
+
+
+def _mock_poneglyph(poneglyph_id: uuid.UUID, phase_number: int) -> MagicMock:
+    p = MagicMock()
+    p.id = poneglyph_id
+    p.voyage_id = VOYAGE_ID
+    p.phase_number = phase_number
+    p.content = '{"title": "Test"}'
+    return p
+
+
+def _mock_health_check(hc_id: uuid.UUID, phase_number: int) -> MagicMock:
+    hc = MagicMock()
+    hc.id = hc_id
+    hc.voyage_id = VOYAGE_ID
+    hc.poneglyph_id = PONEGLYPH_ID_1
+    hc.phase_number = phase_number
+    hc.file_path = f"tests/test_phase{phase_number}.py"
+    hc.content = "def test_x(): assert False"
+    hc.framework = "pytest"
+    hc.last_run_status = None
+    hc.last_run_output = None
+    hc.last_run_at = None
+    hc.metadata_ = {"framework": "pytest"}
+    hc.created_by = "doctor"
+    hc.created_at = datetime(2026, 4, 16, tzinfo=UTC)
+    return hc
+
+
+def _mock_doctor_service() -> AsyncMock:
+    svc = AsyncMock()
+    svc.write_health_checks = AsyncMock(
+        return_value=[
+            _mock_health_check(HC_ID_1, 1),
+            _mock_health_check(HC_ID_2, 2),
+        ]
+    )
+    svc.get_health_checks = AsyncMock(
+        return_value=[
+            _mock_health_check(HC_ID_1, 1),
+            _mock_health_check(HC_ID_2, 2),
+        ]
+    )
+    svc.validate_code = AsyncMock(
+        return_value=ValidationResultResponse(
+            voyage_id=VOYAGE_ID,
+            status="passed",
+            passed_count=2,
+            failed_count=0,
+            total_count=2,
+            summary="2 passed",
+        )
+    )
+    return svc
+
+
+def _mock_navigator_reader() -> AsyncMock:
+    svc = AsyncMock()
+    svc.get_poneglyphs = AsyncMock(
+        return_value=[
+            _mock_poneglyph(PONEGLYPH_ID_1, 1),
+            _mock_poneglyph(PONEGLYPH_ID_2, 2),
+        ]
+    )
+    return svc
+
+
+class TestWriteHealthChecksEndpoint:
+    @pytest.mark.asyncio
+    async def test_returns_201_with_health_check_ids(self) -> None:
+        from app.api.v1.doctor import write_health_checks
+
+        doc_svc = _mock_doctor_service()
+        nav_reader = _mock_navigator_reader()
+
+        result = await write_health_checks(
+            VOYAGE_ID, _mock_user(), _mock_voyage(), doc_svc, nav_reader
+        )
+
+        assert result.voyage_id == VOYAGE_ID
+        assert result.count == 2
+        assert HC_ID_1 in result.health_check_ids
+        doc_svc.write_health_checks.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_returns_409_if_not_charted(self) -> None:
+        from app.api.v1.doctor import write_health_checks
+
+        doc_svc = _mock_doctor_service()
+        nav_reader = _mock_navigator_reader()
+        voyage = _mock_voyage(status=VoyageStatus.PLANNING.value)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await write_health_checks(VOYAGE_ID, _mock_user(), voyage, doc_svc, nav_reader)
+
+        assert exc_info.value.status_code == 409
+        assert exc_info.value.detail["error"]["code"] == "VOYAGE_NOT_CHARTABLE"
+
+    @pytest.mark.asyncio
+    async def test_returns_404_if_no_poneglyphs(self) -> None:
+        from app.api.v1.doctor import write_health_checks
+
+        doc_svc = _mock_doctor_service()
+        nav_reader = _mock_navigator_reader()
+        nav_reader.get_poneglyphs.return_value = []
+
+        with pytest.raises(HTTPException) as exc_info:
+            await write_health_checks(VOYAGE_ID, _mock_user(), _mock_voyage(), doc_svc, nav_reader)
+
+        assert exc_info.value.status_code == 404
+        assert exc_info.value.detail["error"]["code"] == "PONEGLYPHS_NOT_FOUND"
+
+    @pytest.mark.asyncio
+    async def test_returns_422_on_doctor_error(self) -> None:
+        from app.api.v1.doctor import write_health_checks
+
+        doc_svc = _mock_doctor_service()
+        doc_svc.write_health_checks.side_effect = DoctorError(
+            "HEALTH_CHECK_PARSE_FAILED", "Bad LLM output"
+        )
+        nav_reader = _mock_navigator_reader()
+
+        with pytest.raises(HTTPException) as exc_info:
+            await write_health_checks(VOYAGE_ID, _mock_user(), _mock_voyage(), doc_svc, nav_reader)
+
+        assert exc_info.value.status_code == 422
+        assert exc_info.value.detail["error"]["code"] == "HEALTH_CHECK_PARSE_FAILED"
+
+
+class TestGetHealthChecksEndpoint:
+    @pytest.mark.asyncio
+    async def test_returns_200_with_health_checks(self) -> None:
+        from app.api.v1.doctor import get_health_checks
+
+        doc_svc = _mock_doctor_service()
+
+        result = await get_health_checks(VOYAGE_ID, _mock_user(), _mock_voyage(), doc_svc)
+
+        assert result.voyage_id == VOYAGE_ID
+        assert len(result.health_checks) == 2
+
+    @pytest.mark.asyncio
+    async def test_returns_200_with_empty_list(self) -> None:
+        from app.api.v1.doctor import get_health_checks
+
+        doc_svc = _mock_doctor_service()
+        doc_svc.get_health_checks.return_value = []
+
+        result = await get_health_checks(VOYAGE_ID, _mock_user(), _mock_voyage(), doc_svc)
+
+        assert result.voyage_id == VOYAGE_ID
+        assert result.health_checks == []
+
+
+class TestRunValidationEndpoint:
+    @pytest.mark.asyncio
+    async def test_returns_200_with_passed_result(self) -> None:
+        from app.api.v1.doctor import run_validation
+
+        doc_svc = _mock_doctor_service()
+        body = ValidateCodeRequest(files={"src/main.py": "print('hi')"})
+
+        result = await run_validation(VOYAGE_ID, body, _mock_user(), _mock_voyage(), doc_svc)
+
+        assert result.status == "passed"
+        assert result.passed_count == 2
+        doc_svc.validate_code.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_returns_200_with_failed_result(self) -> None:
+        from app.api.v1.doctor import run_validation
+
+        doc_svc = _mock_doctor_service()
+        doc_svc.validate_code.return_value = ValidationResultResponse(
+            voyage_id=VOYAGE_ID,
+            status="failed",
+            passed_count=1,
+            failed_count=1,
+            total_count=2,
+            summary="1 failed",
+        )
+        body = ValidateCodeRequest(files={"src/main.py": "print('hi')"})
+
+        result = await run_validation(VOYAGE_ID, body, _mock_user(), _mock_voyage(), doc_svc)
+
+        assert result.status == "failed"
+        assert result.failed_count == 1
+
+    @pytest.mark.asyncio
+    async def test_returns_409_if_not_charted(self) -> None:
+        from app.api.v1.doctor import run_validation
+
+        doc_svc = _mock_doctor_service()
+        body = ValidateCodeRequest(files={"src/main.py": "print('hi')"})
+        voyage = _mock_voyage(status=VoyageStatus.PLANNING.value)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await run_validation(VOYAGE_ID, body, _mock_user(), voyage, doc_svc)
+
+        assert exc_info.value.status_code == 409
+
+    @pytest.mark.asyncio
+    async def test_returns_422_on_no_health_checks(self) -> None:
+        from app.api.v1.doctor import run_validation
+
+        doc_svc = _mock_doctor_service()
+        doc_svc.validate_code.side_effect = DoctorError("NO_HEALTH_CHECKS", "No health checks")
+        body = ValidateCodeRequest(files={"src/main.py": "print('hi')"})
+
+        with pytest.raises(HTTPException) as exc_info:
+            await run_validation(VOYAGE_ID, body, _mock_user(), _mock_voyage(), doc_svc)
+
+        assert exc_info.value.status_code == 422
+        assert exc_info.value.detail["error"]["code"] == "NO_HEALTH_CHECKS"

--- a/src/backend/tests/test_doctor_api.py
+++ b/src/backend/tests/test_doctor_api.py
@@ -54,9 +54,8 @@ def _mock_health_check(hc_id: uuid.UUID, phase_number: int) -> MagicMock:
     hc.content = "def test_x(): assert False"
     hc.framework = "pytest"
     hc.last_run_status = None
-    hc.last_run_output = None
     hc.last_run_at = None
-    hc.metadata_ = {"framework": "pytest"}
+    hc.last_validation_run_id = None
     hc.created_by = "doctor"
     hc.created_at = datetime(2026, 4, 16, tzinfo=UTC)
     return hc
@@ -193,9 +192,12 @@ class TestRunValidationEndpoint:
         from app.api.v1.doctor import run_validation
 
         doc_svc = _mock_doctor_service()
+        doc_reader = _mock_doctor_service()
         body = ValidateCodeRequest(files={"src/main.py": "print('hi')"})
 
-        result = await run_validation(VOYAGE_ID, body, _mock_user(), _mock_voyage(), doc_svc)
+        result = await run_validation(
+            VOYAGE_ID, body, _mock_user(), _mock_voyage(), doc_svc, doc_reader
+        )
 
         assert result.status == "passed"
         assert result.passed_count == 2
@@ -206,6 +208,7 @@ class TestRunValidationEndpoint:
         from app.api.v1.doctor import run_validation
 
         doc_svc = _mock_doctor_service()
+        doc_reader = _mock_doctor_service()
         doc_svc.validate_code.return_value = ValidationResultResponse(
             voyage_id=VOYAGE_ID,
             status="failed",
@@ -216,7 +219,9 @@ class TestRunValidationEndpoint:
         )
         body = ValidateCodeRequest(files={"src/main.py": "print('hi')"})
 
-        result = await run_validation(VOYAGE_ID, body, _mock_user(), _mock_voyage(), doc_svc)
+        result = await run_validation(
+            VOYAGE_ID, body, _mock_user(), _mock_voyage(), doc_svc, doc_reader
+        )
 
         assert result.status == "failed"
         assert result.failed_count == 1
@@ -226,24 +231,42 @@ class TestRunValidationEndpoint:
         from app.api.v1.doctor import run_validation
 
         doc_svc = _mock_doctor_service()
+        doc_reader = _mock_doctor_service()
         body = ValidateCodeRequest(files={"src/main.py": "print('hi')"})
         voyage = _mock_voyage(status=VoyageStatus.PLANNING.value)
 
         with pytest.raises(HTTPException) as exc_info:
-            await run_validation(VOYAGE_ID, body, _mock_user(), voyage, doc_svc)
+            await run_validation(VOYAGE_ID, body, _mock_user(), voyage, doc_svc, doc_reader)
 
         assert exc_info.value.status_code == 409
 
     @pytest.mark.asyncio
-    async def test_returns_422_on_no_health_checks(self) -> None:
+    async def test_returns_404_when_no_health_checks(self) -> None:
         from app.api.v1.doctor import run_validation
 
         doc_svc = _mock_doctor_service()
-        doc_svc.validate_code.side_effect = DoctorError("NO_HEALTH_CHECKS", "No health checks")
+        doc_reader = _mock_doctor_service()
+        doc_reader.get_health_checks.return_value = []
         body = ValidateCodeRequest(files={"src/main.py": "print('hi')"})
 
         with pytest.raises(HTTPException) as exc_info:
-            await run_validation(VOYAGE_ID, body, _mock_user(), _mock_voyage(), doc_svc)
+            await run_validation(VOYAGE_ID, body, _mock_user(), _mock_voyage(), doc_svc, doc_reader)
+
+        assert exc_info.value.status_code == 404
+        assert exc_info.value.detail["error"]["code"] == "NO_HEALTH_CHECKS"
+        doc_svc.validate_code.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_returns_422_on_doctor_error(self) -> None:
+        from app.api.v1.doctor import run_validation
+
+        doc_svc = _mock_doctor_service()
+        doc_reader = _mock_doctor_service()
+        doc_svc.validate_code.side_effect = DoctorError("HEALTH_CHECK_PARSE_FAILED", "Bad stuff")
+        body = ValidateCodeRequest(files={"src/main.py": "print('hi')"})
+
+        with pytest.raises(HTTPException) as exc_info:
+            await run_validation(VOYAGE_ID, body, _mock_user(), _mock_voyage(), doc_svc, doc_reader)
 
         assert exc_info.value.status_code == 422
-        assert exc_info.value.detail["error"]["code"] == "NO_HEALTH_CHECKS"
+        assert exc_info.value.detail["error"]["code"] == "HEALTH_CHECK_PARSE_FAILED"

--- a/src/backend/tests/test_doctor_graph.py
+++ b/src/backend/tests/test_doctor_graph.py
@@ -1,0 +1,199 @@
+"""Tests for Doctor LangGraph graph (mocked LLM)."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.crew.doctor_graph import build_doctor_graph, generate, validate
+from app.models.enums import CrewRole
+from app.schemas.dial_system import CompletionResult, TokenUsage
+
+PONEGLYPHS = [
+    {
+        "phase_number": 1,
+        "title": "Design auth module",
+        "task_description": "Create JWT-based auth",
+        "test_criteria": ["login returns JWT", "expired tokens reject"],
+        "file_paths": ["src/auth.py"],
+    },
+    {
+        "phase_number": 2,
+        "title": "Build API endpoints",
+        "task_description": "FastAPI routes",
+        "test_criteria": ["POST /login returns 200", "GET /me requires auth"],
+        "file_paths": ["src/api.py"],
+    },
+]
+
+VALID_OUTPUT_JSON = json.dumps(
+    {
+        "health_checks": [
+            {
+                "phase_number": 1,
+                "file_path": "tests/test_auth.py",
+                "content": "def test_jwt(): from src.auth import login; assert login()",
+                "framework": "pytest",
+            },
+            {
+                "phase_number": 2,
+                "file_path": "tests/test_api.py",
+                "content": "def test_login(): assert False  # TDD failing",
+                "framework": "pytest",
+            },
+        ]
+    }
+)
+
+
+def _llm_result(content: str) -> CompletionResult:
+    return CompletionResult(
+        content=content,
+        provider="anthropic",
+        model="claude-sonnet-4-20250514",
+        usage=TokenUsage(),
+    )
+
+
+class TestGenerateNode:
+    @pytest.mark.asyncio
+    async def test_sends_doctor_role_and_stores_raw(self) -> None:
+        mock_router = AsyncMock()
+        mock_router.route = AsyncMock(return_value=_llm_result(VALID_OUTPUT_JSON))
+
+        state = {
+            "poneglyphs": PONEGLYPHS,
+            "raw_output": "",
+            "health_checks": None,
+            "error": None,
+        }
+        result = await generate(state, mock_router)
+
+        mock_router.route.assert_awaited_once()
+        assert mock_router.route.call_args.args[0] == CrewRole.DOCTOR
+        assert result["raw_output"] == VALID_OUTPUT_JSON
+
+    @pytest.mark.asyncio
+    async def test_includes_poneglyph_content_in_user_message(self) -> None:
+        mock_router = AsyncMock()
+        mock_router.route = AsyncMock(return_value=_llm_result(VALID_OUTPUT_JSON))
+
+        state = {
+            "poneglyphs": PONEGLYPHS,
+            "raw_output": "",
+            "health_checks": None,
+            "error": None,
+        }
+        await generate(state, mock_router)
+
+        request = mock_router.route.call_args.args[1]
+        user_msg = next(m for m in request.messages if m["role"] == "user")
+        assert "Design auth module" in user_msg["content"]
+        assert "login returns JWT" in user_msg["content"]
+
+
+class TestValidateNode:
+    def test_parses_valid_json(self) -> None:
+        state = {
+            "poneglyphs": PONEGLYPHS,
+            "raw_output": VALID_OUTPUT_JSON,
+            "health_checks": None,
+            "error": None,
+        }
+        result = validate(state)
+
+        assert result["health_checks"] is not None
+        assert len(result["health_checks"]) == 2
+        assert result["health_checks"][0].file_path == "tests/test_auth.py"
+        assert result["error"] is None
+
+    def test_sets_error_on_invalid_json(self) -> None:
+        state = {
+            "poneglyphs": PONEGLYPHS,
+            "raw_output": "definitely not json",
+            "health_checks": None,
+            "error": None,
+        }
+        result = validate(state)
+
+        assert result["health_checks"] is None
+        assert result["error"] is not None
+
+    def test_sets_error_on_empty_health_checks(self) -> None:
+        state = {
+            "poneglyphs": PONEGLYPHS,
+            "raw_output": json.dumps({"health_checks": []}),
+            "health_checks": None,
+            "error": None,
+        }
+        result = validate(state)
+
+        assert result["health_checks"] is None
+        assert result["error"] is not None
+
+    def test_strips_markdown_json_fences(self) -> None:
+        fenced = f"```json\n{VALID_OUTPUT_JSON}\n```"
+        state = {
+            "poneglyphs": PONEGLYPHS,
+            "raw_output": fenced,
+            "health_checks": None,
+            "error": None,
+        }
+        result = validate(state)
+
+        assert result["health_checks"] is not None
+        assert result["error"] is None
+
+    def test_strips_bare_fences(self) -> None:
+        fenced = f"```\n{VALID_OUTPUT_JSON}\n```"
+        state = {
+            "poneglyphs": PONEGLYPHS,
+            "raw_output": fenced,
+            "health_checks": None,
+            "error": None,
+        }
+        result = validate(state)
+
+        assert result["health_checks"] is not None
+        assert result["error"] is None
+
+
+class TestFullGraph:
+    @pytest.mark.asyncio
+    async def test_end_to_end_success(self) -> None:
+        mock_router = AsyncMock()
+        mock_router.route = AsyncMock(return_value=_llm_result(VALID_OUTPUT_JSON))
+
+        graph = build_doctor_graph(mock_router)
+        result = await graph.ainvoke(
+            {
+                "poneglyphs": PONEGLYPHS,
+                "raw_output": "",
+                "health_checks": None,
+                "error": None,
+            }
+        )
+
+        assert result["health_checks"] is not None
+        assert result["error"] is None
+        assert len(result["health_checks"]) == 2
+
+    @pytest.mark.asyncio
+    async def test_end_to_end_invalid_output(self) -> None:
+        mock_router = AsyncMock()
+        mock_router.route = AsyncMock(return_value=_llm_result("I cannot comply"))
+
+        graph = build_doctor_graph(mock_router)
+        result = await graph.ainvoke(
+            {
+                "poneglyphs": PONEGLYPHS,
+                "raw_output": "",
+                "health_checks": None,
+                "error": None,
+            }
+        )
+
+        assert result["health_checks"] is None
+        assert result["error"] is not None

--- a/src/backend/tests/test_doctor_schemas.py
+++ b/src/backend/tests/test_doctor_schemas.py
@@ -72,6 +72,38 @@ class TestHealthCheckSpec:
         )
         assert spec.framework == "pytest"
 
+    def test_rejects_absolute_file_path(self) -> None:
+        with pytest.raises(ValidationError, match="relative"):
+            HealthCheckSpec(
+                phase_number=1,
+                file_path="/etc/passwd",
+                content="pass",
+            )
+
+    def test_rejects_path_traversal(self) -> None:
+        with pytest.raises(ValidationError, match="traversal"):
+            HealthCheckSpec(
+                phase_number=1,
+                file_path="../../etc/passwd",
+                content="pass",
+            )
+
+    def test_rejects_nested_path_traversal(self) -> None:
+        with pytest.raises(ValidationError, match="traversal"):
+            HealthCheckSpec(
+                phase_number=1,
+                file_path="tests/../../etc/passwd",
+                content="pass",
+            )
+
+    def test_accepts_nested_relative_path(self) -> None:
+        spec = HealthCheckSpec(
+            phase_number=1,
+            file_path="tests/unit/test_auth.py",
+            content="pass",
+        )
+        assert spec.file_path == "tests/unit/test_auth.py"
+
 
 class TestDoctorOutputSpec:
     def test_rejects_empty_health_checks(self) -> None:
@@ -105,3 +137,11 @@ class TestValidateCodeRequest:
     def test_accepts_files_dict(self) -> None:
         req = ValidateCodeRequest(files={"src/main.py": "print('hi')"})
         assert "src/main.py" in req.files
+
+    def test_rejects_absolute_path_in_files(self) -> None:
+        with pytest.raises(ValidationError, match="relative"):
+            ValidateCodeRequest(files={"/etc/passwd": "bad"})
+
+    def test_rejects_path_traversal_in_files(self) -> None:
+        with pytest.raises(ValidationError, match="traversal"):
+            ValidateCodeRequest(files={"../../etc/passwd": "bad"})

--- a/src/backend/tests/test_doctor_schemas.py
+++ b/src/backend/tests/test_doctor_schemas.py
@@ -1,0 +1,107 @@
+"""Tests for Doctor Agent Pydantic schemas."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from app.schemas.doctor import (
+    DoctorOutputSpec,
+    HealthCheckSpec,
+    ValidateCodeRequest,
+)
+
+
+class TestHealthCheckSpec:
+    def test_accepts_valid_pytest(self) -> None:
+        spec = HealthCheckSpec(
+            phase_number=1,
+            file_path="tests/test_auth.py",
+            content="def test_login(): assert False",
+            framework="pytest",
+        )
+        assert spec.framework == "pytest"
+
+    def test_accepts_valid_vitest(self) -> None:
+        spec = HealthCheckSpec(
+            phase_number=1,
+            file_path="src/auth.test.ts",
+            content="test('login', () => { expect(true).toBe(false) })",
+            framework="vitest",
+        )
+        assert spec.framework == "vitest"
+
+    def test_rejects_phase_number_below_one(self) -> None:
+        with pytest.raises(ValidationError):
+            HealthCheckSpec(
+                phase_number=0,
+                file_path="tests/x.py",
+                content="pass",
+            )
+
+    def test_rejects_empty_file_path(self) -> None:
+        with pytest.raises(ValidationError):
+            HealthCheckSpec(
+                phase_number=1,
+                file_path="",
+                content="pass",
+            )
+
+    def test_rejects_empty_content(self) -> None:
+        with pytest.raises(ValidationError):
+            HealthCheckSpec(
+                phase_number=1,
+                file_path="tests/x.py",
+                content="",
+            )
+
+    def test_rejects_invalid_framework(self) -> None:
+        with pytest.raises(ValidationError):
+            HealthCheckSpec(
+                phase_number=1,
+                file_path="tests/x.py",
+                content="pass",
+                framework="mocha",  # type: ignore[arg-type]
+            )
+
+    def test_defaults_framework_to_pytest(self) -> None:
+        spec = HealthCheckSpec(
+            phase_number=1,
+            file_path="tests/x.py",
+            content="pass",
+        )
+        assert spec.framework == "pytest"
+
+
+class TestDoctorOutputSpec:
+    def test_rejects_empty_health_checks(self) -> None:
+        with pytest.raises(ValidationError):
+            DoctorOutputSpec(health_checks=[])
+
+    def test_rejects_duplicate_file_paths(self) -> None:
+        with pytest.raises(ValidationError, match="Duplicate file_path"):
+            DoctorOutputSpec(
+                health_checks=[
+                    HealthCheckSpec(phase_number=1, file_path="tests/x.py", content="a"),
+                    HealthCheckSpec(phase_number=2, file_path="tests/x.py", content="b"),
+                ]
+            )
+
+    def test_accepts_multi_phase_output(self) -> None:
+        spec = DoctorOutputSpec(
+            health_checks=[
+                HealthCheckSpec(phase_number=1, file_path="tests/a.py", content="a"),
+                HealthCheckSpec(phase_number=2, file_path="tests/b.py", content="b"),
+            ]
+        )
+        assert len(spec.health_checks) == 2
+
+
+class TestValidateCodeRequest:
+    def test_rejects_empty_files(self) -> None:
+        with pytest.raises(ValidationError):
+            ValidateCodeRequest(files={})
+
+    def test_accepts_files_dict(self) -> None:
+        req = ValidateCodeRequest(files={"src/main.py": "print('hi')"})
+        assert "src/main.py" in req.files

--- a/src/backend/tests/test_doctor_service.py
+++ b/src/backend/tests/test_doctor_service.py
@@ -1,0 +1,547 @@
+"""Tests for DoctorService (mocked dependencies)."""
+
+from __future__ import annotations
+
+import json
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.models.enums import CrewRole, VoyageStatus
+from app.models.health_check import HealthCheck
+from app.models.vivre_card import VivreCard
+from app.schemas.dial_system import CompletionResult, TokenUsage
+from app.schemas.execution import ExecutionResult
+from app.services.doctor_service import DoctorError, DoctorService
+
+VOYAGE_ID = uuid.uuid4()
+USER_ID = uuid.uuid4()
+PONEGLYPH_ID_1 = uuid.uuid4()
+PONEGLYPH_ID_2 = uuid.uuid4()
+
+VALID_DOCTOR_OUTPUT = json.dumps(
+    {
+        "health_checks": [
+            {
+                "phase_number": 1,
+                "file_path": "tests/test_auth.py",
+                "content": "def test_auth(): assert False  # TDD",
+                "framework": "pytest",
+            },
+            {
+                "phase_number": 2,
+                "file_path": "tests/test_api.py",
+                "content": "def test_api(): assert False  # TDD",
+                "framework": "pytest",
+            },
+        ]
+    }
+)
+
+
+def _mock_voyage(
+    status: str = VoyageStatus.CHARTED.value,
+    target_repo: str | None = None,
+) -> MagicMock:
+    voyage = MagicMock()
+    voyage.id = VOYAGE_ID
+    voyage.user_id = USER_ID
+    voyage.status = status
+    voyage.target_repo = target_repo
+    return voyage
+
+
+def _mock_poneglyph(poneglyph_id: uuid.UUID, phase_number: int) -> MagicMock:
+    p = MagicMock()
+    p.id = poneglyph_id
+    p.voyage_id = VOYAGE_ID
+    p.phase_number = phase_number
+    p.content = json.dumps(
+        {
+            "phase_number": phase_number,
+            "title": f"Phase {phase_number}",
+            "task_description": "desc",
+            "technical_constraints": [],
+            "expected_inputs": [],
+            "expected_outputs": [],
+            "test_criteria": ["must work"],
+            "file_paths": [f"src/phase{phase_number}.py"],
+            "implementation_notes": "",
+        }
+    )
+    return p
+
+
+def _poneglyphs() -> list[MagicMock]:
+    return [_mock_poneglyph(PONEGLYPH_ID_1, 1), _mock_poneglyph(PONEGLYPH_ID_2, 2)]
+
+
+def _llm_result(content: str) -> CompletionResult:
+    return CompletionResult(
+        content=content,
+        provider="anthropic",
+        model="claude-sonnet-4-20250514",
+        usage=TokenUsage(prompt_tokens=100, completion_tokens=200, total_tokens=300),
+    )
+
+
+def _exec_result(exit_code: int, stdout: str = "") -> ExecutionResult:
+    return ExecutionResult(
+        exit_code=exit_code,
+        stdout=stdout,
+        stderr="",
+        timed_out=False,
+        duration_seconds=1.0,
+        sandbox_id="sb-1",
+    )
+
+
+@pytest.fixture
+def mock_dial_router() -> AsyncMock:
+    router = AsyncMock()
+    router.route = AsyncMock(return_value=_llm_result(VALID_DOCTOR_OUTPUT))
+    return router
+
+
+@pytest.fixture
+def mock_mushi() -> AsyncMock:
+    mushi = AsyncMock()
+    mushi.publish = AsyncMock(return_value="msg-1")
+    return mushi
+
+
+@pytest.fixture
+def mock_session() -> AsyncMock:
+    session = AsyncMock()
+    session.add = MagicMock()
+    session.flush = AsyncMock()
+    session.commit = AsyncMock()
+    session.refresh = AsyncMock()
+    result_mock = MagicMock()
+    result_mock.scalars.return_value.all.return_value = []
+    session.execute = AsyncMock(return_value=result_mock)
+    return session
+
+
+@pytest.fixture
+def mock_execution() -> AsyncMock:
+    svc = AsyncMock()
+    svc.run = AsyncMock(return_value=_exec_result(0, "2 passed"))
+    return svc
+
+
+@pytest.fixture
+def mock_git() -> AsyncMock:
+    git = AsyncMock()
+    git.create_branch = AsyncMock()
+    git.commit = AsyncMock()
+    git.push = AsyncMock()
+    return git
+
+
+@pytest.fixture
+def service(
+    mock_dial_router: AsyncMock,
+    mock_mushi: AsyncMock,
+    mock_session: AsyncMock,
+    mock_execution: AsyncMock,
+    mock_git: AsyncMock,
+) -> DoctorService:
+    return DoctorService(mock_dial_router, mock_mushi, mock_session, mock_execution, mock_git)
+
+
+class TestWriteHealthChecks:
+    @pytest.mark.asyncio
+    async def test_restores_charted_status_after_success(self, service: DoctorService) -> None:
+        voyage = _mock_voyage()
+        await service.write_health_checks(voyage, _poneglyphs(), USER_ID)
+        assert voyage.status == VoyageStatus.CHARTED.value
+
+    @pytest.mark.asyncio
+    async def test_invokes_dial_router_with_doctor_role(
+        self, service: DoctorService, mock_dial_router: AsyncMock
+    ) -> None:
+        voyage = _mock_voyage()
+        await service.write_health_checks(voyage, _poneglyphs(), USER_ID)
+        mock_dial_router.route.assert_awaited_once()
+        assert mock_dial_router.route.call_args.args[0] == CrewRole.DOCTOR
+
+    @pytest.mark.asyncio
+    async def test_persists_one_health_check_per_spec(
+        self, service: DoctorService, mock_session: AsyncMock
+    ) -> None:
+        voyage = _mock_voyage()
+        result = await service.write_health_checks(voyage, _poneglyphs(), USER_ID)
+        assert len(result) == 2
+        added = [call.args[0] for call in mock_session.add.call_args_list]
+        hc_adds = [o for o in added if isinstance(o, HealthCheck)]
+        assert len(hc_adds) == 2
+
+    @pytest.mark.asyncio
+    async def test_links_poneglyph_by_phase_number(self, service: DoctorService) -> None:
+        voyage = _mock_voyage()
+        result = await service.write_health_checks(voyage, _poneglyphs(), USER_ID)
+        by_phase = {hc.phase_number: hc.poneglyph_id for hc in result}
+        assert by_phase[1] == PONEGLYPH_ID_1
+        assert by_phase[2] == PONEGLYPH_ID_2
+
+    @pytest.mark.asyncio
+    async def test_stores_content_and_file_path_verbatim(self, service: DoctorService) -> None:
+        voyage = _mock_voyage()
+        result = await service.write_health_checks(voyage, _poneglyphs(), USER_ID)
+        by_phase = {hc.phase_number: hc for hc in result}
+        assert by_phase[1].file_path == "tests/test_auth.py"
+        assert "def test_auth" in by_phase[1].content
+
+    @pytest.mark.asyncio
+    async def test_creates_vivre_card_checkpoint(
+        self, service: DoctorService, mock_session: AsyncMock
+    ) -> None:
+        voyage = _mock_voyage()
+        await service.write_health_checks(voyage, _poneglyphs(), USER_ID)
+        added = [call.args[0] for call in mock_session.add.call_args_list]
+        cards = [o for o in added if isinstance(o, VivreCard)]
+        assert len(cards) == 1
+        assert cards[0].crew_member == "doctor"
+
+    @pytest.mark.asyncio
+    async def test_commits_atomically(
+        self, service: DoctorService, mock_session: AsyncMock
+    ) -> None:
+        voyage = _mock_voyage()
+        await service.write_health_checks(voyage, _poneglyphs(), USER_ID)
+        mock_session.commit.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_publishes_health_check_written_event_per_row(
+        self, service: DoctorService, mock_mushi: AsyncMock
+    ) -> None:
+        voyage = _mock_voyage()
+        await service.write_health_checks(voyage, _poneglyphs(), USER_ID)
+        assert mock_mushi.publish.await_count == 2
+        events = [call.args[1] for call in mock_mushi.publish.call_args_list]
+        assert all(e.event_type == "health_check_written" for e in events)
+        assert all(e.source_role == CrewRole.DOCTOR for e in events)
+
+    @pytest.mark.asyncio
+    async def test_succeeds_when_publish_fails(
+        self,
+        service: DoctorService,
+        mock_mushi: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        mock_mushi.publish.side_effect = ConnectionError("Redis down")
+        voyage = _mock_voyage()
+        result = await service.write_health_checks(voyage, _poneglyphs(), USER_ID)
+        assert len(result) == 2
+        mock_session.commit.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_deletes_existing_health_checks_before_insert(
+        self, service: DoctorService, mock_session: AsyncMock
+    ) -> None:
+        from sqlalchemy.sql.dml import Delete
+
+        voyage = _mock_voyage()
+        await service.write_health_checks(voyage, _poneglyphs(), USER_ID)
+        executed = [call.args[0] for call in mock_session.execute.call_args_list]
+        deletes = [s for s in executed if isinstance(s, Delete)]
+        assert len(deletes) == 1
+
+    @pytest.mark.asyncio
+    async def test_raises_on_invalid_llm_output(
+        self, service: DoctorService, mock_dial_router: AsyncMock
+    ) -> None:
+        mock_dial_router.route.return_value = _llm_result("not json")
+        voyage = _mock_voyage()
+        with pytest.raises(DoctorError) as exc_info:
+            await service.write_health_checks(voyage, _poneglyphs(), USER_ID)
+        assert exc_info.value.code == "HEALTH_CHECK_PARSE_FAILED"
+        assert voyage.status == VoyageStatus.CHARTED.value
+
+    @pytest.mark.asyncio
+    async def test_raises_on_phase_mismatch(
+        self, service: DoctorService, mock_dial_router: AsyncMock
+    ) -> None:
+        bad = json.dumps(
+            {
+                "health_checks": [
+                    {
+                        "phase_number": 1,
+                        "file_path": "tests/a.py",
+                        "content": "x",
+                        "framework": "pytest",
+                    },
+                    {
+                        "phase_number": 99,
+                        "file_path": "tests/b.py",
+                        "content": "y",
+                        "framework": "pytest",
+                    },
+                ]
+            }
+        )
+        mock_dial_router.route.return_value = _llm_result(bad)
+        voyage = _mock_voyage()
+        with pytest.raises(DoctorError) as exc_info:
+            await service.write_health_checks(voyage, _poneglyphs(), USER_ID)
+        assert exc_info.value.code == "HEALTH_CHECK_PHASE_MISMATCH"
+        assert voyage.status == VoyageStatus.CHARTED.value
+
+    @pytest.mark.asyncio
+    async def test_commits_to_git_when_target_repo_set(
+        self, service: DoctorService, mock_git: AsyncMock
+    ) -> None:
+        voyage = _mock_voyage(target_repo="https://github.com/org/repo.git")
+        await service.write_health_checks(voyage, _poneglyphs(), USER_ID)
+        mock_git.create_branch.assert_awaited_once()
+        mock_git.commit.assert_awaited_once()
+        mock_git.push.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_skips_git_when_no_target_repo(
+        self, service: DoctorService, mock_git: AsyncMock
+    ) -> None:
+        voyage = _mock_voyage(target_repo=None)
+        await service.write_health_checks(voyage, _poneglyphs(), USER_ID)
+        mock_git.create_branch.assert_not_called()
+        mock_git.commit.assert_not_called()
+        mock_git.push.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_succeeds_when_git_commit_fails(
+        self, service: DoctorService, mock_git: AsyncMock
+    ) -> None:
+        mock_git.commit.side_effect = RuntimeError("git boom")
+        voyage = _mock_voyage(target_repo="https://github.com/org/repo.git")
+        result = await service.write_health_checks(voyage, _poneglyphs(), USER_ID)
+        assert len(result) == 2
+
+    @pytest.mark.asyncio
+    async def test_no_git_service_skips_git_path(
+        self,
+        mock_dial_router: AsyncMock,
+        mock_mushi: AsyncMock,
+        mock_session: AsyncMock,
+        mock_execution: AsyncMock,
+    ) -> None:
+        svc = DoctorService(
+            mock_dial_router, mock_mushi, mock_session, mock_execution, git_service=None
+        )
+        voyage = _mock_voyage(target_repo="https://github.com/org/repo.git")
+        result = await svc.write_health_checks(voyage, _poneglyphs(), USER_ID)
+        assert len(result) == 2
+
+
+class TestValidateCode:
+    @pytest.mark.asyncio
+    async def test_passes_when_pytest_exits_zero(
+        self,
+        service: DoctorService,
+        mock_session: AsyncMock,
+        mock_execution: AsyncMock,
+    ) -> None:
+        mock_execution.run.return_value = _exec_result(0, "===== 2 passed in 0.01s =====")
+        hc1 = HealthCheck(
+            id=uuid.uuid4(),
+            voyage_id=VOYAGE_ID,
+            phase_number=1,
+            file_path="tests/a.py",
+            content="x",
+            framework="pytest",
+        )
+        result_mock = MagicMock()
+        result_mock.scalars.return_value.all.return_value = [hc1]
+        mock_session.execute.return_value = result_mock
+
+        voyage = _mock_voyage()
+        resp = await service.validate_code(voyage, USER_ID, {"src/a.py": "pass"})
+
+        assert resp.status == "passed"
+        assert resp.passed_count == 2
+        assert hc1.last_run_status == "passed"
+
+    @pytest.mark.asyncio
+    async def test_fails_when_pytest_exits_nonzero(
+        self,
+        service: DoctorService,
+        mock_session: AsyncMock,
+        mock_execution: AsyncMock,
+    ) -> None:
+        mock_execution.run.return_value = _exec_result(1, "1 failed, 1 passed")
+        hc1 = HealthCheck(
+            id=uuid.uuid4(),
+            voyage_id=VOYAGE_ID,
+            phase_number=1,
+            file_path="tests/a.py",
+            content="x",
+            framework="pytest",
+        )
+        result_mock = MagicMock()
+        result_mock.scalars.return_value.all.return_value = [hc1]
+        mock_session.execute.return_value = result_mock
+
+        voyage = _mock_voyage()
+        resp = await service.validate_code(voyage, USER_ID, {"src/a.py": "pass"})
+
+        assert resp.status == "failed"
+        assert resp.failed_count == 1
+        assert hc1.last_run_status == "failed"
+
+    @pytest.mark.asyncio
+    async def test_layers_shipwright_and_healthcheck_files(
+        self,
+        service: DoctorService,
+        mock_session: AsyncMock,
+        mock_execution: AsyncMock,
+    ) -> None:
+        hc = HealthCheck(
+            id=uuid.uuid4(),
+            voyage_id=VOYAGE_ID,
+            phase_number=1,
+            file_path="tests/test_a.py",
+            content="test_content",
+            framework="pytest",
+        )
+        result_mock = MagicMock()
+        result_mock.scalars.return_value.all.return_value = [hc]
+        mock_session.execute.return_value = result_mock
+
+        voyage = _mock_voyage()
+        await service.validate_code(voyage, USER_ID, {"src/a.py": "shipwright"})
+
+        exec_request = mock_execution.run.call_args.args[1]
+        assert "src/a.py" in exec_request.files
+        assert "tests/test_a.py" in exec_request.files
+        assert exec_request.files["tests/test_a.py"] == "test_content"
+
+    @pytest.mark.asyncio
+    async def test_restores_charted_status_after_success(
+        self,
+        service: DoctorService,
+        mock_session: AsyncMock,
+    ) -> None:
+        hc = HealthCheck(
+            id=uuid.uuid4(),
+            voyage_id=VOYAGE_ID,
+            phase_number=1,
+            file_path="tests/a.py",
+            content="x",
+            framework="pytest",
+        )
+        result_mock = MagicMock()
+        result_mock.scalars.return_value.all.return_value = [hc]
+        mock_session.execute.return_value = result_mock
+
+        voyage = _mock_voyage()
+        await service.validate_code(voyage, USER_ID, {"src/a.py": "pass"})
+        assert voyage.status == VoyageStatus.CHARTED.value
+
+    @pytest.mark.asyncio
+    async def test_publishes_passed_event_on_pass(
+        self,
+        service: DoctorService,
+        mock_session: AsyncMock,
+        mock_mushi: AsyncMock,
+    ) -> None:
+        hc = HealthCheck(
+            id=uuid.uuid4(),
+            voyage_id=VOYAGE_ID,
+            phase_number=1,
+            file_path="tests/a.py",
+            content="x",
+            framework="pytest",
+        )
+        result_mock = MagicMock()
+        result_mock.scalars.return_value.all.return_value = [hc]
+        mock_session.execute.return_value = result_mock
+
+        voyage = _mock_voyage()
+        await service.validate_code(voyage, USER_ID, {"src/a.py": "pass"})
+
+        event = mock_mushi.publish.call_args.args[1]
+        assert event.event_type == "validation_passed"
+
+    @pytest.mark.asyncio
+    async def test_publishes_failed_event_on_fail(
+        self,
+        service: DoctorService,
+        mock_session: AsyncMock,
+        mock_mushi: AsyncMock,
+        mock_execution: AsyncMock,
+    ) -> None:
+        mock_execution.run.return_value = _exec_result(1, "1 failed")
+        hc = HealthCheck(
+            id=uuid.uuid4(),
+            voyage_id=VOYAGE_ID,
+            phase_number=1,
+            file_path="tests/a.py",
+            content="x",
+            framework="pytest",
+        )
+        result_mock = MagicMock()
+        result_mock.scalars.return_value.all.return_value = [hc]
+        mock_session.execute.return_value = result_mock
+
+        voyage = _mock_voyage()
+        await service.validate_code(voyage, USER_ID, {"src/a.py": "pass"})
+
+        event = mock_mushi.publish.call_args.args[1]
+        assert event.event_type == "validation_failed"
+
+    @pytest.mark.asyncio
+    async def test_raises_when_no_health_checks(
+        self,
+        service: DoctorService,
+        mock_session: AsyncMock,
+    ) -> None:
+        result_mock = MagicMock()
+        result_mock.scalars.return_value.all.return_value = []
+        mock_session.execute.return_value = result_mock
+
+        voyage = _mock_voyage()
+        with pytest.raises(DoctorError) as exc_info:
+            await service.validate_code(voyage, USER_ID, {"src/a.py": "pass"})
+        assert exc_info.value.code == "NO_HEALTH_CHECKS"
+        assert voyage.status == VoyageStatus.CHARTED.value
+
+
+class TestGetHealthChecks:
+    @pytest.mark.asyncio
+    async def test_returns_ordered_rows(
+        self, service: DoctorService, mock_session: AsyncMock
+    ) -> None:
+        hc1, hc2 = MagicMock(), MagicMock()
+        hc1.phase_number, hc2.phase_number = 1, 2
+        result_mock = MagicMock()
+        result_mock.scalars.return_value.all.return_value = [hc1, hc2]
+        mock_session.execute.return_value = result_mock
+
+        result = await service.get_health_checks(VOYAGE_ID)
+        assert len(result) == 2
+        assert result[0].phase_number == 1
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_list(
+        self, service: DoctorService, mock_session: AsyncMock
+    ) -> None:
+        result_mock = MagicMock()
+        result_mock.scalars.return_value.all.return_value = []
+        mock_session.execute.return_value = result_mock
+
+        result = await service.get_health_checks(VOYAGE_ID)
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_reader_instance_works(self) -> None:
+        session = AsyncMock()
+        hc = MagicMock()
+        hc.phase_number = 1
+        result_mock = MagicMock()
+        result_mock.scalars.return_value.all.return_value = [hc]
+        session.execute = AsyncMock(return_value=result_mock)
+
+        reader = DoctorService.reader(session)
+        result = await reader.get_health_checks(VOYAGE_ID)
+        assert len(result) == 1

--- a/src/backend/tests/test_doctor_service.py
+++ b/src/backend/tests/test_doctor_service.py
@@ -10,6 +10,7 @@ import pytest
 
 from app.models.enums import CrewRole, VoyageStatus
 from app.models.health_check import HealthCheck
+from app.models.validation_run import ValidationRun
 from app.models.vivre_card import VivreCard
 from app.schemas.dial_system import CompletionResult, TokenUsage
 from app.schemas.execution import ExecutionResult
@@ -505,6 +506,38 @@ class TestValidateCode:
             await service.validate_code(voyage, USER_ID, {"src/a.py": "pass"})
         assert exc_info.value.code == "NO_HEALTH_CHECKS"
         assert voyage.status == VoyageStatus.CHARTED.value
+
+    @pytest.mark.asyncio
+    async def test_persists_validation_run_row(
+        self,
+        service: DoctorService,
+        mock_session: AsyncMock,
+        mock_execution: AsyncMock,
+    ) -> None:
+        mock_execution.run.return_value = _exec_result(0, "===== 2 passed in 0.01s =====")
+        hc = HealthCheck(
+            id=uuid.uuid4(),
+            voyage_id=VOYAGE_ID,
+            phase_number=1,
+            file_path="tests/a.py",
+            content="x",
+            framework="pytest",
+        )
+        result_mock = MagicMock()
+        result_mock.scalars.return_value.all.return_value = [hc]
+        mock_session.execute.return_value = result_mock
+
+        voyage = _mock_voyage()
+        await service.validate_code(voyage, USER_ID, {"src/a.py": "pass"})
+
+        added = [call.args[0] for call in mock_session.add.call_args_list]
+        runs = [o for o in added if isinstance(o, ValidationRun)]
+        assert len(runs) == 1
+        assert runs[0].status == "passed"
+        assert runs[0].exit_code == 0
+        assert runs[0].passed_count == 2
+        assert runs[0].output  # stored once, not per health-check
+        assert hc.last_validation_run_id == runs[0].id
 
 
 class TestGetHealthChecks:

--- a/src/backend/tests/test_models.py
+++ b/src/backend/tests/test_models.py
@@ -9,6 +9,7 @@ from app.models.enums import CheckpointReason, CrewRole, VoyageStatus
 from app.models.health_check import HealthCheck
 from app.models.poneglyph import Poneglyph
 from app.models.user import User
+from app.models.validation_run import ValidationRun
 from app.models.vivre_card import VivreCard
 from app.models.voyage import Voyage, VoyagePlan
 
@@ -24,6 +25,7 @@ def test_all_models_registered_in_metadata() -> None:
         "crew_actions",
         "dial_configs",
         "health_checks",
+        "validation_runs",
     }
     assert expected == table_names
 
@@ -193,9 +195,24 @@ def test_health_check_table_columns() -> None:
         "content",
         "framework",
         "last_run_status",
-        "last_run_output",
         "last_run_at",
-        "metadata",
+        "last_validation_run_id",
         "created_by",
+        "created_at",
+    }
+
+
+def test_validation_run_table_columns() -> None:
+    mapper = inspect(ValidationRun)
+    column_names = {c.key for c in mapper.columns}
+    assert column_names == {
+        "id",
+        "voyage_id",
+        "status",
+        "exit_code",
+        "passed_count",
+        "failed_count",
+        "total_count",
+        "output",
         "created_at",
     }

--- a/src/backend/tests/test_models.py
+++ b/src/backend/tests/test_models.py
@@ -6,6 +6,7 @@ from app.models import Base
 from app.models.crew_action import CrewAction
 from app.models.dial_config import DialConfig
 from app.models.enums import CheckpointReason, CrewRole, VoyageStatus
+from app.models.health_check import HealthCheck
 from app.models.poneglyph import Poneglyph
 from app.models.user import User
 from app.models.vivre_card import VivreCard
@@ -22,6 +23,7 @@ def test_all_models_registered_in_metadata() -> None:
         "vivre_cards",
         "crew_actions",
         "dial_configs",
+        "health_checks",
     }
     assert expected == table_names
 
@@ -177,3 +179,23 @@ def test_crew_action_crew_member_indexed() -> None:
     table = CrewAction.__table__
     crew_col = table.c.crew_member
     assert crew_col.index is True
+
+
+def test_health_check_table_columns() -> None:
+    mapper = inspect(HealthCheck)
+    column_names = {c.key for c in mapper.columns}
+    assert column_names == {
+        "id",
+        "voyage_id",
+        "poneglyph_id",
+        "phase_number",
+        "file_path",
+        "content",
+        "framework",
+        "last_run_status",
+        "last_run_output",
+        "last_run_at",
+        "metadata",
+        "created_by",
+        "created_at",
+    }


### PR DESCRIPTION
## Summary
- Adds the **Doctor Agent** — a two-mode QA agent that writes failing health-check tests BEFORE implementation (TDD) and validates Shipwright code against them (post-build).
- Closes #13

## What's included

### Models & persistence
- `HealthCheck` model + Alembic migration (`health_checks` table, indexed on voyage_id/poneglyph_id)
- `ValidationFailedEvent` added alongside existing `ValidationPassedEvent` and `HealthCheckWrittenEvent`

### Agent
- `app/crew/doctor_graph.py` — two-node LangGraph (`generate` → `validate`) that calls Dial System with `CrewRole.DOCTOR` and parses `HealthCheckSpec[]` from the LLM
- `DOCTOR_SYSTEM_PROMPT` explicitly instructs the LLM to write **failing** tests (TDD) that reference symbols the Shipwrights will build

### Service
- `DoctorService.write_health_checks()` — graph invoke, phase-alignment (subset), delete-before-insert, atomic commit (rows + VivreCard), status lifecycle (CHARTED → TDD → CHARTED), best-effort git commit to `agent/doctor/<voyage-id>`, event publish per row
- `DoctorService.validate_code()` — loads health checks, layers Shipwright files + test files, runs pytest via Execution Service, records `last_run_status`/`last_run_output`/`last_run_at`, emits passed/failed event
- `DoctorService.reader()` classmethod for read-only paths
- Structured `DoctorError(code, message)` — API returns 422

### API
- `POST /voyages/{id}/health-checks` → 201 (write mode)
- `GET /voyages/{id}/health-checks` → 200
- `POST /voyages/{id}/validation` → 200 (run pytest)

Error codes: `VOYAGE_NOT_CHARTABLE` (409), `PONEGLYPHS_NOT_FOUND` (404), `HEALTH_CHECK_PARSE_FAILED` / `HEALTH_CHECK_PHASE_MISMATCH` / `NO_HEALTH_CHECKS` (422).

### Patterns preserved from Navigator/Captain
- `reader()` factory, atomic commit + VivreCard, delete-before-insert, best-effort git and events, `strip_fences` utility
- Uses `get_navigator_reader` for cross-agent read access to Poneglyphs

## Test plan
- [x] Schema tests: `test_doctor_schemas.py` (12 tests)
- [x] Graph tests: `test_doctor_graph.py` (9 tests, mocked router)
- [x] Service tests: `test_doctor_service.py` (26 tests)
- [x] API tests: `test_doctor_api.py` (10 tests)
- [x] Model registration test updated in `test_models.py`
- [x] Full suite: **464 passed, 10 skipped**
- [x] `ruff format` + `ruff check` clean
- [x] `mypy` clean (only pre-existing `jose` stub warning)

## PDD artifacts
- `pdd/prompts/features/crew/PLAN-doctor-agent.md`
- `pdd/prompts/features/crew/grandline-12-doctor.md`