### PR TITLE
feat: add Shipwright Agent with iterative code generation (Phase 13) #14

### DIFF
--- a/pdd/context/decisions.md
+++ b/pdd/context/decisions.md
@@ -161,3 +161,43 @@
 **What was decided**: `chart_course` commits plan + VivreCard to PostgreSQL first, then publishes the `VoyagePlanCreatedEvent` to Den Den Mushi in a try/except. If Redis is down, the event is logged as a warning and the request succeeds.
 **Why**: The plan is the source of truth, not the event. If publish fails after a successful commit, the caller gets a successful response and can retry the event later. Failing the request after the plan is already committed leaves the caller with a 500 for a successful write and no safe retry path (the voyage status has moved out of CHARTED).
 **Don't suggest**: Publishing before commit (data loss risk), failing the request on publish failure, transactional outbox (premature for current scale)
+
+---
+
+## Decision: Shipwright invocation is phase-scoped
+**Date**: 2026-04-17
+**What was decided**: The Shipwright Agent's build API is phase-scoped (`POST /voyages/{id}/phases/{phase_number}/build`), not voyage-scoped. One invocation builds exactly one phase. The future voyage pipeline (Phase 15) fans out one invocation per phase to enable parallelism.
+**Why**: Per-phase invocations are the parallelism primitive. A voyage-level endpoint would force serial phase builds, or require the Shipwright itself to manage internal parallelism — premature complexity. Scoping per-phase also keeps the LLM context small (one Poneglyph + its tests) and enables independent retries.
+**Don't suggest**: Voyage-scoped build endpoint that loops over phases internally, hidden intra-Shipwright concurrency
+
+---
+
+## Decision: Service-owned iteration loop, graph stays side-effect-free
+**Date**: 2026-04-17
+**What was decided**: The Shipwright's generate→test→refine iteration loop is implemented in the **service layer**, not inside the compiled LangGraph graph. The service runs single-iteration graph invocations in a Python loop, writing a `VivreCard` between iterations for "no work lost" guarantees.
+**Why**: LangGraph graphs should remain pure — nodes call LLMs and sandboxes but don't own DB state. Per-iteration checkpointing is a DB write; keeping it in the service preserves graph purity and makes the loop trivially testable with mocked graph invocations. The alternative (LangGraph's built-in checkpointer) adds infrastructure without solving the observability problem (we want one VivreCard row per iteration, queryable by the Observation Deck).
+**Don't suggest**: Putting `session.commit()` inside graph nodes, relying on LangGraph's internal checkpointer for product-level state, one giant `.ainvoke()` that runs the full loop opaquely
+
+---
+
+## Decision: Shipwright voyage-level status gate (v1 scope-cut)
+**Date**: 2026-04-17
+**What was decided**: v1 of the Shipwright enforces a single in-flight invocation per voyage via the `voyage.status == CHARTED` gate (transitions to `BUILDING` during the call). True per-phase parallelism is deferred until a `phase_status` map is added to the voyage model.
+**Why**: Shipping a correct sequential path first. Concurrent invocations on the same voyage would race the `voyage.status` transition and the `delete-before-insert` step for `BuildArtifact`. A `phase_status` refactor is the right long-term fix but premature for the first Shipwright cut. Phase 15's voyage pipeline will sequence phase builds; user-level fan-out across phases waits for the refactor.
+**Don't suggest**: Removing the 409 gate, introducing a voyage-level lock in Redis (heavier than needed), bolting on a phase_status column without a migration plan
+
+---
+
+## Decision: Vitest deferred; Shipwright v1 is pytest-only
+**Date**: 2026-04-17
+**What was decided**: If a phase's `HealthCheck.framework == "vitest"`, `ShipwrightService.build_code` returns `ShipwrightError("VITEST_NOT_SUPPORTED")` → 422. pytest-only for v1. Vitest support is a follow-up feature.
+**Why**: Running Node/Vitest inside the sandbox is a separate integration (different runtime, different pytest-vs-vitest output parsing, different file layout). Scoping v1 to pytest keeps the first Shipwright cut focused. The error code is explicit so the voyage pipeline can surface it cleanly.
+**Don't suggest**: Silent fallback to pytest for Vitest tests, adding Vitest runner without a dedicated PDD cycle
+
+---
+
+## Decision: Shipwright max_iterations hardcoded to 3
+**Date**: 2026-04-17
+**What was decided**: `SHIPWRIGHT_MAX_ITERATIONS = 3` is a module-level constant, not an env/config value. The loop terminates on green tests or after 3 attempts (generate + run, 3x).
+**Why**: Config surface area has a cost. 3 matches typical Claude/GPT-4 "fix your own output" attention span and keeps worst-case latency bounded. If Phase 15 integration tests show 3 is too low, bump the constant — no schema change, no API change. Adding an env var now signals "this is a knob we tune" when it's actually a best-effort convergence limit.
+**Don't suggest**: Exposing `max_iterations` via API, reading from `.env` at startup, per-voyage overrides

--- a/pdd/prompts/features/crew/PLAN-shipwright-agent.md
+++ b/pdd/prompts/features/crew/PLAN-shipwright-agent.md
@@ -1,0 +1,274 @@
+# Implementation Plan: Shipwright Agent (Phase 13)
+
+**Created**: 2026-04-17
+**Issue**: #14
+**Complexity**: High — iteration loop in the graph, parallel invocations, novel DB model for per-phase build runs, git commit path
+**Estimated prompts**: 1 (single PDD prompt, matching Captain/Navigator/Doctor precedent)
+
+## Summary
+
+The Shipwright is a **phase-scoped developer agent**. A single invocation takes
+one `phase_number` for a voyage, reads that phase's Poneglyph and the matching
+`HealthCheck` rows (the failing tests from the Doctor), and enters an iteration
+loop: **generate code → run phase tests in the sandbox → on failure, feed the
+test output back into the prompt → regenerate → re-run**, up to
+`max_iterations`. On success, it commits the generated source files to the
+Shipwright's git branch and emits `CodeGeneratedEvent` + `TestsPassedEvent`.
+
+One invocation = one phase. Callers (Phase 15's voyage pipeline, or a user hitting
+the API directly) can fan out — multiple Shipwright invocations run concurrently
+against independent phases, each in its own sandbox session with its own LLM
+conversation state.
+
+Same three-layer crew pattern as Captain/Navigator/Doctor (`graph → service → API`
+with a `reader()` factory), atomic DB commit that includes a `VivreCard`
+checkpoint per iteration, best-effort event publishing after commit, best-effort
+git commit path.
+
+## Phases
+
+### Phase 1 (single prompt): Shipwright Agent end-to-end
+
+**Produces**:
+- `alembic/versions/<rev>_build_artifacts.py` — migration adding the
+  `build_artifacts` and `shipwright_runs` tables
+- `app/models/build_artifact.py` — `BuildArtifact` SQLAlchemy model
+  (one row per source file produced per phase)
+- `app/models/shipwright_run.py` — `ShipwrightRun` model (one row per
+  `build_code` invocation; stores iteration count, final status, pytest output)
+- `app/schemas/shipwright.py` — Pydantic schemas:
+  `BuildArtifactSpec`, `ShipwrightOutputSpec`, `BuildCodeRequest`,
+  `BuildResultResponse`, `BuildArtifactRead`, `BuildArtifactListResponse`
+- `app/schemas/build_artifact.py` — `BuildArtifactRead` (mirrors
+  `schemas/health_check.py`)
+- `app/crew/shipwright_graph.py` — LangGraph graph with nodes:
+  `generate → run_tests → [conditional: done | refine]` in a loop
+- `app/services/shipwright_service.py` — `ShipwrightService` with
+  `build_code(voyage, phase_number, user_id)` and
+  `get_build_artifacts(voyage_id, phase_number=None)`
+- `app/api/v1/shipwright.py` — `POST /voyages/{id}/phases/{phase_number}/build`,
+  `GET /voyages/{id}/phases/{phase_number}/build`,
+  `GET /voyages/{id}/build-artifacts`
+- `app/den_den_mushi/events.py` — add `CodeGeneratedEvent` and
+  `TestsPassedEvent` (if not already defined); wire into `AnyEvent`
+- `app/api/v1/router.py` — include the new router
+- Tests: `tests/test_shipwright_schemas.py`, `tests/test_shipwright_graph.py`,
+  `tests/test_shipwright_service.py`, `tests/test_shipwright_api.py`,
+  `tests/test_models.py` (extended)
+
+**Depends on**:
+- Navigator (`Poneglyph` rows must exist) — PR #28, merged
+- Doctor (`HealthCheck` rows must exist) — PR #32, merged
+- `ExecutionService` — used for sandboxed pytest runs during the loop
+- `GitService` — used for the best-effort final commit on success
+
+**Risk**: High — the iteration loop introduces state that Captain/Navigator/
+Doctor didn't need. Test-output feedback into the prompt is novel. Parallelism
+implies per-invocation isolation, not shared caches. Git commit on success has
+the same best-effort semantics as Doctor.
+
+**Prompt**: `pdd/prompts/features/crew/grandline-13-shipwrights.md`
+
+## Key design decisions (locked before prompt)
+
+1. **One invocation = one phase.** The API is `POST /voyages/{id}/phases/{phase_number}/build`,
+   not a voyage-level build endpoint. This is the parallelism primitive — the
+   future voyage pipeline (Phase 15) fans out one invocation per phase and
+   awaits them concurrently. Shipwright itself has no internal parallelism.
+
+2. **Iteration loop lives in the graph.** LangGraph `StateGraph` nodes:
+   - `generate` — LLM call via `CrewRole.SHIPWRIGHT` with system prompt +
+     user message built from Poneglyph + health-check sources + (if iteration > 1)
+     last run's pytest output.
+   - `run_tests` — calls `ExecutionService.run(user_id, ExecutionRequest(
+     command="python -m pytest -x --tb=short",
+     files=generated_files | test_files, timeout_seconds=120))`.
+   - **Conditional edge**: if `exit_code == 0` → `END`. Else if
+     `iteration < max_iterations` → back to `generate` with an incremented
+     iteration counter and the failure output added to state. Else → `END`
+     with `error="MAX_ITERATIONS_EXCEEDED"`.
+   - `max_iterations = 3` (constant `SHIPWRIGHT_MAX_ITERATIONS`).
+
+3. **Two new models**:
+   - `ShipwrightRun`: one row per `build_code` call. Holds `voyage_id`,
+     `phase_number`, `poneglyph_id`, `status` (`passed` | `failed` |
+     `max_iterations`), `iteration_count`, `exit_code`, `passed_count`,
+     `failed_count`, `total_count`, `output` (last 4000 chars of pytest stdout),
+     `created_at`.
+   - `BuildArtifact`: one row per generated source file, linked to the
+     ShipwrightRun via `shipwright_run_id`. Holds `voyage_id`, `phase_number`,
+     `file_path`, `content`, `language` (`python` | `typescript`),
+     `created_by="shipwright"`, `created_at`.
+
+   Rationale: `ShipwrightRun` is the equivalent of Doctor's `ValidationRun` —
+   one row per invocation for observability. `BuildArtifact` mirrors
+   `HealthCheck` — one row per file with the content verbatim. Git branch
+   is the externalized source of truth; the DB rows are the structured,
+   queryable record for the Observation Deck.
+
+4. **Replace-mode per phase.** Re-invoking on the same phase deletes existing
+   `BuildArtifact` rows for that `(voyage_id, phase_number)` before inserting.
+   `ShipwrightRun` rows are append-only (history preserved). Same lesson as
+   Navigator/Doctor — re-drafts replace, history of the attempt is retained.
+
+5. **Path safety (Doctor lesson).** `BuildArtifactSpec.file_path` uses the
+   same `_validate_relative_path` validator pattern Doctor added in PR #32 —
+   reject absolute paths, drive/scheme prefixes, and `..` traversal. LLM
+   output is untrusted and feeds both the sandbox and the host-side git commit.
+
+6. **Graph state shape** (TypedDict):
+   ```python
+   class ShipwrightState(TypedDict):
+       voyage_id: uuid.UUID
+       phase_number: int
+       poneglyph: dict[str, Any]          # parsed PoneglyphContentSpec
+       health_checks: list[dict[str, str]] # [{file_path, content, framework}]
+       iteration: int                      # 1-indexed
+       max_iterations: int
+       generated_files: dict[str, str]     # file_path -> content
+       last_test_output: str | None        # stdout+stderr from prev run
+       exit_code: int | None
+       passed_count: int
+       failed_count: int
+       total_count: int
+       status: Literal["passed", "failed", "max_iterations"] | None
+       error: str | None                   # parse failures, not test failures
+   ```
+
+7. **Structured `DoctorError`-style exception**: `ShipwrightError(code, message)`
+   with codes:
+   - `BUILD_PARSE_FAILED` — LLM returned malformed JSON after retries inside
+     the loop (not test failures — those are normal).
+   - `BUILD_MAX_ITERATIONS` — iteration loop exhausted without green tests.
+   - `PHASE_NOT_FOUND` — no Poneglyph for the requested phase_number.
+   - `HEALTH_CHECKS_NOT_FOUND` — no HealthCheck rows for the phase.
+   - API layer maps parse/iter errors to 422 and the not-found pair to 404.
+
+8. **Status lifecycle**: voyage moves to transient `BUILDING` during
+   `build_code`; restores to `CHARTED` on both success and failure so
+   re-invocation is possible. (Add `VoyageStatus.BUILDING` if missing from
+   enum — **check first**; project.md says phases 1-10 defined it but verify.)
+
+9. **`ShipwrightService.reader(session)`** — classmethod returning a
+   session-only instance for the GET endpoints, same pattern as Captain/
+   Navigator/Doctor.
+
+10. **Best-effort git commit** (after DB commit, on success only):
+    - `git_service.create_branch(voyage.id, user_id, "shipwright", base_branch="main")`
+    - `git_service.commit(voyage.id, user_id,
+      f"feat(phase-{phase_number}): Shipwright implementation",
+      crew_member="shipwright", files=generated_files)`
+    - `git_service.push(voyage.id, user_id, branch)`
+    - Wrapped in a single try/except — logs a warning on failure, never
+      fails the request. Skip if `voyage.target_repo` is not set.
+
+11. **Events** (best-effort publish after DB commit):
+    - `CodeGeneratedEvent(voyage_id, phase_number, shipwright_run_id,
+      file_count)` — always published on success.
+    - `TestsPassedEvent(voyage_id, phase_number, shipwright_run_id,
+      passed_count)` — published alongside `CodeGenerated` when tests green.
+    - No event on `BUILD_MAX_ITERATIONS` — that's an error response; the
+      voyage status reset is the observable signal. (Optionally add
+      `TestsFailedEvent` later; not required by the issue.)
+
+12. **Single Dial System call per iteration** — one LLM call, one JSON
+    response `{"files": [{"file_path": "...", "content": "...",
+    "language": "python"}]}`. Same `strip_fences` + `json.loads` +
+    `ShipwrightOutputSpec.model_validate()` flow as Navigator/Doctor. On
+    parse failure inside the loop: try ONE more LLM call with the parse
+    error appended; if that also fails, raise `ShipwrightError(
+    "BUILD_PARSE_FAILED")`.
+
+13. **VivreCard checkpoint per iteration** — during the loop, after each
+    `run_tests` node completes, the service persists a lightweight VivreCard
+    (`crew_member="shipwright"`, `state_data={"iteration": N,
+    "exit_code": X, "file_count": Y}`,
+    `checkpoint_reason="iteration"`). This is the "no work lost" guarantee —
+    if a provider failover happens mid-loop, the next invocation can see how
+    far the previous one got. Implementation: the service owns the loop
+    orchestration wrapper around graph invocations so it can checkpoint
+    between iterations (graph itself is pure; service is the orchestrator).
+
+    **Subtlety**: LangGraph's `.ainvoke()` runs the whole graph to completion.
+    To checkpoint per iteration, the service either (a) runs the graph with
+    `recursion_limit=1` in a Python loop, calling DB commit between runs,
+    or (b) uses LangGraph's built-in checkpointer. For v1, option (a) —
+    the service's loop wraps single-iteration graph invocations and owns
+    the VivreCard writes. Keeps DB persistence out of the graph (graph
+    stays side-effect-free except for the LLM/sandbox calls its nodes make).
+
+14. **API responses** (`BuildResultResponse`):
+    ```python
+    class BuildResultResponse(BaseModel):
+        voyage_id: uuid.UUID
+        phase_number: int
+        shipwright_run_id: uuid.UUID
+        status: Literal["passed", "failed", "max_iterations"]
+        iteration_count: int
+        passed_count: int
+        failed_count: int
+        total_count: int
+        file_count: int
+        summary: str
+    ```
+    201 on first-time success, 200 on re-invocation replace. 409 if voyage
+    status is not `CHARTED`. 404 for missing poneglyph/health-checks
+    (API-layer pre-check via `NavigatorService.reader` and
+    `DoctorService.reader`, following Doctor's 404-not-422 pattern).
+
+15. **Shipwright system prompt** is explicit that it is implementing code
+    to satisfy *pre-written failing tests*. The LLM receives the health
+    check test file(s) verbatim as part of the user message, plus the
+    Poneglyph's `task_description`, `test_criteria`, and `file_paths`.
+    On iteration 2+, it additionally receives the previous pytest
+    `stdout[-2000:]` with a "the tests still fail. fix the issues
+    reported below" directive.
+
+## Risks & Unknowns
+
+- **Parallel invocation contention on `voyage.status`**: two Shipwrights
+  racing to set `status = BUILDING` on the same voyage both think they
+  own it. For v1, sequential enforcement at the API layer (one in-flight
+  per voyage) is simplest. Better long-term: move phase-level status off
+  the voyage row into a new `phase_status` map (future work). **Locking
+  decision**: v1 keeps the voyage-level status check (409 if already
+  `BUILDING`). The Phase 15 voyage pipeline will sequence Shipwright
+  invocations per-phase; user-level parallelism across phases waits for
+  the phase_status refactor. **This is a scope-cut, log in decisions.md.**
+
+- **Max iterations = 3 arbitrariness**: chosen to match typical Claude/
+  GPT-4 code-writing attention span. Configurable via an env var in a
+  follow-up; not exposed via API yet. If 3 proves too low in Phase 15
+  integration tests, bump the constant — no schema change needed.
+
+- **pytest not installed in sandbox**: same risk Doctor had. Mitigation
+  is the same — mock `ExecutionService` in unit tests; leave the real
+  end-to-end check to Phase 15's pipeline integration test.
+
+- **Token budget**: feeding test output back into the prompt inflates
+  tokens each iteration. Cap `last_test_output` at 2000 chars and
+  truncate verbosely. Consider dropping the original test criteria from
+  iteration 2+ since they're now implicit in the test content — skip for
+  v1 to keep the prompt construction simple.
+
+- **Non-Python languages**: Shipwright must also produce TypeScript for
+  frontend phases. For v1 the test runner is `pytest` only; if a phase's
+  `health_checks[0].framework == "vitest"`, the service returns early
+  with `ShipwrightError("VITEST_NOT_SUPPORTED")`. Document explicitly
+  in the prompt. Vitest support is a follow-up phase.
+
+## Decisions Needed
+
+All locked above — proceeding to prompt generation. Three decisions worth
+logging to `pdd/context/decisions.md` after implementation:
+1. Shipwright invocation is **phase-scoped** (not voyage-scoped).
+2. Iteration loop is **service-owned**, not graph-owned, to enable
+   per-iteration VivreCard checkpointing without graph side effects.
+3. `BuildArtifact` + `ShipwrightRun` split mirrors the Doctor's
+   `HealthCheck` + `ValidationRun` split — per-file rows linked to
+   per-run rows.
+
+## Next step
+
+Run `/pdd-skill:pdd-prompts` with this plan in hand, producing
+`pdd/prompts/features/crew/grandline-13-shipwrights.md`.

--- a/pdd/prompts/features/crew/grandline-13-shipwrights.md
+++ b/pdd/prompts/features/crew/grandline-13-shipwrights.md
@@ -1,0 +1,786 @@
+# Phase 13: Shipwright Agent (Developer)
+
+## Context
+
+The Shipwright is the fourth crew agent. It's the **developer** — reads the
+Navigator's Poneglyph for one phase, reads the Doctor's failing `HealthCheck`
+tests for that phase, and generates source code that makes those tests pass.
+When it succeeds, it commits the code to the Shipwright's git branch.
+
+Unlike Navigator (one call, multi-phase batch) and Doctor (one call,
+multi-phase batch), the Shipwright is **phase-scoped**: one invocation builds
+one phase. This is the parallelism primitive — the future voyage pipeline
+(Phase 15) will fan out one Shipwright invocation per phase and run them
+concurrently.
+
+The Shipwright also has an **iteration loop** the other agents don't have.
+After generating code, it runs pytest against the generated files + the
+stored health-check tests in the sandbox. If tests fail and iterations
+remain, the failure output is fed back into the prompt and the code is
+regenerated. The loop terminates on green tests or after 3 attempts
+(`SHIPWRIGHT_MAX_ITERATIONS = 3`).
+
+Same three-layer crew agent pattern as Captain/Navigator/Doctor
+(`graph → service → API` with `reader()` factory), atomic DB commit that
+includes a `VivreCard` checkpoint, best-effort event publishing after
+commit, best-effort git commit path. Reuse `strip_fences` from
+`app/crew/utils.py`.
+
+**Key architectural note**: the iteration loop lives in the **service layer**,
+not inside the compiled LangGraph graph. The service runs single-iteration
+graph invocations in a Python loop and persists a `VivreCard` between
+iterations. Graph nodes stay side-effect-free (they only call the Dial
+System and the Execution Service). This choice is locked in
+`pdd/context/decisions.md` (2026-04-17) — see "Service-owned iteration
+loop".
+
+### Existing Infrastructure
+
+| System | Module | Key Interfaces |
+|--------|--------|----------------|
+| **Navigator** | `app.services.navigator_service.NavigatorService` | `NavigatorService.reader(session).get_poneglyphs(voyage_id)` |
+| **Doctor** | `app.services.doctor_service.DoctorService` | `DoctorService.reader(session).get_health_checks(voyage_id)` |
+| **Dial System** | `app.dial_system.router.DialSystemRouter` | `route(role, CompletionRequest) -> CompletionResult` |
+| **Den Den Mushi** | `app.den_den_mushi.mushi.DenDenMushi` | `publish(stream, event)` |
+| **Execution Service** | `app.services.execution_service.ExecutionService` | `run(user_id, ExecutionRequest) -> ExecutionResult` |
+| **Git Service** | `app.services.git_service.GitService` | `create_branch(voyage_id, user_id, crew_member, base)`, `commit(voyage_id, user_id, message, crew_member, files={path: content})`, `push(voyage_id, user_id, branch)` |
+| **VivreCard Service** | `app.services.vivre_card_service.VivreCardService` | `checkpoint(session, voyage_id, crew_member, state_data, checkpoint_reason)` |
+| **Models** | `app.models.poneglyph.Poneglyph` | `id, voyage_id, phase_number, content (Text), metadata_` |
+| **Models** | `app.models.health_check.HealthCheck` | `id, voyage_id, phase_number, poneglyph_id, file_path, content, framework, ...` |
+| **Events** | `app.den_den_mushi.events` | `CodeGeneratedEvent` (already defined); `TestsPassedEvent` needs to be added |
+| **Enums** | `app.models.enums` | `CrewRole.SHIPWRIGHT`, `VoyageStatus.BUILDING`, `VoyageStatus.CHARTED` (all already defined) |
+| **Constants** | `app.den_den_mushi.constants` | `stream_key(voyage_id)` |
+| **Shared helpers** | `app.crew.utils` | `strip_fences(text)` |
+| **Doctor Graph** | `app.crew.doctor_graph` | Reference pattern: two-node StateGraph |
+
+`Poneglyph.content` is a JSON string holding a `PoneglyphContentSpec` (from
+`app.schemas.navigator`). The Shipwright parses it to extract
+`task_description`, `test_criteria`, and `file_paths`. If a Poneglyph's JSON
+is malformed, log a warning and fall back to an empty dict (Doctor lesson —
+do not raise, do not silently swallow).
+
+`HealthCheck.content` is the failing test source verbatim. The Shipwright
+passes the list of `{file_path, content, framework}` tuples to the LLM so
+the model sees the tests it must make pass.
+
+`ExecutionRequest` takes `command: str`, `files: dict[str, str] | None = None`,
+`timeout_seconds: int | None = None`. `ExecutionResult` has
+`stdout, stderr, exit_code, duration_ms`. Paths in `files=` are relative to
+`/workspace/` in the sandbox.
+
+## Deliverables
+
+### 1. Database — new `BuildArtifact` + `ShipwrightRun` models + migration
+
+Two new tables in a single migration file under
+`src/backend/alembic/versions/`. `shipwright_runs` is created first so
+`build_artifacts.shipwright_run_id` can reference it. The migration's
+`down_revision` is the current head — **verify with `alembic history`**; at
+time of writing it is `a1b2c3d4e5f6`.
+
+```python
+op.create_table(
+    "shipwright_runs",
+    sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+    sa.Column("voyage_id", postgresql.UUID(as_uuid=True),
+              sa.ForeignKey("voyages.id"), nullable=False, index=True),
+    sa.Column("poneglyph_id", postgresql.UUID(as_uuid=True),
+              sa.ForeignKey("poneglyphs.id"), nullable=True, index=True),
+    sa.Column("phase_number", sa.Integer(), nullable=False),
+    sa.Column("status", sa.String(20), nullable=False),  # passed | failed | max_iterations
+    sa.Column("iteration_count", sa.Integer(), nullable=False, server_default="0"),
+    sa.Column("exit_code", sa.Integer(), nullable=True),
+    sa.Column("passed_count", sa.Integer(), nullable=False, server_default="0"),
+    sa.Column("failed_count", sa.Integer(), nullable=False, server_default="0"),
+    sa.Column("total_count", sa.Integer(), nullable=False, server_default="0"),
+    sa.Column("output", sa.Text(), nullable=True),
+    sa.Column("created_at", sa.DateTime(timezone=True), nullable=False,
+              server_default=sa.func.now()),
+)
+op.create_index("ix_shipwright_runs_voyage_phase", "shipwright_runs",
+                ["voyage_id", "phase_number"])
+
+op.create_table(
+    "build_artifacts",
+    sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+    sa.Column("voyage_id", postgresql.UUID(as_uuid=True),
+              sa.ForeignKey("voyages.id"), nullable=False, index=True),
+    sa.Column("shipwright_run_id", postgresql.UUID(as_uuid=True),
+              sa.ForeignKey("shipwright_runs.id"), nullable=False, index=True),
+    sa.Column("phase_number", sa.Integer(), nullable=False),
+    sa.Column("file_path", sa.String(500), nullable=False),
+    sa.Column("content", sa.Text(), nullable=False),
+    sa.Column("language", sa.String(20), nullable=False, server_default="python"),
+    sa.Column("created_by", sa.String(50), nullable=False, server_default="shipwright"),
+    sa.Column("created_at", sa.DateTime(timezone=True), nullable=False,
+              server_default=sa.func.now()),
+)
+op.create_index("ix_build_artifacts_voyage_phase", "build_artifacts",
+                ["voyage_id", "phase_number"])
+```
+
+Downgrade drops both tables and both indexes in reverse order
+(`build_artifacts` first, then `shipwright_runs`).
+
+**No `metadata` JSONB on `BuildArtifact` and no stdout duplicated onto
+per-file rows.** Per-run output lives on `ShipwrightRun.output`; the
+`BuildArtifact` table is pure source-file content. (Doctor review lesson —
+don't re-add a bag-of-extras column and don't duplicate stdout across
+every file row.)
+
+SQLAlchemy models:
+
+`app/models/shipwright_run.py`:
+
+```python
+class ShipwrightRun(Base):
+    __tablename__ = "shipwright_runs"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True,
+                                          default=uuid.uuid4)
+    voyage_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("voyages.id"), index=True, nullable=False
+    )
+    poneglyph_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("poneglyphs.id"), index=True, nullable=True
+    )
+    phase_number: Mapped[int] = mapped_column(Integer, nullable=False)
+    status: Mapped[str] = mapped_column(String(20), nullable=False)
+    iteration_count: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
+    exit_code: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    passed_count: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
+    failed_count: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
+    total_count: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
+    output: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+```
+
+`app/models/build_artifact.py`:
+
+```python
+class BuildArtifact(Base):
+    __tablename__ = "build_artifacts"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True,
+                                          default=uuid.uuid4)
+    voyage_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("voyages.id"), index=True, nullable=False
+    )
+    shipwright_run_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("shipwright_runs.id"),
+        index=True, nullable=False
+    )
+    phase_number: Mapped[int] = mapped_column(Integer, nullable=False)
+    file_path: Mapped[str] = mapped_column(String(500), nullable=False)
+    content: Mapped[str] = mapped_column(Text, nullable=False)
+    language: Mapped[str] = mapped_column(String(20), default="python", nullable=False)
+    created_by: Mapped[str] = mapped_column(String(50), default="shipwright",
+                                             nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+```
+
+Export both from `app/models/__init__.py`.
+
+### 2. Pydantic Schemas
+
+`app/schemas/build_artifact.py` — read model (mirrors
+`schemas/health_check.py`):
+
+```python
+class BuildArtifactRead(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+    id: uuid.UUID
+    voyage_id: uuid.UUID
+    shipwright_run_id: uuid.UUID
+    phase_number: int
+    file_path: str
+    content: str
+    language: str
+    created_by: str
+    created_at: datetime
+```
+
+`app/schemas/shipwright.py` — includes **path-safety validators** on every
+LLM-supplied path. Reuse the exact validator pattern Doctor landed in PR
+#32 (`_validate_relative_path`): reject absolute paths, drive/scheme
+prefixes in the first segment, and `..` traversal.
+
+```python
+import posixpath
+
+def _validate_relative_path(path: str) -> str:
+    if path.startswith("/") or path.startswith("\\"):
+        raise ValueError(f"Path must be relative, got {path!r}")
+    if ":" in path.split("/")[0]:
+        raise ValueError(f"Path must not be a drive/scheme, got {path!r}")
+    normalized = posixpath.normpath(path)
+    if normalized.startswith("..") or "/../" in f"/{normalized}/":
+        raise ValueError(f"Path traversal not allowed in {path!r}")
+    if normalized in (".", ""):
+        raise ValueError(f"Path must not be empty, got {path!r}")
+    return path
+
+
+class BuildArtifactSpec(BaseModel):
+    """What the LLM emits for one generated source file."""
+    file_path: str = Field(min_length=1, max_length=500)
+    content: str = Field(min_length=1)
+    language: Literal["python", "typescript", "javascript"] = "python"
+
+    @field_validator("file_path")
+    @classmethod
+    def _validate_file_path(cls, v: str) -> str:
+        return _validate_relative_path(v)
+
+
+class ShipwrightOutputSpec(BaseModel):
+    """Full LLM output — at least one source file per invocation."""
+    files: list[BuildArtifactSpec] = Field(min_length=1)
+
+    @model_validator(mode="after")
+    def validate_unique_file_paths(self) -> ShipwrightOutputSpec:
+        paths = [f.file_path for f in self.files]
+        if len(paths) != len(set(paths)):
+            raise ValueError("Duplicate file_path values in files")
+        return self
+
+
+class BuildResultResponse(BaseModel):
+    voyage_id: uuid.UUID
+    phase_number: int
+    shipwright_run_id: uuid.UUID
+    status: Literal["passed", "failed", "max_iterations"]
+    iteration_count: int
+    passed_count: int
+    failed_count: int
+    total_count: int
+    file_count: int
+    summary: str
+
+
+class BuildArtifactListResponse(BaseModel):
+    voyage_id: uuid.UUID
+    phase_number: int | None
+    artifacts: list[BuildArtifactRead]
+```
+
+Note: `BuildCodeRequest` is **not** a body — the phase number lives in the
+URL path. `POST /phases/{phase_number}/build` takes no body. (If a future
+caller needs to pass overrides, add a body then; v1 keeps it simple.)
+
+### 3. LangGraph Graph — `app/crew/shipwright_graph.py`
+
+A minimal **two-node** StateGraph (same pattern as Navigator/Doctor).
+The graph runs **one iteration** per `.ainvoke()` call — the service
+wraps it in a Python loop and persists a `VivreCard` between iterations.
+Graph nodes have **no DB writes**.
+
+```
+[generate] → [run_tests]
+```
+
+**State schema:**
+
+```python
+class ShipwrightState(TypedDict):
+    voyage_id: uuid.UUID
+    phase_number: int
+    poneglyph: dict[str, Any]           # parsed PoneglyphContentSpec + phase_number
+    health_checks: list[dict[str, str]] # [{file_path, content, framework}]
+    iteration: int                       # 1-indexed
+    last_test_output: str | None         # previous iteration's pytest stdout
+    generated_files: list[BuildArtifactSpec] | None
+    exit_code: int | None
+    stdout: str
+    passed_count: int
+    failed_count: int
+    total_count: int
+    error: str | None                    # LLM parse failure, not test failure
+```
+
+**Nodes:**
+
+- `generate`: builds a user message containing the Poneglyph's
+  `task_description`, `test_criteria`, and `file_paths`, plus the full text
+  of each `HealthCheck.content` under a clearly-labeled "## Tests you must
+  make pass" section. If `state["iteration"] > 1` and `last_test_output is
+  not None`, append a "## Previous attempt — tests still failed" section
+  containing `last_test_output[-2000:]` and the directive *"The tests above
+  still fail. Fix the issues reported and regenerate the complete file
+  set."* Calls `DialSystemRouter.route(CrewRole.SHIPWRIGHT, ...)` and
+  stores `raw_output`. Then runs `strip_fences` + `json.loads` +
+  `ShipwrightOutputSpec.model_validate`. On any `json.JSONDecodeError`,
+  `ValueError`, or `KeyError`, stores the error string and sets
+  `generated_files=None`.
+
+- `run_tests`: **only runs if `generated_files is not None`.** Builds
+  `files = {f.file_path: f.content for f in state["generated_files"]} |
+  {hc["file_path"]: hc["content"] for hc in state["health_checks"]}`.
+  Calls `ExecutionService.run(user_id, ExecutionRequest(
+  command="cd /workspace && python -m pytest -x --tb=short",
+  files=files, timeout_seconds=120))`. Stores `exit_code`, `stdout`, and
+  parses `passed_count`/`failed_count` from the stdout (best-effort — same
+  parsing rule as Doctor: count `PASSED`/`FAILED` tokens, fall back to
+  `exit_code == 0 → passed=total`, else `failed=total`).
+
+**System prompt** (constant `SHIPWRIGHT_SYSTEM_PROMPT`):
+
+```
+You are a Shipwright — a developer agent on a software engineering crew.
+Your job is to write source code that makes the Doctor's pre-written
+failing tests pass. The tests are the specification; your code is the
+implementation.
+
+You will receive:
+- A Poneglyph describing one phase of the work (task description, test
+  criteria, intended file paths)
+- The exact content of the failing test files for that phase
+- If this is a retry, the previous test run's output
+
+Produce a complete set of source files that satisfy the tests. Every file
+you emit must be importable and runnable as-is. Do not include the test
+files themselves in your output — those already exist.
+
+Rules for file_path values:
+- Use relative paths only (no leading /, no drive letters, no ..)
+- Match the style in the Poneglyph's file_paths hint where possible
+
+Respond with ONLY a JSON object: {"files": [{"file_path": "...",
+"content": "...", "language": "python"}, ...]}
+Do not include any other text, markdown formatting, or explanation.
+```
+
+**Build function:**
+
+```python
+def build_shipwright_graph(
+    dial_router: DialSystemRouter,
+    execution_service: ExecutionService,
+) -> CompiledStateGraph: ...
+```
+
+### 4. Events — add `TestsPassedEvent`
+
+`CodeGeneratedEvent` already exists in `app/den_den_mushi/events.py`.
+Add `TestsPassedEvent` symmetric with `ValidationPassedEvent`:
+
+```python
+class TestsPassedEvent(DenDenMushiEvent):
+    event_type: Literal["tests_passed"] = "tests_passed"
+```
+
+Add it to the `AnyEvent` discriminated union. Do not add
+`TestsFailedEvent` — the issue doesn't require it and a failed
+`build_code` returns an error response; the voyage status reset is the
+observable signal.
+
+### 5. ShipwrightService — `app/services/shipwright_service.py`
+
+```python
+SHIPWRIGHT_MAX_ITERATIONS = 3
+
+
+class ShipwrightError(Exception):
+    def __init__(self, code: str, message: str) -> None:
+        self.code = code
+        self.message = message
+        super().__init__(message)
+
+
+class ShipwrightService:
+    def __init__(
+        self,
+        dial_router: DialSystemRouter,
+        mushi: DenDenMushi,
+        session: AsyncSession,
+        execution_service: ExecutionService,
+        git_service: GitService | None = None,  # optional
+    ) -> None:
+        self._dial_router = dial_router
+        self._mushi = mushi
+        self._session = session
+        self._execution = execution_service
+        self._git = git_service
+        self._graph = build_shipwright_graph(dial_router, execution_service)
+
+    @classmethod
+    def reader(cls, session: AsyncSession) -> ShipwrightService:
+        inst = cls.__new__(cls)
+        inst._session = session
+        inst._dial_router = None   # type: ignore[assignment]
+        inst._mushi = None         # type: ignore[assignment]
+        inst._execution = None     # type: ignore[assignment]
+        inst._git = None           # type: ignore[assignment]
+        inst._graph = None         # type: ignore[assignment]
+        return inst
+
+    async def build_code(
+        self,
+        voyage: Voyage,
+        phase_number: int,
+        poneglyph: Poneglyph,
+        health_checks: list[HealthCheck],
+        user_id: uuid.UUID,
+    ) -> BuildResultResponse: ...
+
+    async def get_build_artifacts(
+        self,
+        voyage_id: uuid.UUID,
+        phase_number: int | None = None,
+    ) -> list[BuildArtifact]: ...
+
+    async def get_latest_run(
+        self,
+        voyage_id: uuid.UUID,
+        phase_number: int,
+    ) -> ShipwrightRun | None: ...
+```
+
+**`build_code` flow:**
+
+1. **Framework gate**: if any `hc.framework != "pytest"`, raise
+   `ShipwrightError("VITEST_NOT_SUPPORTED", ...)`. Vitest is deferred
+   (see `decisions.md` 2026-04-17).
+2. Set `voyage.status = BUILDING`, flush.
+3. Build the initial graph state:
+   - `poneglyph = {"phase_number": poneglyph.phase_number, **_parse_poneglyph_content(poneglyph)}`
+     where `_parse_poneglyph_content` does `json.loads` with a
+     `try/except json.JSONDecodeError` that logs a warning with
+     `poneglyph_id` and `phase_number` and returns `{}`.
+   - `health_checks = [{"file_path": hc.file_path, "content": hc.content,
+     "framework": hc.framework} for hc in health_checks]`
+   - `iteration = 1`, `last_test_output = None`, `generated_files = None`.
+4. **Iteration loop** (service-owned, up to `SHIPWRIGHT_MAX_ITERATIONS`):
+   ```python
+   for i in range(1, SHIPWRIGHT_MAX_ITERATIONS + 1):
+       state["iteration"] = i
+       state = await self._graph.ainvoke(state)
+       # Checkpoint after each iteration (best-effort)
+       await self._checkpoint_iteration(voyage, state)
+       if state.get("error"):
+           # LLM output couldn't be parsed. Try one more iteration with
+           # the error fed back in via last_test_output; if it fails a
+           # second time, raise.
+           if i < SHIPWRIGHT_MAX_ITERATIONS:
+               state["last_test_output"] = f"Previous JSON parse failed: {state['error']}"
+               continue
+           voyage.status = VoyageStatus.CHARTED.value
+           await self._session.flush()
+           raise ShipwrightError("BUILD_PARSE_FAILED", state["error"])
+       if state["exit_code"] == 0:
+           break
+       # Tests failed — feed output back for next iteration
+       state["last_test_output"] = state["stdout"]
+   ```
+5. After the loop, decide final status:
+   - `"passed"` if `exit_code == 0`
+   - `"max_iterations"` if all iterations ran without green
+6. Create one `ShipwrightRun` row with `status`, `iteration_count = i`,
+   `exit_code`, counts, `output = stdout[-4000:]`. Flush to get `run.id`.
+7. If status is `"passed"`: delete any existing `BuildArtifact` rows for
+   `(voyage_id, phase_number)` (**replace mode** — Navigator/Doctor lesson),
+   then insert one `BuildArtifact` per generated file linked to `run.id`.
+8. Create a final `VivreCard` (`crew_member="shipwright"`,
+   `state_data={"phase_number": phase_number, "iteration_count": i,
+   "status": status, "file_count": N}`,
+   `checkpoint_reason="build_complete"`).
+9. Set `voyage.status = CHARTED`, `await session.commit()`, refresh rows.
+10. **Best-effort git commit** (only on `status == "passed"` and only if
+    `self._git is not None` and `voyage.target_repo` is set):
+    - `create_branch(voyage.id, user_id, "shipwright", base_branch="main")`
+    - `commit(voyage.id, user_id,
+      f"feat(phase-{phase_number}): Shipwright implementation",
+      crew_member="shipwright",
+      files={a.file_path: a.content for a in artifacts})`
+    - `push(voyage.id, user_id, branch)`
+    Wrapped in a single try/except — logs a warning on failure, never
+    fails the request.
+11. **Best-effort event publish** (only on `status == "passed"`):
+    - `CodeGeneratedEvent(voyage_id, source_role=CrewRole.SHIPWRIGHT,
+      payload={"phase_number": N, "shipwright_run_id": run.id,
+      "file_count": N})`
+    - `TestsPassedEvent(voyage_id, source_role=CrewRole.SHIPWRIGHT,
+      payload={"phase_number": N, "shipwright_run_id": run.id,
+      "passed_count": N})`
+    - On failure or max_iterations: do not publish.
+12. Return a `BuildResultResponse`.
+
+**`_checkpoint_iteration` helper:**
+
+Writes a `VivreCard` with `crew_member="shipwright"`,
+`state_data={"phase_number": N, "iteration": i, "exit_code": X,
+"file_count": len(generated_files or [])}`,
+`checkpoint_reason="iteration"`. Best-effort — logs on failure but does
+not raise. This is how we honor "no work lost" during long loops.
+
+**`get_build_artifacts` flow:**
+
+- `SELECT * FROM build_artifacts WHERE voyage_id = :v`
+- If `phase_number is not None`, add `AND phase_number = :p`.
+- Return ordered by `phase_number, file_path`.
+
+**`get_latest_run` flow:**
+
+- `SELECT * FROM shipwright_runs WHERE voyage_id = :v AND phase_number = :p
+  ORDER BY created_at DESC LIMIT 1`.
+
+### 6. REST API — `app/api/v1/shipwright.py`
+
+Router with prefix `/voyages/{voyage_id}`, tag `shipwright`.
+
+| Method | Path | Handler | Response |
+|--------|------|---------|----------|
+| POST | `/phases/{phase_number}/build` | `build_phase` | 201 → `BuildResultResponse` |
+| GET  | `/phases/{phase_number}/build` | `get_phase_build` | 200 → `BuildResultResponse` |
+| GET  | `/build-artifacts` | `list_build_artifacts` | 200 → `BuildArtifactListResponse` |
+
+**POST `/phases/{phase_number}/build` rules:**
+
+1. Voyage must be owned by user and have status `CHARTED` → else
+   409 `VOYAGE_NOT_BUILDABLE`. (Serializes invocations per voyage in v1;
+   see `decisions.md`.)
+2. **API-layer 404 pre-checks** (Doctor lesson — 404 for missing
+   prerequisites, 422 is for service-layer invariant violations):
+   - Fetch Poneglyphs via `NavigatorService.reader(session).get_poneglyphs(
+     voyage_id)`. Find the one matching `phase_number`. If none → 404
+     `PONEGLYPH_NOT_FOUND`.
+   - Fetch HealthChecks via `DoctorService.reader(session).get_health_checks(
+     voyage_id)`. Filter to `phase_number`. If empty → 404
+     `HEALTH_CHECKS_NOT_FOUND`.
+3. Call `shipwright_service.build_code(voyage, phase_number, poneglyph,
+   filtered_health_checks, user.id)`.
+4. `ShipwrightError` → 422 `{"error": {"code": exc.code,
+   "message": exc.message}}`.
+
+**GET `/phases/{phase_number}/build` rules:**
+
+- Returns the **latest** `ShipwrightRun` for the phase as a
+  `BuildResultResponse`.
+- 404 `BUILD_NOT_FOUND` if no run exists.
+- Uses `get_shipwright_reader` dependency (session-only).
+
+**GET `/build-artifacts` rules:**
+
+- Optional query param `phase_number: int | None = None`.
+- 200 with the list (empty list OK).
+- Uses `get_shipwright_reader`.
+
+**Dependencies:**
+
+```python
+async def get_shipwright_service(
+    voyage_id: uuid.UUID,
+    dial_router: DialSystemRouter = Depends(get_dial_router),
+    mushi: DenDenMushi = Depends(get_den_den_mushi),
+    session: AsyncSession = Depends(get_db),
+    execution_service: ExecutionService = Depends(get_execution_service),
+    git_service: GitService = Depends(get_git_service),
+) -> ShipwrightService:
+    return ShipwrightService(
+        dial_router, mushi, session,
+        execution_service=execution_service,
+        git_service=git_service,
+    )
+
+async def get_shipwright_reader(
+    session: AsyncSession = Depends(get_db),
+) -> ShipwrightService:
+    return ShipwrightService.reader(session)
+```
+
+Reuse existing `get_execution_service` and `get_git_service` from
+`app/api/v1/dependencies.py`. Reuse `get_navigator_reader` from
+`app/api/v1/navigator.py` and `get_doctor_reader` from
+`app/api/v1/doctor.py` for the 404 pre-checks.
+
+### 7. Wiring
+
+- Register `BuildArtifact` and `ShipwrightRun` imports in
+  `app/models/__init__.py`.
+- Add `shipwright.router` include in `app/api/v1/router.py`.
+- Add `TestsPassedEvent` to `app/den_den_mushi/events.py` and the
+  `AnyEvent` union.
+
+## Test Plan
+
+All tests use mocked dependencies (no real LLM, DB, sandbox, or git).
+
+### Model/Migration Tests — extend `tests/test_models.py`
+
+1. `build_artifacts` and `shipwright_runs` appear in
+   `Base.metadata.tables`.
+2. `test_shipwright_run_table_columns` — full column set matches.
+3. `test_build_artifact_table_columns` — full column set matches.
+4. `test_shipwright_run_voyage_phase_indexed` — composite index exists.
+5. `test_build_artifact_voyage_phase_indexed` — composite index exists.
+
+### Schema Tests — `tests/test_shipwright_schemas.py`
+
+1. `BuildArtifactSpec` accepts valid python file.
+2. `BuildArtifactSpec` accepts valid typescript file.
+3. `BuildArtifactSpec` rejects empty `file_path`.
+4. `BuildArtifactSpec` rejects empty `content`.
+5. `BuildArtifactSpec` rejects invalid `language`.
+6. `BuildArtifactSpec` defaults `language` to `python`.
+7. `BuildArtifactSpec` rejects absolute `file_path`.
+8. `BuildArtifactSpec` rejects traversal `../../etc/passwd`.
+9. `BuildArtifactSpec` rejects nested traversal.
+10. `BuildArtifactSpec` accepts nested relative path.
+11. `ShipwrightOutputSpec` rejects empty `files`.
+12. `ShipwrightOutputSpec` rejects duplicate file paths.
+13. `ShipwrightOutputSpec` accepts multi-file output.
+14. `BuildResultResponse` rejects status outside literal set.
+
+### Graph Tests — `tests/test_shipwright_graph.py`
+
+1. `generate` node sends `CrewRole.SHIPWRIGHT` to the dial router.
+2. `generate` node includes Poneglyph `task_description` in user message.
+3. `generate` node includes each `HealthCheck.content` verbatim in user
+   message.
+4. `generate` node on `iteration == 2` includes previous test output.
+5. `generate` node on valid JSON → `generated_files` populated,
+   `error=None`.
+6. `generate` node on malformed JSON → `generated_files=None`,
+   `error` set.
+7. `generate` node strips ```json fences.
+8. `run_tests` node skips execution when `generated_files is None`.
+9. `run_tests` node calls `ExecutionService.run` with merged files.
+10. `run_tests` node parses `exit_code == 0` as pass.
+11. `run_tests` node parses `exit_code != 0` as fail.
+12. Full graph returns a full state dict with both nodes' outputs.
+
+### Service Tests — `tests/test_shipwright_service.py`
+
+Fixtures: mock session (`.add`, `.flush`, `.commit`, `.execute`), mock
+dial_router, mock mushi, mock execution_service, mock git_service,
+mock graph `.ainvoke` that returns a preset state. Build a
+`_mock_poneglyph(phase_number)` helper with valid JSON content and
+`_mock_health_check(phase_number)` helpers.
+
+**`build_code` — happy path:**
+
+1. Sets voyage status to `BUILDING` during the call.
+2. Invokes the graph with `iteration=1` initially.
+3. On graph returning `exit_code=0` on iteration 1, terminates the loop.
+4. Persists one `ShipwrightRun` row with `status="passed"`,
+   `iteration_count=1`, counts from the graph state.
+5. Deletes existing `BuildArtifact` rows for `(voyage_id, phase_number)`
+   before inserting (assert a `Delete` statement is executed).
+6. Persists one `BuildArtifact` per generated file, linked to the run id.
+7. Creates a `VivreCard` with `checkpoint_reason="build_complete"`.
+8. Creates `VivreCard`s with `checkpoint_reason="iteration"` — one per
+   iteration.
+9. Calls `session.commit()` exactly once.
+10. Restores voyage status to `CHARTED`.
+11. Publishes `CodeGeneratedEvent` and `TestsPassedEvent` on success.
+12. Succeeds when publish raises (best-effort).
+13. Calls `git_service.create_branch/commit/push` once each when `git_service`
+    and `voyage.target_repo` are both set.
+14. When `git_service.commit` raises, `build_code` still returns
+    successfully.
+15. Skips git entirely when `git_service` is `None`.
+
+**`build_code` — iteration loop:**
+
+16. When iteration 1 returns `exit_code != 0`, graph is invoked again with
+    `iteration=2` and `last_test_output` populated.
+17. When all iterations fail, terminates with `status="max_iterations"`.
+18. On `max_iterations`, no `BuildArtifact` rows are inserted.
+19. On `max_iterations`, no `CodeGeneratedEvent` or `TestsPassedEvent` is
+    published.
+20. On `max_iterations`, voyage status is restored to `CHARTED`.
+21. On `max_iterations`, a `ShipwrightRun` row is persisted with
+    `iteration_count=3`, `status="max_iterations"`.
+
+**`build_code` — error paths:**
+
+22. Raises `ShipwrightError("VITEST_NOT_SUPPORTED")` when any health check
+    has `framework="vitest"`; voyage status reset to `CHARTED`; no graph
+    invocation.
+23. Raises `ShipwrightError("BUILD_PARSE_FAILED")` when the graph returns
+    `error` on every iteration; voyage status reset to `CHARTED`.
+24. On malformed Poneglyph JSON, a warning is logged and the service
+    still proceeds with an empty-dict fallback (degradation).
+
+**`get_build_artifacts`:**
+
+25. Returns rows ordered by `phase_number, file_path`.
+26. Filters by `phase_number` when supplied.
+27. Returns empty list when none exist.
+28. Reader instance can call it.
+
+**`get_latest_run`:**
+
+29. Returns the most recent row for the phase.
+30. Returns `None` when no row exists.
+
+### API Tests — `tests/test_shipwright_api.py`
+
+1. POST `/phases/{n}/build` returns 201 with `BuildResultResponse`.
+2. POST `/phases/{n}/build` returns 409 when voyage not `CHARTED`.
+3. POST `/phases/{n}/build` returns 404 `PONEGLYPH_NOT_FOUND` when no
+   poneglyph matches; asserts `build_code` was **not** awaited.
+4. POST `/phases/{n}/build` returns 404 `HEALTH_CHECKS_NOT_FOUND` when no
+   health checks match; asserts `build_code` was **not** awaited.
+5. POST `/phases/{n}/build` returns 422 on `ShipwrightError`.
+6. POST `/phases/{n}/build` returns 422 specifically on
+   `VITEST_NOT_SUPPORTED`.
+7. GET `/phases/{n}/build` returns 200 with latest run.
+8. GET `/phases/{n}/build` returns 404 `BUILD_NOT_FOUND` when no run.
+9. GET `/build-artifacts` returns 200 with list.
+10. GET `/build-artifacts?phase_number=2` filters by phase.
+11. GET `/build-artifacts` returns 200 with empty list.
+
+## Constraints
+
+- Mock every external: no real LLM, no real DB, no real sandbox, no real
+  git.
+- Keep the graph minimal (2 nodes, one iteration per `.ainvoke()`). The
+  iteration loop lives in the service.
+- Follow Navigator/Captain/Doctor patterns exactly: `strip_fences` from
+  `app/crew/utils.py`, `reader()` factory, atomic DB commit before events,
+  best-effort publish.
+- **Delete-before-insert** for `BuildArtifact` on successful re-invocation
+  — re-builds replace prior artifacts. `ShipwrightRun` rows are
+  append-only (history preserved).
+- **Status lifecycle** — transient `BUILDING`, restored to `CHARTED` on
+  both success and failure. v1 serializes invocations per voyage via this
+  gate; true per-phase parallelism waits for a future phase_status
+  refactor.
+- Git commit path is **best-effort and opt-in** — wrapped in a single
+  try/except, logs a warning on failure, never fails the request. Only
+  attempted on `status == "passed"`.
+- Reuse `Poneglyph` rows via `NavigatorService.reader(session).get_poneglyphs(...)`
+  and `HealthCheck` rows via
+  `DoctorService.reader(session).get_health_checks(...)`.
+- Add `TestsPassedEvent` to `events.py` + `AnyEvent`. `CodeGeneratedEvent`
+  already exists.
+- Single Dial System call per iteration. One JSON batch of files per call.
+- `ShipwrightRun.output` is truncated to the last 4000 chars.
+- `BuildArtifact` rows never store stdout — they point to a
+  `ShipwrightRun` via `shipwright_run_id`.
+- Pytest invocation is `python -m pytest -x --tb=short` with a 120-second
+  timeout. Counting pass/fail is best-effort from stdout.
+- **Path safety is non-negotiable** — validate every LLM `file_path` at
+  the schema layer. LLM output feeds both the sandbox and the host-side
+  git commit; traversal must be rejected before either touches it.
+- **Vitest is deferred** — return `ShipwrightError("VITEST_NOT_SUPPORTED")`
+  → 422 at the top of `build_code` if any health check's framework is
+  not `"pytest"`. Logged in `decisions.md` 2026-04-17.
+- **`SHIPWRIGHT_MAX_ITERATIONS = 3`** is a module-level constant, not an
+  env/config. Locked in `decisions.md` 2026-04-17.
+- **404 vs 422**: 404 for missing prerequisite resources (no Poneglyph,
+  no HealthChecks, no prior run) — resolved at the API layer via readers.
+  422 for service-layer invariant violations (`ShipwrightError`).
+- **Malformed Poneglyph content → warn, degrade gracefully.** Log the
+  offending `poneglyph_id` and `phase_number` and fall back to an empty
+  dict; do not raise and do not silently swallow.
+- **No `metadata_` JSONB on `BuildArtifact`.** `language` is a first-class
+  column. Add a real column when a second field is actually needed.
+- **Iteration VivreCards are best-effort.** A failed checkpoint write
+  logs a warning but does not fail the iteration — the LLM call already
+  happened.

--- a/src/backend/alembic/versions/b2c3d4e5f6a1_shipwright.py
+++ b/src/backend/alembic/versions/b2c3d4e5f6a1_shipwright.py
@@ -1,0 +1,101 @@
+"""shipwright_runs and build_artifacts
+
+Revision ID: b2c3d4e5f6a1
+Revises: a1b2c3d4e5f6
+Create Date: 2026-04-17
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "b2c3d4e5f6a1"
+down_revision: str | None = "a1b2c3d4e5f6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "shipwright_runs",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "voyage_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("voyages.id"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column(
+            "poneglyph_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("poneglyphs.id"),
+            nullable=True,
+            index=True,
+        ),
+        sa.Column("phase_number", sa.Integer(), nullable=False),
+        sa.Column("status", sa.String(20), nullable=False),
+        sa.Column("iteration_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("exit_code", sa.Integer(), nullable=True),
+        sa.Column("passed_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("failed_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("total_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("output", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+    op.create_index(
+        "ix_shipwright_runs_voyage_phase",
+        "shipwright_runs",
+        ["voyage_id", "phase_number"],
+    )
+
+    op.create_table(
+        "build_artifacts",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "voyage_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("voyages.id"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column(
+            "shipwright_run_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("shipwright_runs.id"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column("phase_number", sa.Integer(), nullable=False),
+        sa.Column("file_path", sa.String(500), nullable=False),
+        sa.Column("content", sa.Text(), nullable=False),
+        sa.Column("language", sa.String(20), nullable=False, server_default="python"),
+        sa.Column("created_by", sa.String(50), nullable=False, server_default="shipwright"),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+    op.create_index(
+        "ix_build_artifacts_voyage_phase",
+        "build_artifacts",
+        ["voyage_id", "phase_number"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_build_artifacts_voyage_phase", table_name="build_artifacts")
+    op.drop_table("build_artifacts")
+    op.drop_index("ix_shipwright_runs_voyage_phase", table_name="shipwright_runs")
+    op.drop_table("shipwright_runs")

--- a/src/backend/app/api/v1/router.py
+++ b/src/backend/app/api/v1/router.py
@@ -8,6 +8,7 @@ from app.api.v1.execution import router as execution_router
 from app.api.v1.git import router as git_router
 from app.api.v1.health import router as health_router
 from app.api.v1.navigator import router as navigator_router
+from app.api.v1.shipwright import router as shipwright_router
 from app.api.v1.vivre_cards import router as vivre_cards_router
 
 v1_router = APIRouter(prefix="/api/v1")
@@ -20,3 +21,4 @@ v1_router.include_router(git_router)
 v1_router.include_router(captain_router)
 v1_router.include_router(navigator_router)
 v1_router.include_router(doctor_router)
+v1_router.include_router(shipwright_router)

--- a/src/backend/app/api/v1/shipwright.py
+++ b/src/backend/app/api/v1/shipwright.py
@@ -1,0 +1,176 @@
+"""Shipwright Agent REST API endpoints."""
+
+from __future__ import annotations
+
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.v1.dependencies import (
+    get_authorized_voyage,
+    get_current_user,
+    get_den_den_mushi,
+    get_dial_router,
+    get_execution_service,
+    get_git_service,
+)
+from app.api.v1.doctor import get_doctor_reader
+from app.api.v1.navigator import get_navigator_reader
+from app.den_den_mushi.mushi import DenDenMushi
+from app.dial_system.router import DialSystemRouter
+from app.models import get_db
+from app.models.enums import VoyageStatus
+from app.models.user import User
+from app.models.voyage import Voyage
+from app.schemas.build_artifact import BuildArtifactRead
+from app.schemas.shipwright import (
+    BuildArtifactListResponse,
+    BuildResultResponse,
+)
+from app.services.doctor_service import DoctorService
+from app.services.execution_service import ExecutionService
+from app.services.git_service import GitService
+from app.services.navigator_service import NavigatorService
+from app.services.shipwright_service import ShipwrightError, ShipwrightService
+
+router = APIRouter(prefix="/voyages/{voyage_id}", tags=["shipwright"])
+
+
+async def get_shipwright_service(
+    voyage_id: uuid.UUID,
+    dial_router: DialSystemRouter = Depends(get_dial_router),
+    mushi: DenDenMushi = Depends(get_den_den_mushi),
+    session: AsyncSession = Depends(get_db),
+    execution_service: ExecutionService = Depends(get_execution_service),
+    git_service: GitService = Depends(get_git_service),
+) -> ShipwrightService:
+    return ShipwrightService(
+        dial_router,
+        mushi,
+        session,
+        execution_service=execution_service,
+        git_service=git_service,
+    )
+
+
+async def get_shipwright_reader(
+    session: AsyncSession = Depends(get_db),
+) -> ShipwrightService:
+    return ShipwrightService.reader(session)
+
+
+@router.post(
+    "/phases/{phase_number}/build",
+    response_model=BuildResultResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def build_phase(
+    voyage_id: uuid.UUID,
+    phase_number: int,
+    user: User = Depends(get_current_user),
+    voyage: Voyage = Depends(get_authorized_voyage),
+    shipwright_service: ShipwrightService = Depends(get_shipwright_service),
+    navigator_reader: NavigatorService = Depends(get_navigator_reader),
+    doctor_reader: DoctorService = Depends(get_doctor_reader),
+) -> BuildResultResponse:
+    if voyage.status != VoyageStatus.CHARTED.value:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "error": {
+                    "code": "VOYAGE_NOT_BUILDABLE",
+                    "message": (f"Voyage status is {voyage.status}, expected CHARTED"),
+                }
+            },
+        )
+
+    poneglyphs = await navigator_reader.get_poneglyphs(voyage_id)
+    poneglyph = next((p for p in poneglyphs if p.phase_number == phase_number), None)
+    if poneglyph is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={
+                "error": {
+                    "code": "PONEGLYPH_NOT_FOUND",
+                    "message": (f"No Poneglyph for voyage {voyage_id} phase {phase_number}"),
+                }
+            },
+        )
+
+    phase_health_checks = await doctor_reader.get_health_checks(voyage_id, phase_number)
+    if not phase_health_checks:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={
+                "error": {
+                    "code": "HEALTH_CHECKS_NOT_FOUND",
+                    "message": (f"No health checks for voyage {voyage_id} phase {phase_number}"),
+                }
+            },
+        )
+
+    try:
+        return await shipwright_service.build_code(
+            voyage, phase_number, poneglyph, phase_health_checks, user.id
+        )
+    except ShipwrightError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail={"error": {"code": exc.code, "message": exc.message}},
+        ) from exc
+
+
+@router.get(
+    "/phases/{phase_number}/build",
+    response_model=BuildResultResponse,
+)
+async def get_phase_build(
+    voyage_id: uuid.UUID,
+    phase_number: int,
+    user: User = Depends(get_current_user),
+    voyage: Voyage = Depends(get_authorized_voyage),
+    shipwright_reader: ShipwrightService = Depends(get_shipwright_reader),
+) -> BuildResultResponse:
+    run = await shipwright_reader.get_latest_run(voyage_id, phase_number)
+    if run is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={
+                "error": {
+                    "code": "BUILD_NOT_FOUND",
+                    "message": (f"No build run for voyage {voyage_id} phase {phase_number}"),
+                }
+            },
+        )
+
+    artifacts = await shipwright_reader.get_build_artifacts(voyage_id, phase_number)
+    summary = (run.output or "")[-500:]
+    return BuildResultResponse(
+        voyage_id=voyage_id,
+        phase_number=phase_number,
+        shipwright_run_id=run.id,
+        status=run.status,
+        iteration_count=run.iteration_count,
+        passed_count=run.passed_count,
+        failed_count=run.failed_count,
+        total_count=run.total_count,
+        file_count=len(artifacts),
+        summary=summary,
+    )
+
+
+@router.get("/build-artifacts", response_model=BuildArtifactListResponse)
+async def list_build_artifacts(
+    voyage_id: uuid.UUID,
+    phase_number: int | None = None,
+    user: User = Depends(get_current_user),
+    voyage: Voyage = Depends(get_authorized_voyage),
+    shipwright_reader: ShipwrightService = Depends(get_shipwright_reader),
+) -> BuildArtifactListResponse:
+    artifacts = await shipwright_reader.get_build_artifacts(voyage_id, phase_number)
+    return BuildArtifactListResponse(
+        voyage_id=voyage_id,
+        phase_number=phase_number,
+        artifacts=[BuildArtifactRead.model_validate(a) for a in artifacts],
+    )

--- a/src/backend/app/crew/shipwright_graph.py
+++ b/src/backend/app/crew/shipwright_graph.py
@@ -1,0 +1,191 @@
+"""Shipwright Agent LangGraph — generates code and runs it against the Doctor's tests.
+
+One invocation of the compiled graph is ONE iteration: the `generate` node calls the
+LLM to produce source files, and the `run_tests` node executes them against the stored
+health-check tests in the sandbox. The iteration loop lives in the service layer so
+per-iteration VivreCard checkpoints remain a service concern, not a graph concern.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from typing import Any, TypedDict
+
+from langgraph.graph import END, StateGraph
+from langgraph.graph.state import CompiledStateGraph
+
+from app.crew.utils import strip_fences
+from app.dial_system.router import DialSystemRouter
+from app.models.enums import CrewRole
+from app.schemas.dial_system import CompletionRequest
+from app.schemas.execution import ExecutionRequest
+from app.schemas.shipwright import BuildArtifactSpec, ShipwrightOutputSpec
+from app.services.execution_service import ExecutionService
+
+SHIPWRIGHT_SYSTEM_PROMPT = """\
+You are a Shipwright — a developer agent on a software engineering crew. Your job \
+is to write source code that makes the Doctor's pre-written failing tests pass. \
+The tests are the specification; your code is the implementation.
+
+You will receive:
+- A Poneglyph describing one phase of the work (task description, test criteria, \
+intended file paths)
+- The exact content of the failing test files for that phase
+- If this is a retry, the previous test run's output
+
+Produce a complete set of source files that satisfy the tests. Every file you emit \
+must be importable and runnable as-is. Do not include the test files themselves in \
+your output — those already exist.
+
+Rules for file_path values:
+- Use relative paths only (no leading /, no drive letters, no ..)
+- Match the style in the Poneglyph's file_paths hint where possible
+
+Respond with ONLY a JSON object: {"files": [{"file_path": "...", "content": "...", \
+"language": "python"}, ...]}
+Do not include any other text, markdown formatting, or explanation."""
+
+
+class ShipwrightState(TypedDict):
+    voyage_id: uuid.UUID
+    user_id: uuid.UUID
+    phase_number: int
+    poneglyph: dict[str, Any]
+    health_checks: list[dict[str, str]]
+    iteration: int
+    last_test_output: str | None
+    raw_output: str
+    generated_files: list[BuildArtifactSpec] | None
+    exit_code: int | None
+    stdout: str
+    passed_count: int
+    failed_count: int
+    total_count: int
+    error: str | None
+
+
+def _build_user_message(state: ShipwrightState) -> str:
+    poneglyph_block = json.dumps(state["poneglyph"], indent=2)
+    tests_block = "\n\n".join(
+        f"### {hc['file_path']} ({hc.get('framework', 'pytest')})\n```\n{hc['content']}\n```"
+        for hc in state["health_checks"]
+    )
+    sections = [
+        f"## Poneglyph (phase {state['phase_number']})\n{poneglyph_block}",
+        f"## Tests you must make pass\n{tests_block}",
+    ]
+    if state["iteration"] > 1 and state.get("last_test_output"):
+        output = state["last_test_output"] or ""
+        sections.append(
+            "## Previous attempt — tests still failed\n"
+            "The tests above still fail. Fix the issues reported and regenerate the "
+            "complete file set.\n"
+            f"```\n{output[-2000:]}\n```"
+        )
+    return "\n\n".join(sections)
+
+
+async def generate(
+    state: ShipwrightState,
+    dial_router: DialSystemRouter,
+) -> dict[str, Any]:
+    """Call the LLM to generate source files for this phase/iteration."""
+    user_message = _build_user_message(state)
+    request = CompletionRequest(
+        messages=[
+            {"role": "system", "content": SHIPWRIGHT_SYSTEM_PROMPT},
+            {"role": "user", "content": user_message},
+        ],
+        role=CrewRole.SHIPWRIGHT,
+        voyage_id=state["voyage_id"],
+    )
+    result = await dial_router.route(CrewRole.SHIPWRIGHT, request)
+    raw = result.content
+    try:
+        stripped = strip_fences(raw)
+        data = json.loads(stripped)
+        spec = ShipwrightOutputSpec.model_validate(data)
+        return {
+            "raw_output": raw,
+            "generated_files": spec.files,
+            "error": None,
+        }
+    except (json.JSONDecodeError, ValueError, KeyError) as exc:
+        return {
+            "raw_output": raw,
+            "generated_files": None,
+            "error": str(exc),
+        }
+
+
+def _parse_counts(stdout: str, exit_code: int, total_hint: int) -> tuple[int, int, int]:
+    """Best-effort pass/fail counting from pytest stdout."""
+    passed = stdout.count("PASSED")
+    failed = stdout.count("FAILED")
+    if passed == 0 and failed == 0:
+        if exit_code == 0:
+            return total_hint, 0, total_hint
+        return 0, max(total_hint, 1), max(total_hint, 1)
+    return passed, failed, passed + failed
+
+
+async def run_tests(
+    state: ShipwrightState,
+    execution_service: ExecutionService,
+) -> dict[str, Any]:
+    """Run pytest against generated files + stored health-check tests."""
+    generated = state.get("generated_files")
+    if generated is None:
+        # parse failed — nothing to run
+        return {
+            "exit_code": None,
+            "stdout": "",
+            "passed_count": 0,
+            "failed_count": 0,
+            "total_count": len(state["health_checks"]),
+        }
+
+    files: dict[str, str] = {f.file_path: f.content for f in generated}
+    for hc in state["health_checks"]:
+        files[hc["file_path"]] = hc["content"]
+
+    request = ExecutionRequest(
+        command="cd /workspace && python -m pytest -x --tb=short",
+        files=files,
+        timeout_seconds=120,
+    )
+    result = await execution_service.run(state["user_id"], request)
+    passed, failed, total = _parse_counts(
+        result.stdout, result.exit_code, len(state["health_checks"])
+    )
+    return {
+        "exit_code": result.exit_code,
+        "stdout": result.stdout,
+        "passed_count": passed,
+        "failed_count": failed,
+        "total_count": total,
+    }
+
+
+def build_shipwright_graph(
+    dial_router: DialSystemRouter,
+    execution_service: ExecutionService,
+) -> CompiledStateGraph:  # type: ignore[type-arg]
+    """Build and compile the Shipwright's two-node graph (one iteration per invocation)."""
+    graph = StateGraph(ShipwrightState)
+
+    async def _generate(state: ShipwrightState) -> dict[str, Any]:
+        return await generate(state, dial_router)
+
+    async def _run_tests(state: ShipwrightState) -> dict[str, Any]:
+        return await run_tests(state, execution_service)
+
+    graph.add_node("generate", _generate)
+    graph.add_node("run_tests", _run_tests)
+
+    graph.set_entry_point("generate")
+    graph.add_edge("generate", "run_tests")
+    graph.add_edge("run_tests", END)
+
+    return graph.compile()

--- a/src/backend/app/den_den_mushi/events.py
+++ b/src/backend/app/den_den_mushi/events.py
@@ -36,6 +36,10 @@ class CodeGeneratedEvent(DenDenMushiEvent):
     event_type: Literal["code_generated"] = "code_generated"
 
 
+class TestsPassedEvent(DenDenMushiEvent):
+    event_type: Literal["tests_passed"] = "tests_passed"
+
+
 class ValidationPassedEvent(DenDenMushiEvent):
     event_type: Literal["validation_passed"] = "validation_passed"
 
@@ -61,6 +65,7 @@ AnyEvent = Annotated[
     | PoneglyphDraftedEvent
     | HealthCheckWrittenEvent
     | CodeGeneratedEvent
+    | TestsPassedEvent
     | ValidationPassedEvent
     | ValidationFailedEvent
     | DeploymentCompletedEvent

--- a/src/backend/app/models/__init__.py
+++ b/src/backend/app/models/__init__.py
@@ -17,10 +17,12 @@ async def get_db() -> AsyncSession:  # type: ignore[misc]
 
 
 # Import all models so Alembic can detect them
+from app.models.build_artifact import BuildArtifact  # noqa: E402, F401
 from app.models.crew_action import CrewAction  # noqa: E402, F401
 from app.models.dial_config import DialConfig  # noqa: E402, F401
 from app.models.health_check import HealthCheck  # noqa: E402, F401
 from app.models.poneglyph import Poneglyph  # noqa: E402, F401
+from app.models.shipwright_run import ShipwrightRun  # noqa: E402, F401
 from app.models.user import User  # noqa: E402, F401
 from app.models.validation_run import ValidationRun  # noqa: E402, F401
 from app.models.vivre_card import VivreCard  # noqa: E402, F401

--- a/src/backend/app/models/build_artifact.py
+++ b/src/backend/app/models/build_artifact.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, Index, Integer, String, Text, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models import Base
+
+
+class BuildArtifact(Base):
+    __tablename__ = "build_artifacts"
+    __table_args__ = (Index("ix_build_artifacts_voyage_phase", "voyage_id", "phase_number"),)
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    voyage_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("voyages.id"), index=True, nullable=False
+    )
+    shipwright_run_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("shipwright_runs.id"),
+        index=True,
+        nullable=False,
+    )
+    phase_number: Mapped[int] = mapped_column(Integer, nullable=False)
+    file_path: Mapped[str] = mapped_column(String(500), nullable=False)
+    content: Mapped[str] = mapped_column(Text, nullable=False)
+    language: Mapped[str] = mapped_column(String(20), default="python", nullable=False)
+    created_by: Mapped[str] = mapped_column(String(50), default="shipwright", nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )

--- a/src/backend/app/models/shipwright_run.py
+++ b/src/backend/app/models/shipwright_run.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, Index, Integer, String, Text, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models import Base
+
+
+class ShipwrightRun(Base):
+    __tablename__ = "shipwright_runs"
+    __table_args__ = (Index("ix_shipwright_runs_voyage_phase", "voyage_id", "phase_number"),)
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    voyage_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("voyages.id"), index=True, nullable=False
+    )
+    poneglyph_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("poneglyphs.id"), index=True, nullable=True
+    )
+    phase_number: Mapped[int] = mapped_column(Integer, nullable=False)
+    status: Mapped[str] = mapped_column(String(20), nullable=False)
+    iteration_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    exit_code: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    passed_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    failed_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    total_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    output: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )

--- a/src/backend/app/schemas/build_artifact.py
+++ b/src/backend/app/schemas/build_artifact.py
@@ -1,0 +1,18 @@
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict
+
+
+class BuildArtifactRead(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    voyage_id: uuid.UUID
+    shipwright_run_id: uuid.UUID
+    phase_number: int
+    file_path: str
+    content: str
+    language: str
+    created_by: str
+    created_at: datetime

--- a/src/backend/app/schemas/shipwright.py
+++ b/src/backend/app/schemas/shipwright.py
@@ -1,0 +1,74 @@
+"""Schemas for Shipwright Agent (Developer)."""
+
+from __future__ import annotations
+
+import posixpath
+import uuid
+from typing import Literal
+
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+from app.schemas.build_artifact import BuildArtifactRead
+
+
+def _validate_relative_path(path: str) -> str:
+    """Reject absolute paths and path-traversal segments."""
+    if path.startswith("/") or path.startswith("\\"):
+        raise ValueError(f"Path must be relative, got {path!r}")
+    if ":" in path.split("/")[0]:
+        raise ValueError(f"Path must not be a drive/scheme, got {path!r}")
+    normalized = posixpath.normpath(path)
+    if normalized.startswith("..") or "/../" in f"/{normalized}/":
+        raise ValueError(f"Path traversal not allowed in {path!r}")
+    if normalized in (".", ""):
+        raise ValueError(f"Path must not be empty, got {path!r}")
+    return path
+
+
+class BuildArtifactSpec(BaseModel):
+    """Structured content the LLM generates for one source file."""
+
+    file_path: str = Field(min_length=1, max_length=500)
+    content: str = Field(min_length=1)
+    language: Literal["python", "typescript", "javascript"] = "python"
+
+    @field_validator("file_path")
+    @classmethod
+    def _validate_file_path(cls, v: str) -> str:
+        return _validate_relative_path(v)
+
+
+class ShipwrightOutputSpec(BaseModel):
+    """Full LLM output: one or more source files for a single phase."""
+
+    files: list[BuildArtifactSpec] = Field(min_length=1)
+
+    @model_validator(mode="after")
+    def validate_unique_file_paths(self) -> ShipwrightOutputSpec:
+        paths = [f.file_path for f in self.files]
+        if len(paths) != len(set(paths)):
+            seen: set[str] = set()
+            for p in paths:
+                if p in seen:
+                    raise ValueError(f"Duplicate file_path {p!r}")
+                seen.add(p)
+        return self
+
+
+class BuildResultResponse(BaseModel):
+    voyage_id: uuid.UUID
+    phase_number: int
+    shipwright_run_id: uuid.UUID
+    status: Literal["passed", "failed", "max_iterations"]
+    iteration_count: int
+    passed_count: int
+    failed_count: int
+    total_count: int
+    file_count: int
+    summary: str
+
+
+class BuildArtifactListResponse(BaseModel):
+    voyage_id: uuid.UUID
+    phase_number: int | None
+    artifacts: list[BuildArtifactRead]

--- a/src/backend/app/services/doctor_service.py
+++ b/src/backend/app/services/doctor_service.py
@@ -316,12 +316,13 @@ class DoctorService:
     async def get_health_checks(
         self,
         voyage_id: uuid.UUID,
+        phase_number: int | None = None,
     ) -> list[HealthCheck]:
-        result = await self._session.execute(
-            select(HealthCheck)
-            .where(HealthCheck.voyage_id == voyage_id)
-            .order_by(HealthCheck.phase_number)
-        )
+        stmt = select(HealthCheck).where(HealthCheck.voyage_id == voyage_id)
+        if phase_number is not None:
+            stmt = stmt.where(HealthCheck.phase_number == phase_number)
+        stmt = stmt.order_by(HealthCheck.phase_number)
+        result = await self._session.execute(stmt)
         return list(result.scalars().all())
 
 

--- a/src/backend/app/services/shipwright_service.py
+++ b/src/backend/app/services/shipwright_service.py
@@ -1,0 +1,381 @@
+"""ShipwrightService — orchestrates phase-scoped code generation.
+
+One invocation of `build_code` covers ONE phase and owns the iteration loop
+(generate → run_tests → refine) up to `SHIPWRIGHT_MAX_ITERATIONS` attempts.
+The LangGraph runs one iteration per `.ainvoke()`; the service writes a
+per-iteration VivreCard so long loops don't lose progress.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+from typing import Any
+
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.crew.shipwright_graph import build_shipwright_graph
+from app.den_den_mushi.constants import stream_key
+from app.den_den_mushi.events import CodeGeneratedEvent, TestsPassedEvent
+from app.den_den_mushi.mushi import DenDenMushi
+from app.dial_system.router import DialSystemRouter
+from app.models.build_artifact import BuildArtifact
+from app.models.enums import CrewRole, VoyageStatus
+from app.models.health_check import HealthCheck
+from app.models.poneglyph import Poneglyph
+from app.models.shipwright_run import ShipwrightRun
+from app.models.vivre_card import VivreCard
+from app.models.voyage import Voyage
+from app.schemas.shipwright import BuildResultResponse
+from app.services.execution_service import ExecutionService
+from app.services.git_service import GitService
+
+logger = logging.getLogger(__name__)
+
+SHIPWRIGHT_MAX_ITERATIONS = 3
+_OUTPUT_TRUNCATE = 4000
+
+
+class ShipwrightError(Exception):
+    """Raised when Shipwright agent operations fail at the service layer."""
+
+    def __init__(self, code: str, message: str) -> None:
+        self.code = code
+        self.message = message
+        super().__init__(message)
+
+
+class ShipwrightService:
+    def __init__(
+        self,
+        dial_router: DialSystemRouter,
+        mushi: DenDenMushi,
+        session: AsyncSession,
+        execution_service: ExecutionService,
+        git_service: GitService | None = None,
+    ) -> None:
+        self._dial_router = dial_router
+        self._mushi = mushi
+        self._session = session
+        self._execution = execution_service
+        self._git = git_service
+        self._graph = build_shipwright_graph(dial_router, execution_service)
+
+    @classmethod
+    def reader(cls, session: AsyncSession) -> ShipwrightService:
+        """Create a read-only instance that only needs a DB session."""
+        inst = cls.__new__(cls)
+        inst._session = session
+        inst._dial_router = None  # type: ignore[assignment]
+        inst._mushi = None  # type: ignore[assignment]
+        inst._execution = None  # type: ignore[assignment]
+        inst._git = None
+        inst._graph = None  # type: ignore[assignment]
+        return inst
+
+    async def build_code(
+        self,
+        voyage: Voyage,
+        phase_number: int,
+        poneglyph: Poneglyph,
+        health_checks: list[HealthCheck],
+        user_id: uuid.UUID,
+    ) -> BuildResultResponse:
+        non_pytest = [hc for hc in health_checks if hc.framework != "pytest"]
+        if non_pytest:
+            raise ShipwrightError(
+                "VITEST_NOT_SUPPORTED",
+                (
+                    f"Only pytest health checks are supported in v1; found "
+                    f"{sorted({hc.framework for hc in non_pytest})} — see "
+                    "decisions.md 2026-04-17"
+                ),
+            )
+
+        voyage.status = VoyageStatus.BUILDING.value
+        await self._session.flush()
+
+        state: dict[str, Any] = {
+            "voyage_id": voyage.id,
+            "user_id": user_id,
+            "phase_number": phase_number,
+            "poneglyph": {
+                "phase_number": poneglyph.phase_number,
+                **_parse_poneglyph_content(poneglyph),
+            },
+            "health_checks": [
+                {
+                    "file_path": hc.file_path,
+                    "content": hc.content,
+                    "framework": hc.framework,
+                }
+                for hc in health_checks
+            ],
+            "iteration": 1,
+            "last_test_output": None,
+            "raw_output": "",
+            "generated_files": None,
+            "exit_code": None,
+            "stdout": "",
+            "passed_count": 0,
+            "failed_count": 0,
+            "total_count": 0,
+            "error": None,
+        }
+
+        iteration_count = 0
+        final_parse_error: str | None = None
+        try:
+            for i in range(1, SHIPWRIGHT_MAX_ITERATIONS + 1):
+                iteration_count = i
+                state["iteration"] = i
+                state = await self._graph.ainvoke(state)
+                await self._checkpoint_iteration(voyage, state)
+
+                if state.get("error"):
+                    final_parse_error = state["error"]
+                    if i < SHIPWRIGHT_MAX_ITERATIONS:
+                        state["last_test_output"] = f"Previous JSON parse failed: {state['error']}"
+                        continue
+                    break
+
+                final_parse_error = None
+                if state.get("exit_code") == 0:
+                    break
+
+                state["last_test_output"] = state.get("stdout", "")
+        except Exception:
+            voyage.status = VoyageStatus.CHARTED.value
+            await self._session.flush()
+            raise
+
+        passed = state.get("exit_code") == 0
+        if passed:
+            status_str: str = "passed"
+        elif final_parse_error is not None:
+            status_str = "failed"
+        else:
+            status_str = "max_iterations"
+        generated_files = state.get("generated_files") or []
+        stdout = state.get("stdout") or ""
+        truncated = stdout[-_OUTPUT_TRUNCATE:] or (final_parse_error or "")
+
+        run = ShipwrightRun(
+            id=uuid.uuid4(),
+            voyage_id=voyage.id,
+            poneglyph_id=poneglyph.id,
+            phase_number=phase_number,
+            status=status_str,
+            iteration_count=iteration_count,
+            exit_code=state.get("exit_code"),
+            passed_count=state.get("passed_count", 0),
+            failed_count=state.get("failed_count", 0),
+            total_count=state.get("total_count", 0),
+            output=truncated,
+        )
+        self._session.add(run)
+        await self._session.flush()
+
+        artifacts: list[BuildArtifact] = []
+        if passed:
+            await self._session.execute(
+                delete(BuildArtifact).where(
+                    BuildArtifact.voyage_id == voyage.id,
+                    BuildArtifact.phase_number == phase_number,
+                )
+            )
+            for spec in generated_files:
+                artifact = BuildArtifact(
+                    voyage_id=voyage.id,
+                    shipwright_run_id=run.id,
+                    phase_number=phase_number,
+                    file_path=spec.file_path,
+                    content=spec.content,
+                    language=spec.language,
+                    created_by="shipwright",
+                )
+                self._session.add(artifact)
+                artifacts.append(artifact)
+
+        card = VivreCard(
+            voyage_id=voyage.id,
+            crew_member="shipwright",
+            state_data={
+                "phase_number": phase_number,
+                "iteration_count": iteration_count,
+                "status": status_str,
+                "file_count": len(artifacts),
+            },
+            checkpoint_reason="build_complete",
+        )
+        self._session.add(card)
+
+        voyage.status = VoyageStatus.CHARTED.value
+        await self._session.commit()
+        await self._session.refresh(run)
+        for artifact in artifacts:
+            await self._session.refresh(artifact)
+
+        if passed:
+            await self._maybe_commit_to_git(voyage, user_id, phase_number, artifacts)
+            await self._publish_success_events(voyage.id, phase_number, run, artifacts)
+
+        if final_parse_error is not None:
+            raise ShipwrightError(
+                "BUILD_PARSE_FAILED",
+                (
+                    f"Failed to parse LLM output after {iteration_count} iterations: "
+                    f"{final_parse_error}"
+                ),
+            )
+
+        return BuildResultResponse(
+            voyage_id=voyage.id,
+            phase_number=phase_number,
+            shipwright_run_id=run.id,
+            status=status_str,
+            iteration_count=iteration_count,
+            passed_count=run.passed_count,
+            failed_count=run.failed_count,
+            total_count=run.total_count,
+            file_count=len(artifacts),
+            summary=truncated[-500:],
+        )
+
+    async def _checkpoint_iteration(
+        self,
+        voyage: Voyage,
+        state: dict[str, Any],
+    ) -> None:
+        """Best-effort per-iteration checkpoint. A failure logs and returns."""
+        try:
+            generated = state.get("generated_files") or []
+            card = VivreCard(
+                voyage_id=voyage.id,
+                crew_member="shipwright",
+                state_data={
+                    "phase_number": state.get("phase_number"),
+                    "iteration": state.get("iteration"),
+                    "exit_code": state.get("exit_code"),
+                    "file_count": len(generated),
+                },
+                checkpoint_reason="iteration",
+            )
+            self._session.add(card)
+            await self._session.flush()
+        except Exception:
+            logger.warning(
+                "Failed to checkpoint iteration %s for voyage %s",
+                state.get("iteration"),
+                voyage.id,
+                exc_info=True,
+            )
+
+    async def _maybe_commit_to_git(
+        self,
+        voyage: Voyage,
+        user_id: uuid.UUID,
+        phase_number: int,
+        artifacts: list[BuildArtifact],
+    ) -> None:
+        """Best-effort git commit of the Shipwright's source files."""
+        if self._git is None or not voyage.target_repo or not artifacts:
+            return
+        try:
+            await self._git.create_branch(voyage.id, user_id, "shipwright", "main")
+            files = {a.file_path: a.content for a in artifacts}
+            await self._git.commit(
+                voyage.id,
+                user_id,
+                f"feat(phase-{phase_number}): Shipwright implementation",
+                crew_member="shipwright",
+                files=files,
+            )
+            branch = f"agent/shipwright/{voyage.id.hex[:8]}"
+            await self._git.push(voyage.id, user_id, branch)
+        except Exception:
+            logger.warning(
+                "Git commit failed for Shipwright phase %s on voyage %s",
+                phase_number,
+                voyage.id,
+                exc_info=True,
+            )
+
+    async def _publish_success_events(
+        self,
+        voyage_id: uuid.UUID,
+        phase_number: int,
+        run: ShipwrightRun,
+        artifacts: list[BuildArtifact],
+    ) -> None:
+        try:
+            code_event = CodeGeneratedEvent(
+                voyage_id=voyage_id,
+                source_role=CrewRole.SHIPWRIGHT,
+                payload={
+                    "phase_number": phase_number,
+                    "shipwright_run_id": str(run.id),
+                    "file_count": len(artifacts),
+                },
+            )
+            tests_event = TestsPassedEvent(
+                voyage_id=voyage_id,
+                source_role=CrewRole.SHIPWRIGHT,
+                payload={
+                    "phase_number": phase_number,
+                    "shipwright_run_id": str(run.id),
+                    "passed_count": run.passed_count,
+                },
+            )
+            await self._mushi.publish(stream_key(voyage_id), code_event)
+            await self._mushi.publish(stream_key(voyage_id), tests_event)
+        except Exception:
+            logger.warning(
+                "Failed to publish Shipwright success events for voyage %s",
+                voyage_id,
+                exc_info=True,
+            )
+
+    async def get_build_artifacts(
+        self,
+        voyage_id: uuid.UUID,
+        phase_number: int | None = None,
+    ) -> list[BuildArtifact]:
+        stmt = select(BuildArtifact).where(BuildArtifact.voyage_id == voyage_id)
+        if phase_number is not None:
+            stmt = stmt.where(BuildArtifact.phase_number == phase_number)
+        stmt = stmt.order_by(BuildArtifact.phase_number, BuildArtifact.file_path)
+        result = await self._session.execute(stmt)
+        return list(result.scalars().all())
+
+    async def get_latest_run(
+        self,
+        voyage_id: uuid.UUID,
+        phase_number: int,
+    ) -> ShipwrightRun | None:
+        result = await self._session.execute(
+            select(ShipwrightRun)
+            .where(
+                ShipwrightRun.voyage_id == voyage_id,
+                ShipwrightRun.phase_number == phase_number,
+            )
+            .order_by(ShipwrightRun.created_at.desc())
+            .limit(1)
+        )
+        return result.scalars().first()
+
+
+def _parse_poneglyph_content(poneglyph: Poneglyph) -> dict[str, Any]:
+    """Load the JSON content of a Poneglyph. On malformed JSON, warn and fall back."""
+    try:
+        data = json.loads(poneglyph.content)
+    except (json.JSONDecodeError, TypeError):
+        logger.warning(
+            "Poneglyph %s (phase %s) has malformed content — using empty fallback",
+            poneglyph.id,
+            poneglyph.phase_number,
+        )
+        return {}
+    return data if isinstance(data, dict) else {}

--- a/src/backend/tests/test_models.py
+++ b/src/backend/tests/test_models.py
@@ -3,11 +3,13 @@
 from sqlalchemy import inspect
 
 from app.models import Base
+from app.models.build_artifact import BuildArtifact
 from app.models.crew_action import CrewAction
 from app.models.dial_config import DialConfig
 from app.models.enums import CheckpointReason, CrewRole, VoyageStatus
 from app.models.health_check import HealthCheck
 from app.models.poneglyph import Poneglyph
+from app.models.shipwright_run import ShipwrightRun
 from app.models.user import User
 from app.models.validation_run import ValidationRun
 from app.models.vivre_card import VivreCard
@@ -26,6 +28,8 @@ def test_all_models_registered_in_metadata() -> None:
         "dial_configs",
         "health_checks",
         "validation_runs",
+        "shipwright_runs",
+        "build_artifacts",
     }
     assert expected == table_names
 
@@ -216,3 +220,50 @@ def test_validation_run_table_columns() -> None:
         "output",
         "created_at",
     }
+
+
+def test_shipwright_run_table_columns() -> None:
+    mapper = inspect(ShipwrightRun)
+    column_names = {c.key for c in mapper.columns}
+    assert column_names == {
+        "id",
+        "voyage_id",
+        "poneglyph_id",
+        "phase_number",
+        "status",
+        "iteration_count",
+        "exit_code",
+        "passed_count",
+        "failed_count",
+        "total_count",
+        "output",
+        "created_at",
+    }
+
+
+def test_build_artifact_table_columns() -> None:
+    mapper = inspect(BuildArtifact)
+    column_names = {c.key for c in mapper.columns}
+    assert column_names == {
+        "id",
+        "voyage_id",
+        "shipwright_run_id",
+        "phase_number",
+        "file_path",
+        "content",
+        "language",
+        "created_by",
+        "created_at",
+    }
+
+
+def test_shipwright_run_voyage_phase_indexed() -> None:
+    table = ShipwrightRun.__table__
+    index_names = {idx.name for idx in table.indexes}
+    assert "ix_shipwright_runs_voyage_phase" in index_names
+
+
+def test_build_artifact_voyage_phase_indexed() -> None:
+    table = BuildArtifact.__table__
+    index_names = {idx.name for idx in table.indexes}
+    assert "ix_build_artifacts_voyage_phase" in index_names

--- a/src/backend/tests/test_shipwright_api.py
+++ b/src/backend/tests/test_shipwright_api.py
@@ -1,0 +1,305 @@
+"""Tests for Shipwright Agent REST API endpoints."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+from app.models.enums import VoyageStatus
+from app.schemas.shipwright import BuildResultResponse
+from app.services.shipwright_service import ShipwrightError
+
+VOYAGE_ID = uuid.uuid4()
+USER_ID = uuid.uuid4()
+RUN_ID = uuid.uuid4()
+ARTIFACT_ID_1 = uuid.uuid4()
+ARTIFACT_ID_2 = uuid.uuid4()
+PONEGLYPH_ID = uuid.uuid4()
+HC_ID = uuid.uuid4()
+
+
+def _mock_user() -> MagicMock:
+    user = MagicMock()
+    user.id = USER_ID
+    return user
+
+
+def _mock_voyage(status: str = VoyageStatus.CHARTED.value) -> MagicMock:
+    voyage = MagicMock()
+    voyage.id = VOYAGE_ID
+    voyage.user_id = USER_ID
+    voyage.status = status
+    return voyage
+
+
+def _mock_poneglyph(phase_number: int = 1) -> MagicMock:
+    p = MagicMock()
+    p.id = PONEGLYPH_ID
+    p.voyage_id = VOYAGE_ID
+    p.phase_number = phase_number
+    p.content = '{"title": "Phase 1"}'
+    return p
+
+
+def _mock_health_check(phase_number: int = 1) -> MagicMock:
+    hc = MagicMock()
+    hc.id = HC_ID
+    hc.voyage_id = VOYAGE_ID
+    hc.phase_number = phase_number
+    hc.file_path = f"tests/test_phase{phase_number}.py"
+    hc.content = "def test_x(): assert False"
+    hc.framework = "pytest"
+    return hc
+
+
+def _mock_artifact(artifact_id: uuid.UUID, phase_number: int, file_path: str) -> MagicMock:
+    a = MagicMock()
+    a.id = artifact_id
+    a.voyage_id = VOYAGE_ID
+    a.shipwright_run_id = RUN_ID
+    a.phase_number = phase_number
+    a.file_path = file_path
+    a.content = "def f(): pass"
+    a.language = "python"
+    a.created_by = "shipwright"
+    a.created_at = datetime(2026, 4, 17, tzinfo=UTC)
+    return a
+
+
+def _mock_run(
+    phase_number: int = 1, status_: str = "passed", iteration_count: int = 1
+) -> MagicMock:
+    r = MagicMock()
+    r.id = RUN_ID
+    r.voyage_id = VOYAGE_ID
+    r.phase_number = phase_number
+    r.status = status_
+    r.iteration_count = iteration_count
+    r.exit_code = 0 if status_ == "passed" else 1
+    r.passed_count = 2
+    r.failed_count = 0
+    r.total_count = 2
+    r.output = "2 passed"
+    r.created_at = datetime(2026, 4, 17, tzinfo=UTC)
+    return r
+
+
+def _mock_shipwright_service(phase_number: int = 1) -> AsyncMock:
+    svc = AsyncMock()
+    svc.build_code = AsyncMock(
+        return_value=BuildResultResponse(
+            voyage_id=VOYAGE_ID,
+            phase_number=phase_number,
+            shipwright_run_id=RUN_ID,
+            status="passed",
+            iteration_count=1,
+            passed_count=2,
+            failed_count=0,
+            total_count=2,
+            file_count=2,
+            summary="2 passed",
+        )
+    )
+    svc.get_latest_run = AsyncMock(return_value=_mock_run(phase_number))
+    svc.get_build_artifacts = AsyncMock(
+        return_value=[
+            _mock_artifact(ARTIFACT_ID_1, phase_number, "src/a.py"),
+            _mock_artifact(ARTIFACT_ID_2, phase_number, "src/b.py"),
+        ]
+    )
+    return svc
+
+
+def _mock_navigator_reader(phase_number: int = 1) -> AsyncMock:
+    nav = AsyncMock()
+    nav.get_poneglyphs = AsyncMock(return_value=[_mock_poneglyph(phase_number)])
+    return nav
+
+
+def _mock_doctor_reader(phase_number: int = 1) -> AsyncMock:
+    doc = AsyncMock()
+    doc.get_health_checks = AsyncMock(return_value=[_mock_health_check(phase_number)])
+    return doc
+
+
+class TestBuildPhaseEndpoint:
+    @pytest.mark.asyncio
+    async def test_returns_201_with_build_result(self) -> None:
+        from app.api.v1.shipwright import build_phase
+
+        sw = _mock_shipwright_service()
+        result = await build_phase(
+            VOYAGE_ID,
+            1,
+            _mock_user(),
+            _mock_voyage(),
+            sw,
+            _mock_navigator_reader(),
+            _mock_doctor_reader(),
+        )
+        assert result.status == "passed"
+        assert result.phase_number == 1
+        sw.build_code.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_returns_409_if_not_charted(self) -> None:
+        from app.api.v1.shipwright import build_phase
+
+        sw = _mock_shipwright_service()
+        voyage = _mock_voyage(status=VoyageStatus.BUILDING.value)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await build_phase(
+                VOYAGE_ID,
+                1,
+                _mock_user(),
+                voyage,
+                sw,
+                _mock_navigator_reader(),
+                _mock_doctor_reader(),
+            )
+        assert exc_info.value.status_code == 409
+        assert exc_info.value.detail["error"]["code"] == "VOYAGE_NOT_BUILDABLE"
+        sw.build_code.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_returns_404_when_poneglyph_missing(self) -> None:
+        from app.api.v1.shipwright import build_phase
+
+        sw = _mock_shipwright_service()
+        nav = _mock_navigator_reader()
+        nav.get_poneglyphs.return_value = []
+
+        with pytest.raises(HTTPException) as exc_info:
+            await build_phase(
+                VOYAGE_ID,
+                1,
+                _mock_user(),
+                _mock_voyage(),
+                sw,
+                nav,
+                _mock_doctor_reader(),
+            )
+        assert exc_info.value.status_code == 404
+        assert exc_info.value.detail["error"]["code"] == "PONEGLYPH_NOT_FOUND"
+        sw.build_code.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_returns_404_when_health_checks_missing(self) -> None:
+        from app.api.v1.shipwright import build_phase
+
+        sw = _mock_shipwright_service()
+        doc = _mock_doctor_reader()
+        doc.get_health_checks.return_value = []
+
+        with pytest.raises(HTTPException) as exc_info:
+            await build_phase(
+                VOYAGE_ID,
+                1,
+                _mock_user(),
+                _mock_voyage(),
+                sw,
+                _mock_navigator_reader(),
+                doc,
+            )
+        assert exc_info.value.status_code == 404
+        assert exc_info.value.detail["error"]["code"] == "HEALTH_CHECKS_NOT_FOUND"
+        sw.build_code.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_returns_422_on_shipwright_error(self) -> None:
+        from app.api.v1.shipwright import build_phase
+
+        sw = _mock_shipwright_service()
+        sw.build_code.side_effect = ShipwrightError("BUILD_PARSE_FAILED", "LLM JSON parse failed")
+
+        with pytest.raises(HTTPException) as exc_info:
+            await build_phase(
+                VOYAGE_ID,
+                1,
+                _mock_user(),
+                _mock_voyage(),
+                sw,
+                _mock_navigator_reader(),
+                _mock_doctor_reader(),
+            )
+        assert exc_info.value.status_code == 422
+        assert exc_info.value.detail["error"]["code"] == "BUILD_PARSE_FAILED"
+
+    @pytest.mark.asyncio
+    async def test_returns_422_on_vitest_not_supported(self) -> None:
+        from app.api.v1.shipwright import build_phase
+
+        sw = _mock_shipwright_service()
+        sw.build_code.side_effect = ShipwrightError("VITEST_NOT_SUPPORTED", "vitest deferred")
+
+        with pytest.raises(HTTPException) as exc_info:
+            await build_phase(
+                VOYAGE_ID,
+                1,
+                _mock_user(),
+                _mock_voyage(),
+                sw,
+                _mock_navigator_reader(),
+                _mock_doctor_reader(),
+            )
+        assert exc_info.value.status_code == 422
+        assert exc_info.value.detail["error"]["code"] == "VITEST_NOT_SUPPORTED"
+
+
+class TestGetPhaseBuildEndpoint:
+    @pytest.mark.asyncio
+    async def test_returns_200_with_latest_run(self) -> None:
+        from app.api.v1.shipwright import get_phase_build
+
+        sw = _mock_shipwright_service()
+        result = await get_phase_build(VOYAGE_ID, 1, _mock_user(), _mock_voyage(), sw)
+        assert result.status == "passed"
+        assert result.shipwright_run_id == RUN_ID
+        assert result.file_count == 2
+
+    @pytest.mark.asyncio
+    async def test_returns_404_when_no_run(self) -> None:
+        from app.api.v1.shipwright import get_phase_build
+
+        sw = _mock_shipwright_service()
+        sw.get_latest_run.return_value = None
+
+        with pytest.raises(HTTPException) as exc_info:
+            await get_phase_build(VOYAGE_ID, 1, _mock_user(), _mock_voyage(), sw)
+        assert exc_info.value.status_code == 404
+        assert exc_info.value.detail["error"]["code"] == "BUILD_NOT_FOUND"
+
+
+class TestListBuildArtifactsEndpoint:
+    @pytest.mark.asyncio
+    async def test_returns_200_with_list(self) -> None:
+        from app.api.v1.shipwright import list_build_artifacts
+
+        sw = _mock_shipwright_service()
+        result = await list_build_artifacts(VOYAGE_ID, None, _mock_user(), _mock_voyage(), sw)
+        assert len(result.artifacts) == 2
+        assert result.phase_number is None
+
+    @pytest.mark.asyncio
+    async def test_filters_by_phase_number(self) -> None:
+        from app.api.v1.shipwright import list_build_artifacts
+
+        sw = _mock_shipwright_service()
+        result = await list_build_artifacts(VOYAGE_ID, 2, _mock_user(), _mock_voyage(), sw)
+        sw.get_build_artifacts.assert_awaited_once_with(VOYAGE_ID, 2)
+        assert result.phase_number == 2
+
+    @pytest.mark.asyncio
+    async def test_returns_200_with_empty_list(self) -> None:
+        from app.api.v1.shipwright import list_build_artifacts
+
+        sw = _mock_shipwright_service()
+        sw.get_build_artifacts.return_value = []
+
+        result = await list_build_artifacts(VOYAGE_ID, None, _mock_user(), _mock_voyage(), sw)
+        assert result.artifacts == []

--- a/src/backend/tests/test_shipwright_graph.py
+++ b/src/backend/tests/test_shipwright_graph.py
@@ -1,0 +1,266 @@
+"""Tests for Shipwright LangGraph graph (mocked LLM + mocked executor)."""
+
+from __future__ import annotations
+
+import json
+import uuid
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.crew.shipwright_graph import build_shipwright_graph, generate, run_tests
+from app.models.enums import CrewRole
+from app.schemas.dial_system import CompletionResult, TokenUsage
+from app.schemas.execution import ExecutionResult
+
+PONEGLYPH = {
+    "phase_number": 1,
+    "title": "Implement auth module",
+    "task_description": "Create a login() function returning a JWT",
+    "test_criteria": ["login returns JWT", "invalid creds raise"],
+    "file_paths": ["app/auth.py"],
+}
+
+HEALTH_CHECKS = [
+    {
+        "file_path": "tests/test_auth.py",
+        "content": "def test_login(): from app.auth import login; assert login('u','p')",
+        "framework": "pytest",
+    },
+]
+
+VALID_OUTPUT_JSON = json.dumps(
+    {
+        "files": [
+            {
+                "file_path": "app/auth.py",
+                "content": "def login(u, p): return 'jwt-token'",
+                "language": "python",
+            }
+        ]
+    }
+)
+
+
+def _base_state(**overrides: object) -> dict[str, object]:
+    state: dict[str, object] = {
+        "voyage_id": uuid.uuid4(),
+        "user_id": uuid.uuid4(),
+        "phase_number": 1,
+        "poneglyph": PONEGLYPH,
+        "health_checks": HEALTH_CHECKS,
+        "iteration": 1,
+        "last_test_output": None,
+        "raw_output": "",
+        "generated_files": None,
+        "exit_code": None,
+        "stdout": "",
+        "passed_count": 0,
+        "failed_count": 0,
+        "total_count": 0,
+        "error": None,
+    }
+    state.update(overrides)
+    return state
+
+
+def _llm_result(content: str) -> CompletionResult:
+    return CompletionResult(
+        content=content,
+        provider="anthropic",
+        model="claude-sonnet-4-20250514",
+        usage=TokenUsage(),
+    )
+
+
+def _exec_result(exit_code: int, stdout: str) -> ExecutionResult:
+    return ExecutionResult(
+        exit_code=exit_code,
+        stdout=stdout,
+        stderr="",
+        timed_out=False,
+        duration_seconds=1.0,
+        sandbox_id="sbx-test",
+    )
+
+
+class TestGenerateNode:
+    @pytest.mark.asyncio
+    async def test_sends_shipwright_role(self) -> None:
+        mock_router = AsyncMock()
+        mock_router.route = AsyncMock(return_value=_llm_result(VALID_OUTPUT_JSON))
+
+        await generate(_base_state(), mock_router)  # type: ignore[arg-type]
+
+        mock_router.route.assert_awaited_once()
+        assert mock_router.route.call_args.args[0] == CrewRole.SHIPWRIGHT
+
+    @pytest.mark.asyncio
+    async def test_includes_poneglyph_in_user_message(self) -> None:
+        mock_router = AsyncMock()
+        mock_router.route = AsyncMock(return_value=_llm_result(VALID_OUTPUT_JSON))
+
+        await generate(_base_state(), mock_router)  # type: ignore[arg-type]
+
+        request = mock_router.route.call_args.args[1]
+        user_msg = next(m for m in request.messages if m["role"] == "user")
+        assert "Create a login() function" in user_msg["content"]
+
+    @pytest.mark.asyncio
+    async def test_includes_health_check_content_verbatim(self) -> None:
+        mock_router = AsyncMock()
+        mock_router.route = AsyncMock(return_value=_llm_result(VALID_OUTPUT_JSON))
+
+        await generate(_base_state(), mock_router)  # type: ignore[arg-type]
+
+        request = mock_router.route.call_args.args[1]
+        user_msg = next(m for m in request.messages if m["role"] == "user")
+        assert HEALTH_CHECKS[0]["content"] in user_msg["content"]
+        assert "tests/test_auth.py" in user_msg["content"]
+
+    @pytest.mark.asyncio
+    async def test_includes_last_test_output_on_retry(self) -> None:
+        mock_router = AsyncMock()
+        mock_router.route = AsyncMock(return_value=_llm_result(VALID_OUTPUT_JSON))
+
+        await generate(
+            _base_state(iteration=2, last_test_output="AssertionError: boom"),
+            mock_router,  # type: ignore[arg-type]
+        )
+
+        request = mock_router.route.call_args.args[1]
+        user_msg = next(m for m in request.messages if m["role"] == "user")
+        assert "Previous attempt" in user_msg["content"]
+        assert "AssertionError: boom" in user_msg["content"]
+
+    @pytest.mark.asyncio
+    async def test_omits_retry_block_on_first_iteration(self) -> None:
+        mock_router = AsyncMock()
+        mock_router.route = AsyncMock(return_value=_llm_result(VALID_OUTPUT_JSON))
+
+        await generate(_base_state(iteration=1), mock_router)  # type: ignore[arg-type]
+
+        request = mock_router.route.call_args.args[1]
+        user_msg = next(m for m in request.messages if m["role"] == "user")
+        assert "Previous attempt" not in user_msg["content"]
+
+    @pytest.mark.asyncio
+    async def test_valid_json_populates_generated_files(self) -> None:
+        mock_router = AsyncMock()
+        mock_router.route = AsyncMock(return_value=_llm_result(VALID_OUTPUT_JSON))
+
+        result = await generate(_base_state(), mock_router)  # type: ignore[arg-type]
+
+        assert result["generated_files"] is not None
+        assert len(result["generated_files"]) == 1
+        assert result["generated_files"][0].file_path == "app/auth.py"
+        assert result["error"] is None
+
+    @pytest.mark.asyncio
+    async def test_malformed_json_sets_error(self) -> None:
+        mock_router = AsyncMock()
+        mock_router.route = AsyncMock(return_value=_llm_result("not valid json"))
+
+        result = await generate(_base_state(), mock_router)  # type: ignore[arg-type]
+
+        assert result["generated_files"] is None
+        assert result["error"] is not None
+
+    @pytest.mark.asyncio
+    async def test_strips_markdown_fences(self) -> None:
+        mock_router = AsyncMock()
+        fenced = f"```json\n{VALID_OUTPUT_JSON}\n```"
+        mock_router.route = AsyncMock(return_value=_llm_result(fenced))
+
+        result = await generate(_base_state(), mock_router)  # type: ignore[arg-type]
+
+        assert result["generated_files"] is not None
+        assert result["error"] is None
+
+
+class TestRunTestsNode:
+    @pytest.mark.asyncio
+    async def test_skips_execution_when_no_generated_files(self) -> None:
+        mock_exec = AsyncMock()
+        mock_exec.run = AsyncMock()
+
+        result = await run_tests(_base_state(generated_files=None), mock_exec)  # type: ignore[arg-type]
+
+        mock_exec.run.assert_not_awaited()
+        assert result["exit_code"] is None
+        assert result["total_count"] == len(HEALTH_CHECKS)
+
+    @pytest.mark.asyncio
+    async def test_merges_generated_and_health_check_files(self) -> None:
+        from app.schemas.shipwright import BuildArtifactSpec
+
+        mock_exec = AsyncMock()
+        mock_exec.run = AsyncMock(return_value=_exec_result(0, "1 passed"))
+
+        generated = [
+            BuildArtifactSpec(file_path="app/auth.py", content="def login(u,p): return 'x'")
+        ]
+        await run_tests(_base_state(generated_files=generated), mock_exec)  # type: ignore[arg-type]
+
+        mock_exec.run.assert_awaited_once()
+        sent_files = mock_exec.run.call_args.args[1].files
+        assert "app/auth.py" in sent_files
+        assert "tests/test_auth.py" in sent_files
+
+    @pytest.mark.asyncio
+    async def test_parses_exit_zero_as_pass(self) -> None:
+        from app.schemas.shipwright import BuildArtifactSpec
+
+        mock_exec = AsyncMock()
+        mock_exec.run = AsyncMock(return_value=_exec_result(0, "========= 3 passed ========="))
+
+        generated = [BuildArtifactSpec(file_path="app/a.py", content="x")]
+        result = await run_tests(_base_state(generated_files=generated), mock_exec)  # type: ignore[arg-type]
+
+        assert result["exit_code"] == 0
+        assert result["failed_count"] == 0
+        assert result["passed_count"] >= 1
+
+    @pytest.mark.asyncio
+    async def test_parses_exit_nonzero_as_fail(self) -> None:
+        from app.schemas.shipwright import BuildArtifactSpec
+
+        mock_exec = AsyncMock()
+        mock_exec.run = AsyncMock(return_value=_exec_result(1, "test_auth.py::test_login FAILED"))
+
+        generated = [BuildArtifactSpec(file_path="app/a.py", content="x")]
+        result = await run_tests(_base_state(generated_files=generated), mock_exec)  # type: ignore[arg-type]
+
+        assert result["exit_code"] == 1
+        assert result["failed_count"] >= 1
+
+
+class TestFullGraph:
+    @pytest.mark.asyncio
+    async def test_end_to_end_success(self) -> None:
+        mock_router = AsyncMock()
+        mock_router.route = AsyncMock(return_value=_llm_result(VALID_OUTPUT_JSON))
+        mock_exec = AsyncMock()
+        mock_exec.run = AsyncMock(return_value=_exec_result(0, "1 passed"))
+
+        graph = build_shipwright_graph(mock_router, mock_exec)
+        result = await graph.ainvoke(_base_state())
+
+        assert result["generated_files"] is not None
+        assert result["exit_code"] == 0
+        assert result["error"] is None
+
+    @pytest.mark.asyncio
+    async def test_end_to_end_malformed_output_skips_tests(self) -> None:
+        mock_router = AsyncMock()
+        mock_router.route = AsyncMock(return_value=_llm_result("not json"))
+        mock_exec = AsyncMock()
+        mock_exec.run = AsyncMock()
+
+        graph = build_shipwright_graph(mock_router, mock_exec)
+        result = await graph.ainvoke(_base_state())
+
+        assert result["generated_files"] is None
+        assert result["error"] is not None
+        assert result["exit_code"] is None
+        mock_exec.run.assert_not_awaited()

--- a/src/backend/tests/test_shipwright_schemas.py
+++ b/src/backend/tests/test_shipwright_schemas.py
@@ -1,0 +1,111 @@
+"""Tests for Shipwright Agent Pydantic schemas."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from app.schemas.shipwright import (
+    BuildArtifactSpec,
+    BuildResultResponse,
+    ShipwrightOutputSpec,
+)
+
+
+class TestBuildArtifactSpec:
+    def test_accepts_valid_python(self) -> None:
+        spec = BuildArtifactSpec(
+            file_path="app/auth.py",
+            content="def login(): ...",
+            language="python",
+        )
+        assert spec.language == "python"
+
+    def test_accepts_valid_typescript(self) -> None:
+        spec = BuildArtifactSpec(
+            file_path="src/auth.ts",
+            content="export function login() {}",
+            language="typescript",
+        )
+        assert spec.language == "typescript"
+
+    def test_rejects_empty_file_path(self) -> None:
+        with pytest.raises(ValidationError):
+            BuildArtifactSpec(file_path="", content="x")
+
+    def test_rejects_empty_content(self) -> None:
+        with pytest.raises(ValidationError):
+            BuildArtifactSpec(file_path="a.py", content="")
+
+    def test_rejects_invalid_language(self) -> None:
+        with pytest.raises(ValidationError):
+            BuildArtifactSpec(
+                file_path="a.py",
+                content="x",
+                language="rust",  # type: ignore[arg-type]
+            )
+
+    def test_defaults_language_to_python(self) -> None:
+        spec = BuildArtifactSpec(file_path="a.py", content="x")
+        assert spec.language == "python"
+
+    def test_rejects_absolute_file_path(self) -> None:
+        with pytest.raises(ValidationError, match="relative"):
+            BuildArtifactSpec(file_path="/etc/passwd", content="x")
+
+    def test_rejects_path_traversal(self) -> None:
+        with pytest.raises(ValidationError, match="traversal"):
+            BuildArtifactSpec(file_path="../../etc/passwd", content="x")
+
+    def test_rejects_nested_path_traversal(self) -> None:
+        with pytest.raises(ValidationError, match="traversal"):
+            BuildArtifactSpec(file_path="app/../../etc/passwd", content="x")
+
+    def test_accepts_nested_relative_path(self) -> None:
+        spec = BuildArtifactSpec(file_path="app/auth/handlers.py", content="x")
+        assert spec.file_path == "app/auth/handlers.py"
+
+    def test_rejects_drive_scheme_prefix(self) -> None:
+        with pytest.raises(ValidationError, match="drive/scheme"):
+            BuildArtifactSpec(file_path="C:/windows/system.ini", content="x")
+
+
+class TestShipwrightOutputSpec:
+    def test_rejects_empty_files(self) -> None:
+        with pytest.raises(ValidationError):
+            ShipwrightOutputSpec(files=[])
+
+    def test_rejects_duplicate_file_paths(self) -> None:
+        with pytest.raises(ValidationError, match="Duplicate file_path"):
+            ShipwrightOutputSpec(
+                files=[
+                    BuildArtifactSpec(file_path="a.py", content="x"),
+                    BuildArtifactSpec(file_path="a.py", content="y"),
+                ]
+            )
+
+    def test_accepts_multi_file_output(self) -> None:
+        spec = ShipwrightOutputSpec(
+            files=[
+                BuildArtifactSpec(file_path="a.py", content="x"),
+                BuildArtifactSpec(file_path="b.py", content="y"),
+            ]
+        )
+        assert len(spec.files) == 2
+
+
+class TestBuildResultResponse:
+    def test_rejects_invalid_status(self) -> None:
+        with pytest.raises(ValidationError):
+            BuildResultResponse(
+                voyage_id="00000000-0000-0000-0000-000000000000",  # type: ignore[arg-type]
+                phase_number=1,
+                shipwright_run_id="00000000-0000-0000-0000-000000000000",  # type: ignore[arg-type]
+                status="weird",  # type: ignore[arg-type]
+                iteration_count=1,
+                passed_count=0,
+                failed_count=0,
+                total_count=0,
+                file_count=0,
+                summary="",
+            )

--- a/src/backend/tests/test_shipwright_service.py
+++ b/src/backend/tests/test_shipwright_service.py
@@ -1,0 +1,554 @@
+"""Tests for ShipwrightService (mocked dependencies)."""
+
+from __future__ import annotations
+
+import json
+import uuid
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.models.build_artifact import BuildArtifact
+from app.models.enums import VoyageStatus
+from app.models.shipwright_run import ShipwrightRun
+from app.models.vivre_card import VivreCard
+from app.schemas.shipwright import BuildArtifactSpec
+from app.services.shipwright_service import (
+    SHIPWRIGHT_MAX_ITERATIONS,
+    ShipwrightError,
+    ShipwrightService,
+)
+
+VOYAGE_ID = uuid.uuid4()
+USER_ID = uuid.uuid4()
+PONEGLYPH_ID = uuid.uuid4()
+
+
+def _mock_voyage(
+    status: str = VoyageStatus.CHARTED.value,
+    target_repo: str | None = None,
+) -> MagicMock:
+    voyage = MagicMock()
+    voyage.id = VOYAGE_ID
+    voyage.user_id = USER_ID
+    voyage.status = status
+    voyage.target_repo = target_repo
+    return voyage
+
+
+def _mock_poneglyph(
+    phase_number: int = 1,
+    malformed: bool = False,
+) -> MagicMock:
+    p = MagicMock()
+    p.id = PONEGLYPH_ID
+    p.voyage_id = VOYAGE_ID
+    p.phase_number = phase_number
+    if malformed:
+        p.content = "not-json{{{"
+    else:
+        p.content = json.dumps(
+            {
+                "phase_number": phase_number,
+                "title": f"Phase {phase_number}",
+                "task_description": "Build the thing",
+                "test_criteria": ["works"],
+                "file_paths": [f"src/phase{phase_number}.py"],
+            }
+        )
+    return p
+
+
+def _mock_health_check(phase_number: int = 1, framework: str = "pytest") -> MagicMock:
+    hc = MagicMock()
+    hc.id = uuid.uuid4()
+    hc.phase_number = phase_number
+    hc.file_path = f"tests/test_phase{phase_number}.py"
+    hc.content = f"def test_p{phase_number}(): assert False"
+    hc.framework = framework
+    return hc
+
+
+def _graph_state(
+    *,
+    exit_code: int = 0,
+    error: str | None = None,
+    stdout: str = "1 passed",
+    passed: int = 1,
+    failed: int = 0,
+    total: int = 1,
+    generated_files: list[BuildArtifactSpec] | None = None,
+) -> dict[str, Any]:
+    if generated_files is None:
+        generated_files = [
+            BuildArtifactSpec(
+                file_path="src/phase1.py",
+                content="def run(): return True",
+                language="python",
+            )
+        ]
+    return {
+        "voyage_id": VOYAGE_ID,
+        "user_id": USER_ID,
+        "phase_number": 1,
+        "poneglyph": {},
+        "health_checks": [],
+        "iteration": 1,
+        "last_test_output": None,
+        "raw_output": "{}",
+        "generated_files": None if error else generated_files,
+        "exit_code": None if error else exit_code,
+        "stdout": stdout,
+        "passed_count": passed,
+        "failed_count": failed,
+        "total_count": total,
+        "error": error,
+    }
+
+
+@pytest.fixture
+def mock_dial_router() -> AsyncMock:
+    return AsyncMock()
+
+
+@pytest.fixture
+def mock_mushi() -> AsyncMock:
+    mushi = AsyncMock()
+    mushi.publish = AsyncMock(return_value="msg-1")
+    return mushi
+
+
+@pytest.fixture
+def mock_session() -> AsyncMock:
+    session = AsyncMock()
+    session.add = MagicMock()
+    session.flush = AsyncMock()
+    session.commit = AsyncMock()
+    session.refresh = AsyncMock()
+    result_mock = MagicMock()
+    result_mock.scalars.return_value.all.return_value = []
+    result_mock.scalars.return_value.first.return_value = None
+    session.execute = AsyncMock(return_value=result_mock)
+    return session
+
+
+@pytest.fixture
+def mock_execution() -> AsyncMock:
+    return AsyncMock()
+
+
+@pytest.fixture
+def mock_git() -> AsyncMock:
+    git = AsyncMock()
+    git.create_branch = AsyncMock()
+    git.commit = AsyncMock()
+    git.push = AsyncMock()
+    return git
+
+
+@pytest.fixture
+def service(
+    mock_dial_router: AsyncMock,
+    mock_mushi: AsyncMock,
+    mock_session: AsyncMock,
+    mock_execution: AsyncMock,
+    mock_git: AsyncMock,
+) -> ShipwrightService:
+    svc = ShipwrightService(mock_dial_router, mock_mushi, mock_session, mock_execution, mock_git)
+    svc._graph = AsyncMock()  # type: ignore[assignment]
+    svc._graph.ainvoke = AsyncMock(return_value=_graph_state())  # type: ignore[attr-defined]
+    return svc
+
+
+class TestBuildCodeHappyPath:
+    @pytest.mark.asyncio
+    async def test_sets_status_to_building_during_call(
+        self, service: ShipwrightService, mock_session: AsyncMock
+    ) -> None:
+        voyage = _mock_voyage()
+        observed: list[str] = []
+
+        async def record_flush() -> None:
+            observed.append(voyage.status)
+
+        mock_session.flush.side_effect = record_flush
+        await service.build_code(voyage, 1, _mock_poneglyph(), [_mock_health_check()], USER_ID)
+        assert VoyageStatus.BUILDING.value in observed
+
+    @pytest.mark.asyncio
+    async def test_invokes_graph_on_iteration_one(self, service: ShipwrightService) -> None:
+        await service.build_code(
+            _mock_voyage(), 1, _mock_poneglyph(), [_mock_health_check()], USER_ID
+        )
+        first_state = service._graph.ainvoke.call_args_list[0].args[0]  # type: ignore[attr-defined]
+        assert first_state["iteration"] == 1
+
+    @pytest.mark.asyncio
+    async def test_terminates_loop_on_first_green(self, service: ShipwrightService) -> None:
+        await service.build_code(
+            _mock_voyage(), 1, _mock_poneglyph(), [_mock_health_check()], USER_ID
+        )
+        assert service._graph.ainvoke.await_count == 1  # type: ignore[attr-defined]
+
+    @pytest.mark.asyncio
+    async def test_persists_shipwright_run_with_passed_status(
+        self, service: ShipwrightService, mock_session: AsyncMock
+    ) -> None:
+        await service.build_code(
+            _mock_voyage(), 1, _mock_poneglyph(), [_mock_health_check()], USER_ID
+        )
+        added = [c.args[0] for c in mock_session.add.call_args_list]
+        runs = [o for o in added if isinstance(o, ShipwrightRun)]
+        assert len(runs) == 1
+        assert runs[0].status == "passed"
+        assert runs[0].iteration_count == 1
+
+    @pytest.mark.asyncio
+    async def test_deletes_existing_build_artifacts_on_pass(
+        self, service: ShipwrightService, mock_session: AsyncMock
+    ) -> None:
+        from sqlalchemy.sql.dml import Delete
+
+        await service.build_code(
+            _mock_voyage(), 1, _mock_poneglyph(), [_mock_health_check()], USER_ID
+        )
+        executed = [c.args[0] for c in mock_session.execute.call_args_list]
+        deletes = [s for s in executed if isinstance(s, Delete)]
+        assert len(deletes) == 1
+
+    @pytest.mark.asyncio
+    async def test_persists_one_build_artifact_per_generated_file(
+        self, service: ShipwrightService, mock_session: AsyncMock
+    ) -> None:
+        files = [
+            BuildArtifactSpec(file_path="a.py", content="x", language="python"),
+            BuildArtifactSpec(file_path="b.py", content="y", language="python"),
+        ]
+        service._graph.ainvoke = AsyncMock(  # type: ignore[attr-defined]
+            return_value=_graph_state(generated_files=files)
+        )
+        await service.build_code(
+            _mock_voyage(), 1, _mock_poneglyph(), [_mock_health_check()], USER_ID
+        )
+        added = [c.args[0] for c in mock_session.add.call_args_list]
+        artifacts = [o for o in added if isinstance(o, BuildArtifact)]
+        assert len(artifacts) == 2
+
+    @pytest.mark.asyncio
+    async def test_creates_build_complete_vivre_card(
+        self, service: ShipwrightService, mock_session: AsyncMock
+    ) -> None:
+        await service.build_code(
+            _mock_voyage(), 1, _mock_poneglyph(), [_mock_health_check()], USER_ID
+        )
+        added = [c.args[0] for c in mock_session.add.call_args_list]
+        cards = [o for o in added if isinstance(o, VivreCard)]
+        reasons = [c.checkpoint_reason for c in cards]
+        assert "build_complete" in reasons
+
+    @pytest.mark.asyncio
+    async def test_creates_iteration_vivre_card_per_iteration(
+        self, service: ShipwrightService, mock_session: AsyncMock
+    ) -> None:
+        await service.build_code(
+            _mock_voyage(), 1, _mock_poneglyph(), [_mock_health_check()], USER_ID
+        )
+        added = [c.args[0] for c in mock_session.add.call_args_list]
+        cards = [o for o in added if isinstance(o, VivreCard)]
+        iter_cards = [c for c in cards if c.checkpoint_reason == "iteration"]
+        assert len(iter_cards) == 1
+
+    @pytest.mark.asyncio
+    async def test_commits_exactly_once(
+        self, service: ShipwrightService, mock_session: AsyncMock
+    ) -> None:
+        await service.build_code(
+            _mock_voyage(), 1, _mock_poneglyph(), [_mock_health_check()], USER_ID
+        )
+        mock_session.commit.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_restores_charted_status_after_success(self, service: ShipwrightService) -> None:
+        voyage = _mock_voyage()
+        await service.build_code(voyage, 1, _mock_poneglyph(), [_mock_health_check()], USER_ID)
+        assert voyage.status == VoyageStatus.CHARTED.value
+
+    @pytest.mark.asyncio
+    async def test_publishes_code_generated_and_tests_passed_events(
+        self, service: ShipwrightService, mock_mushi: AsyncMock
+    ) -> None:
+        await service.build_code(
+            _mock_voyage(), 1, _mock_poneglyph(), [_mock_health_check()], USER_ID
+        )
+        events = [c.args[1] for c in mock_mushi.publish.call_args_list]
+        types = {e.event_type for e in events}
+        assert {"code_generated", "tests_passed"} == types
+
+    @pytest.mark.asyncio
+    async def test_succeeds_when_event_publish_fails(
+        self, service: ShipwrightService, mock_mushi: AsyncMock
+    ) -> None:
+        mock_mushi.publish.side_effect = ConnectionError("Redis down")
+        result = await service.build_code(
+            _mock_voyage(), 1, _mock_poneglyph(), [_mock_health_check()], USER_ID
+        )
+        assert result.status == "passed"
+
+    @pytest.mark.asyncio
+    async def test_calls_git_when_target_repo_set(
+        self, service: ShipwrightService, mock_git: AsyncMock
+    ) -> None:
+        voyage = _mock_voyage(target_repo="https://github.com/org/repo.git")
+        await service.build_code(voyage, 1, _mock_poneglyph(), [_mock_health_check()], USER_ID)
+        mock_git.create_branch.assert_awaited_once()
+        mock_git.commit.assert_awaited_once()
+        mock_git.push.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_succeeds_when_git_commit_fails(
+        self, service: ShipwrightService, mock_git: AsyncMock
+    ) -> None:
+        mock_git.commit.side_effect = RuntimeError("git boom")
+        voyage = _mock_voyage(target_repo="https://github.com/org/repo.git")
+        result = await service.build_code(
+            voyage, 1, _mock_poneglyph(), [_mock_health_check()], USER_ID
+        )
+        assert result.status == "passed"
+
+    @pytest.mark.asyncio
+    async def test_skips_git_when_no_git_service(
+        self,
+        mock_dial_router: AsyncMock,
+        mock_mushi: AsyncMock,
+        mock_session: AsyncMock,
+        mock_execution: AsyncMock,
+    ) -> None:
+        svc = ShipwrightService(
+            mock_dial_router,
+            mock_mushi,
+            mock_session,
+            mock_execution,
+            git_service=None,
+        )
+        svc._graph = AsyncMock()  # type: ignore[assignment]
+        svc._graph.ainvoke = AsyncMock(return_value=_graph_state())  # type: ignore[attr-defined]
+
+        voyage = _mock_voyage(target_repo="https://github.com/org/repo.git")
+        result = await svc.build_code(voyage, 1, _mock_poneglyph(), [_mock_health_check()], USER_ID)
+        assert result.status == "passed"
+
+
+class TestBuildCodeIterationLoop:
+    @pytest.mark.asyncio
+    async def test_retries_with_last_test_output_on_failure(
+        self, service: ShipwrightService
+    ) -> None:
+        service._graph.ainvoke = AsyncMock(  # type: ignore[attr-defined]
+            side_effect=[
+                _graph_state(exit_code=1, stdout="pytest failure output"),
+                _graph_state(exit_code=0, stdout="1 passed"),
+            ]
+        )
+        await service.build_code(
+            _mock_voyage(), 1, _mock_poneglyph(), [_mock_health_check()], USER_ID
+        )
+        assert service._graph.ainvoke.await_count == 2  # type: ignore[attr-defined]
+        second_state = service._graph.ainvoke.call_args_list[1].args[0]  # type: ignore[attr-defined]
+        assert second_state["iteration"] == 2
+        assert second_state["last_test_output"] == "pytest failure output"
+
+    @pytest.mark.asyncio
+    async def test_max_iterations_when_all_fail(
+        self, service: ShipwrightService, mock_session: AsyncMock
+    ) -> None:
+        fail_state = _graph_state(exit_code=1, stdout="boom")
+        service._graph.ainvoke = AsyncMock(  # type: ignore[attr-defined]
+            side_effect=[fail_state] * SHIPWRIGHT_MAX_ITERATIONS
+        )
+        result = await service.build_code(
+            _mock_voyage(), 1, _mock_poneglyph(), [_mock_health_check()], USER_ID
+        )
+        assert result.status == "max_iterations"
+        assert result.iteration_count == SHIPWRIGHT_MAX_ITERATIONS
+
+    @pytest.mark.asyncio
+    async def test_no_artifacts_on_max_iterations(
+        self, service: ShipwrightService, mock_session: AsyncMock
+    ) -> None:
+        service._graph.ainvoke = AsyncMock(  # type: ignore[attr-defined]
+            side_effect=[_graph_state(exit_code=1)] * SHIPWRIGHT_MAX_ITERATIONS
+        )
+        await service.build_code(
+            _mock_voyage(), 1, _mock_poneglyph(), [_mock_health_check()], USER_ID
+        )
+        added = [c.args[0] for c in mock_session.add.call_args_list]
+        artifacts = [o for o in added if isinstance(o, BuildArtifact)]
+        assert artifacts == []
+
+    @pytest.mark.asyncio
+    async def test_no_events_on_max_iterations(
+        self, service: ShipwrightService, mock_mushi: AsyncMock
+    ) -> None:
+        service._graph.ainvoke = AsyncMock(  # type: ignore[attr-defined]
+            side_effect=[_graph_state(exit_code=1)] * SHIPWRIGHT_MAX_ITERATIONS
+        )
+        await service.build_code(
+            _mock_voyage(), 1, _mock_poneglyph(), [_mock_health_check()], USER_ID
+        )
+        mock_mushi.publish.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_restores_charted_on_max_iterations(self, service: ShipwrightService) -> None:
+        service._graph.ainvoke = AsyncMock(  # type: ignore[attr-defined]
+            side_effect=[_graph_state(exit_code=1)] * SHIPWRIGHT_MAX_ITERATIONS
+        )
+        voyage = _mock_voyage()
+        await service.build_code(voyage, 1, _mock_poneglyph(), [_mock_health_check()], USER_ID)
+        assert voyage.status == VoyageStatus.CHARTED.value
+
+    @pytest.mark.asyncio
+    async def test_persists_max_iterations_run(
+        self, service: ShipwrightService, mock_session: AsyncMock
+    ) -> None:
+        service._graph.ainvoke = AsyncMock(  # type: ignore[attr-defined]
+            side_effect=[_graph_state(exit_code=1)] * SHIPWRIGHT_MAX_ITERATIONS
+        )
+        await service.build_code(
+            _mock_voyage(), 1, _mock_poneglyph(), [_mock_health_check()], USER_ID
+        )
+        added = [c.args[0] for c in mock_session.add.call_args_list]
+        runs = [o for o in added if isinstance(o, ShipwrightRun)]
+        assert len(runs) == 1
+        assert runs[0].status == "max_iterations"
+        assert runs[0].iteration_count == SHIPWRIGHT_MAX_ITERATIONS
+
+
+class TestBuildCodeErrorPaths:
+    @pytest.mark.asyncio
+    async def test_raises_vitest_not_supported(self, service: ShipwrightService) -> None:
+        voyage = _mock_voyage()
+        with pytest.raises(ShipwrightError) as exc_info:
+            await service.build_code(
+                voyage,
+                1,
+                _mock_poneglyph(),
+                [_mock_health_check(framework="vitest")],
+                USER_ID,
+            )
+        assert exc_info.value.code == "VITEST_NOT_SUPPORTED"
+        service._graph.ainvoke.assert_not_awaited()  # type: ignore[attr-defined]
+
+    @pytest.mark.asyncio
+    async def test_raises_build_parse_failed_when_graph_errors(
+        self, service: ShipwrightService, mock_session: AsyncMock
+    ) -> None:
+        service._graph.ainvoke = AsyncMock(  # type: ignore[attr-defined]
+            side_effect=[_graph_state(error="parse failed")] * SHIPWRIGHT_MAX_ITERATIONS
+        )
+        voyage = _mock_voyage()
+        with pytest.raises(ShipwrightError) as exc_info:
+            await service.build_code(voyage, 1, _mock_poneglyph(), [_mock_health_check()], USER_ID)
+        assert exc_info.value.code == "BUILD_PARSE_FAILED"
+        assert voyage.status == VoyageStatus.CHARTED.value
+        # The run row must be persisted even on parse failure so it can be inspected.
+        added = [c.args[0] for c in mock_session.add.call_args_list]
+        runs = [o for o in added if isinstance(o, ShipwrightRun)]
+        assert len(runs) == 1
+        assert runs[0].status == "failed"
+        assert runs[0].iteration_count == SHIPWRIGHT_MAX_ITERATIONS
+        # No BuildArtifact rows should be added on parse failure.
+        assert not [o for o in added if isinstance(o, BuildArtifact)]
+        mock_session.commit.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_malformed_poneglyph_degrades_gracefully(
+        self, service: ShipwrightService, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="app.services.shipwright_service"):
+            result = await service.build_code(
+                _mock_voyage(),
+                1,
+                _mock_poneglyph(malformed=True),
+                [_mock_health_check()],
+                USER_ID,
+            )
+        assert result.status == "passed"
+        assert any("malformed" in r.message for r in caplog.records)
+
+
+class TestGetBuildArtifacts:
+    @pytest.mark.asyncio
+    async def test_returns_ordered_rows(
+        self, service: ShipwrightService, mock_session: AsyncMock
+    ) -> None:
+        a1, a2 = MagicMock(), MagicMock()
+        a1.phase_number, a2.phase_number = 1, 2
+        result_mock = MagicMock()
+        result_mock.scalars.return_value.all.return_value = [a1, a2]
+        mock_session.execute.return_value = result_mock
+
+        result = await service.get_build_artifacts(VOYAGE_ID)
+        assert len(result) == 2
+
+    @pytest.mark.asyncio
+    async def test_filters_by_phase_number(
+        self, service: ShipwrightService, mock_session: AsyncMock
+    ) -> None:
+        from sqlalchemy.sql.selectable import Select
+
+        result_mock = MagicMock()
+        result_mock.scalars.return_value.all.return_value = []
+        mock_session.execute.return_value = result_mock
+
+        await service.get_build_artifacts(VOYAGE_ID, phase_number=2)
+        stmt = mock_session.execute.call_args.args[0]
+        assert isinstance(stmt, Select)
+        compiled = str(stmt.compile(compile_kwargs={"literal_binds": True}))
+        assert "phase_number = 2" in compiled
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_list(
+        self, service: ShipwrightService, mock_session: AsyncMock
+    ) -> None:
+        result = await service.get_build_artifacts(VOYAGE_ID)
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_reader_instance_works(self) -> None:
+        session = AsyncMock()
+        result_mock = MagicMock()
+        result_mock.scalars.return_value.all.return_value = []
+        session.execute = AsyncMock(return_value=result_mock)
+
+        reader = ShipwrightService.reader(session)
+        result = await reader.get_build_artifacts(VOYAGE_ID)
+        assert result == []
+
+
+class TestGetLatestRun:
+    @pytest.mark.asyncio
+    async def test_returns_most_recent_row(
+        self, service: ShipwrightService, mock_session: AsyncMock
+    ) -> None:
+        run = MagicMock()
+        run.phase_number = 1
+        result_mock = MagicMock()
+        result_mock.scalars.return_value.first.return_value = run
+        mock_session.execute.return_value = result_mock
+
+        result = await service.get_latest_run(VOYAGE_ID, 1)
+        assert result is run
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_no_row(
+        self, service: ShipwrightService, mock_session: AsyncMock
+    ) -> None:
+        result_mock = MagicMock()
+        result_mock.scalars.return_value.first.return_value = None
+        mock_session.execute.return_value = result_mock
+
+        result = await service.get_latest_run(VOYAGE_ID, 1)
+        assert result is None


### PR DESCRIPTION
## Summary
- Adds the **Shipwright** crew agent: phase-scoped developer that reads a Poneglyph + Doctor's failing health checks, generates source code in the Execution Service sandbox, and iterates `generate → run_tests → refine` up to `SHIPWRIGHT_MAX_ITERATIONS` (3) until pytest exits 0.
- Graph stays side-effect-free (one iteration per `.ainvoke()`); the **service** owns the loop and writes per-iteration `VivreCard` checkpoints so long runs don't lose progress.
- Atomic DB commit precedes best-effort git push of `agent/shipwright/<voyage-id>` + best-effort publication of `CodeGeneratedEvent` + `TestsPassedEvent`.

## Closes
Closes #14

## What's new
- **Models** — `ShipwrightRun` (one per invocation, indexed on voyage+phase) and `BuildArtifact` (one per file, linked to run).
- **Schemas** — `BuildArtifactSpec` with `_validate_relative_path` (rejects absolute paths, drive/scheme prefixes, `..` traversal); `ShipwrightOutputSpec` with duplicate-path validator; `BuildResultResponse`, `BuildArtifactListResponse`, `BuildArtifactRead`.
- **Graph** — `app/crew/shipwright_graph.py`: two nodes (`generate`, `run_tests`), strips markdown fences, merges generated + health-check files for pytest.
- **Service** — `app/services/shipwright_service.py`: iteration loop, vitest gate (`VITEST_NOT_SUPPORTED`), graceful malformed-Poneglyph fallback, parse-failure path that **persists a run row** (`status="failed"`) before raising `BUILD_PARSE_FAILED` for post-mortem inspection, delete-before-insert semantics for re-builds of the same phase.
- **API** — `app/api/v1/shipwright.py`:
  - `POST /voyages/{id}/phases/{n}/build` → 201 / 409 `VOYAGE_NOT_BUILDABLE` / 404 `PONEGLYPH_NOT_FOUND` / 404 `HEALTH_CHECKS_NOT_FOUND` / 422 `BUILD_PARSE_FAILED`/`VITEST_NOT_SUPPORTED`
  - `GET /voyages/{id}/phases/{n}/build` → latest run summary
  - `GET /voyages/{id}/build-artifacts?phase_number=N` → artifact list with optional phase filter
- **Events** — added `TestsPassedEvent` (CodeGeneratedEvent already existed); updated `AnyEvent` union.
- **Migration** — `b2c3d4e5f6a1_shipwright.py` creates both tables with `ix_*_voyage_phase` composite indexes.

## Review-driven fixes (applied before PR)
- **Parse-failure persistence** — if every iteration fails JSON parse, we now write a `ShipwrightRun(status="failed")` + `VivreCard(checkpoint_reason="build_complete")` row before raising `BUILD_PARSE_FAILED`, so the failure is inspectable. Previously the row was lost.
- **Phase filter pushed server-side** — `DoctorService.get_health_checks(voyage_id, phase_number=None)` now filters in SQL; the Shipwright API no longer fetches all checks and filters in Python.
- **Removed redundant flush** on the error path (was a no-op since the earlier BUILDING-status flush was never committed).

## Test plan
- [x] 547 passed, 10 skipped — full backend suite
- [x] `ruff check` — clean
- [x] `mypy` — only pre-existing `jose` stub warning
- [x] 14 graph tests (role routing, prompt structure, retry-block inclusion, markdown fence stripping, malformed-JSON handling, file merging, pass/fail counts)
- [x] 30 service tests (status transitions, atomic commit ordering, iteration loop, per-iteration VivreCards, max_iterations no-artifacts/no-events, vitest gate, parse-failure persists run row, malformed-Poneglyph degrades gracefully, git-failure tolerance)
- [x] 11 API tests (201/409/404/422 matrix, phase filter, empty list)
- [x] 15 schema tests (path safety matrix, duplicate file_path rejection)
- [x] 4 model tests (table columns, indexes, FK constraints)