### PR TITLE
feat: add Helmsman Agent with three-tier deployments (Phase 14) #15

### DIFF
--- a/pdd/prompts/features/crew/PLAN-helmsman-agent.md
+++ b/pdd/prompts/features/crew/PLAN-helmsman-agent.md
@@ -1,0 +1,194 @@
+# Implementation Plan: Helmsman Agent (Phase 14)
+
+**Created**: 2026-04-17
+**Issue**: #15
+**Complexity**: Medium — imperative orchestration over real (simulated) infra, new approval gate, rollback semantics, but only ONE LLM call (failure diagnosis). Less novel than Shipwright's iteration loop.
+**Estimated prompts**: 1 (single PDD prompt, matching crew precedent)
+
+## Summary
+
+The Helmsman is a **voyage-scoped DevOps agent**. One invocation takes a voyage + a deployment tier (`preview` | `staging` | `production`) and triggers a deploy via a swappable `DeploymentBackend`. The v1 backend is a **simulated in-process backend** — no real Docker/k8s yet, which lets us ship the agent and let Phase 15's pipeline wire it in as the `DEPLOYING` state without requiring cluster infrastructure. A future phase slots in a real backend behind the same interface.
+
+Unlike Shipwright (iterative LLM loop) and Doctor (LLM generation + sandbox exec), Helmsman is mostly **imperative**: it reads repo infra files, calls the backend, records a `Deployment` row. The only LLM call is optional **failure diagnosis** — when a deploy fails, the Helmsman asks the Dial System (`CrewRole.HELMSMAN`) to summarize the error logs into a structured `DeploymentDiagnosis` for the Observation Deck. On success, no LLM call.
+
+Three tiers with increasing gates:
+- **Preview** — deploys from `agent/shipwright/<voyage-id>` branch, auto, no approval.
+- **Staging** — deploys from `staging` branch, auto.
+- **Production** — deploys from `main`, requires explicit `approved_by=user_id` in the request. No approval → 403 `APPROVAL_REQUIRED`. (Phase 17 User Intervention later replaces this flag with a full workflow.)
+
+Rollback is a separate explicit action: `POST /voyages/{id}/rollback?tier=<tier>` finds the previous `status=completed` Deployment for that `(voyage, tier)` and redeploys its stored git ref.
+
+Same three-layer crew pattern (`graph → service → API` with `reader()` factory), atomic DB commit before best-effort events, best-effort LLM diagnosis on failure.
+
+## Phases
+
+### Phase 1 (single prompt): Helmsman Agent end-to-end
+
+**Produces**:
+- `alembic/versions/<rev>_deployment.py` — migration adding the `deployments` table
+- `app/models/deployment.py` — `Deployment` SQLAlchemy model (one row per deploy/rollback action)
+- `app/schemas/deployment.py` — Pydantic schemas: `DeploymentTier` enum, `DeploymentStatus` enum, `DeployRequest`, `RollbackRequest`, `DeploymentResponse`, `DeploymentRead`, `DeploymentListResponse`, `DeploymentDiagnosisSpec`
+- `app/deployment/backend.py` — `DeploymentBackend` ABC + `DeploymentArtifact`/`DeploymentResult` dataclasses (mirrors `app/execution/backend.py`)
+- `app/deployment/in_process.py` — `InProcessDeploymentBackend` (simulated; records deploys to a dict keyed by `(voyage_id, tier)`, returns synthetic URLs like `http://preview.voyage-<hex>.local`)
+- `app/crew/helmsman_graph.py` — LangGraph graph with nodes: `deploy` (imperative) → conditional → `diagnose` (LLM, on failure only) → `END`
+- `app/services/helmsman_service.py` — `HelmsmanService` with `deploy(voyage, tier, git_ref, user_id, approved_by=None)`, `rollback(voyage, tier, user_id)`, `get_deployments(voyage_id, tier=None)`, `get_latest_deployment(voyage_id, tier)`, and `reader(session)` classmethod
+- `app/api/v1/helmsman.py` — `POST /voyages/{id}/deploy`, `POST /voyages/{id}/rollback`, `GET /voyages/{id}/deployments`
+- `app/den_den_mushi/events.py` — add `DeploymentStartedEvent`, `DeploymentFailedEvent` (note: `DeploymentCompletedEvent` already exists; verify and reuse)
+- `app/api/v1/router.py` — include the new router
+- `app/main.py` — instantiate `InProcessDeploymentBackend` in lifespan, register via `app.state.deployment_backend` + `get_deployment_backend` dependency
+- Tests: `tests/test_helmsman_schemas.py`, `tests/test_helmsman_graph.py`, `tests/test_helmsman_service.py`, `tests/test_helmsman_api.py`, `tests/test_deployment_backend.py`, `tests/test_models.py` (extended)
+
+**Depends on**:
+- `GitService` — used *lightly* to resolve a git SHA for the requested ref (for auditability); optional if `target_repo` is unset
+- `DialSystemRouter` — only for the `diagnose` node, only on failure
+- `DenDenMushi` — event publishing
+
+**Risk**: Medium — new `DeploymentBackend` abstraction + approval gate are novel. Rollback semantics (find-previous-completed-and-redeploy) are new. But the graph itself is trivial compared to Shipwright's loop.
+
+**Prompt**: `pdd/prompts/features/crew/grandline-14-helmsman.md`
+
+## Key design decisions (proposed — please confirm before prompt)
+
+### (a) What does "deploy" DO in v1? — Simulated backend behind a swappable ABC
+
+**Decision**: Ship v1 with an `InProcessDeploymentBackend` that simulates deployments. Same pattern as `ExecutionBackend` (swappable, ABC-first). The backend records deploys keyed by `(voyage_id, tier)`, generates a synthetic URL, and can simulate failures for testing via a config flag. Real `DockerDeploymentBackend` / `KubernetesDeploymentBackend` slot in later without changing the service layer.
+
+**Why**: Shipping the agent without a cluster. Phase 15 Pipeline can wire the Helmsman in as `DEPLOYING` immediately. Decouples "the agent logic is correct" from "the cluster is set up."
+
+**Log in decisions.md**: _"Helmsman v1 uses a simulated DeploymentBackend; real backends are follow-up work behind the same ABC."_
+
+### (b) Where does tier config live? — Global defaults, no per-voyage override in v1
+
+**Decision**: v1 has hardcoded defaults for each tier (backend selection, URL format) in a `DEPLOYMENT_DEFAULTS` constant in `app/deployment/config.py`. No per-voyage override. Follow-up phase can add a JSONB `deployment_config` column on `Voyage` if users ask for per-voyage targets.
+
+**Why**: Config surface area has a cost. The simulated backend doesn't need real config. Defer real config until a real backend demands it.
+
+### (c) Rollback target storage — `Deployment` table, append-only history
+
+**Decision**: One `Deployment` row per deploy or rollback action. Columns: `id`, `voyage_id`, `tier`, `action` (`deploy` | `rollback`), `git_ref`, `git_sha` (resolved), `status` (`awaiting_approval` | `running` | `completed` | `failed`), `approved_by` (UUID or null), `url` (synthetic in v1), `backend_log` (Text, truncated), `diagnosis` (JSONB, null on success), `previous_deployment_id` (FK for rollbacks), `created_at`, `updated_at`. Indexed on `(voyage_id, tier, created_at DESC)`.
+
+**Why**: Full audit trail. Rollback works by finding the previous `status=completed action=deploy` for the same `(voyage, tier)` and deploying its `git_sha`. Matches the `ValidationRun` / `ShipwrightRun` pattern.
+
+### (d) Production approval gate — explicit `approved_by` field, no separate endpoint in v1
+
+**Decision**: `DeployRequest` includes optional `approved_by: UUID | None`. If `tier == production` and `approved_by` is null or doesn't match a valid user, the service raises `HelmsmanError("APPROVAL_REQUIRED")` → API returns 403. Preview/staging ignore `approved_by`. Phase 17 (User Intervention) later replaces this with a proper workflow (approval request → UI prompt → approval event).
+
+**Why**: Minimum viable approval. Doesn't block Phase 15 Pipeline from integrating. Client-side orchestration (CLI or UI) collects user confirmation and passes `approved_by=user_id`. The field is persisted on `Deployment` for audit.
+
+**Log in decisions.md**: _"Helmsman v1 uses an explicit `approved_by` field on DeployRequest as the production approval gate. Phase 17 replaces with a full intervention workflow."_
+
+### (e) Inputs to Helmsman — `voyage + tier + user_id` (+ optional `approved_by` for prod, optional `git_ref` override)
+
+**Decision**: The service resolves `git_ref` from the tier by default:
+- `preview` → `agent/shipwright/<voyage-id>`
+- `staging` → `staging`
+- `production` → `main`
+
+Caller can override with an explicit `git_ref` in the request (useful for Phase 15 Pipeline which may want to deploy a specific SHA). `git_sha` is resolved from `git_ref` via `GitService.get_head_sha(...)` if `target_repo` is set; otherwise stored as null.
+
+**Why**: Sensible defaults, explicit override. The service doesn't take `BuildArtifacts` directly — git is the source of truth, and the artifacts are already committed.
+
+### (f) Infrastructure files — consume pre-existing, no LLM generation
+
+**Decision**: v1 assumes the repo contains deployment-ready infra (Dockerfile or `docker-compose.yml` at repo root). The Helmsman reads a manifest hint (e.g., `Dockerfile` path) and passes it to the backend. No LLM-generated Dockerfiles in v1. The simulated backend accepts the file path as a string and records it without parsing.
+
+**Why**: Keeps v1 scope tight. LLM-generated infra is a meaningful feature but deserves its own PDD cycle.
+
+### (g) Git interaction — `get_head_sha` only, no merge orchestration
+
+**Decision**: Helmsman calls `GitService.get_head_sha(voyage_id, user_id, branch)` (we'll need to ADD this if missing — check first) to resolve the git ref to a SHA for auditability. No branch creation, no merging. External orchestration (Phase 15 Pipeline) handles git flow between tiers.
+
+**Why**: Separation of concerns. Helmsman's job is "deploy what you're told to deploy," not "manage the git flow." Matches how real-world deployers work — CI pipelines stage the code, the deployer takes it from there.
+
+### (h) Iteration / retry — single-shot, explicit rollback is a separate action
+
+**Decision**: Deploy is single-shot. On failure, the `diagnose` node runs (one LLM call), persists the diagnosis, publishes `DeploymentFailedEvent`, and the request returns `status=failed`. Retry is the caller's responsibility (re-POST `/deploy`). Rollback is a separate endpoint that targets the previous completed deployment.
+
+**Why**: Deploy failures usually need human inspection (cluster state, credentials, etc.) — retrying blindly is often wrong. Rollback is the first-class safety mechanism, not retry.
+
+### Graph shape
+
+Two nodes, one conditional edge:
+
+```
+START → deploy → [success? END : diagnose → END]
+```
+
+- `deploy` — imperative node. Calls `DeploymentBackend.deploy(request) -> DeploymentResult`. Returns `{status, url, backend_log, error}` in graph state. No LLM call.
+- `diagnose` — LLM node. Only runs on `status != "completed"`. Calls `DialSystemRouter.route(CrewRole.HELMSMAN, ...)` with `backend_log` and asks for a structured `DeploymentDiagnosisSpec` (`summary: str`, `likely_cause: str`, `suggested_action: str`). Best-effort — if the LLM call itself fails, store `diagnosis=None` and log a warning. Never fails the deploy request purely because diagnosis failed.
+
+### State shape (TypedDict)
+
+```python
+class HelmsmanState(TypedDict):
+    voyage_id: uuid.UUID
+    user_id: uuid.UUID
+    tier: Literal["preview", "staging", "production"]
+    git_ref: str
+    git_sha: str | None
+    deployment_id: uuid.UUID
+    manifest_path: str | None
+    # filled by deploy node:
+    status: Literal["completed", "failed"]
+    url: str | None
+    backend_log: str
+    error: str | None
+    # filled by diagnose node:
+    diagnosis: dict[str, Any] | None
+```
+
+### `HelmsmanError` codes
+
+- `APPROVAL_REQUIRED` — production deploy without valid `approved_by` → 403
+- `UNKNOWN_TIER` → 422 (shouldn't happen if Pydantic validates)
+- `NO_PREVIOUS_DEPLOYMENT` — rollback requested but no prior completed deploy → 404
+- `DEPLOYMENT_FAILED` → 422, carries the diagnosis summary
+- `GIT_REF_UNRESOLVABLE` → 422, when `get_head_sha` fails
+
+### Status lifecycle on Voyage
+
+Voyage moves `CHARTED → DEPLOYING` during the call, restores to `CHARTED` on both success and failure. Preserves re-invocation. (Note: for rollback, also transition through `DEPLOYING`.) On production deploy success we might eventually transition to `COMPLETED`, but leave that orchestration to Phase 15 — v1 always restores to `CHARTED`.
+
+### Atomic commit + best-effort side effects
+
+Same pattern as Shipwright/Doctor:
+1. `status=running` Deployment row inserted, flushed
+2. Backend call executes
+3. Row updated with final status, url, backend_log, diagnosis
+4. Voyage status restored
+5. `session.commit()`
+6. _Best-effort_ `DeploymentStartedEvent` + (`DeploymentCompletedEvent` | `DeploymentFailedEvent`) published
+
+`DeploymentStartedEvent` is emitted just before step 2 via a nested `session.begin_nested()` commit OR (simpler) emitted alongside the terminal event after the main commit. **Proposed**: emit both events alongside the final commit, in start→terminal order. The "started" event in a post-commit publish is still useful to the Observation Deck for timeline purposes.
+
+## Risks & Unknowns
+
+- **GitService may lack `get_head_sha`.** If so, the prompt adds it (small, non-invasive — `git rev-parse HEAD` in the sandbox). Check existing git_service.py first; if the helper exists under a different name, use that.
+- **Approval field is trust-the-caller.** The `approved_by` UUID is not verified against a separate approval record in v1. A malicious/buggy client could pass any UUID. Phase 17 fixes this with a signed approval token + workflow. **Log as a known limitation in decisions.md.**
+- **Rollback on tier with only one deployment.** No previous completed deploy → 404 `NO_PREVIOUS_DEPLOYMENT`. Correct behavior; the test matrix includes this.
+- **Concurrent deploy requests to same tier.** Two clients deploy to `preview` simultaneously — last write wins at the `deployments` table (both rows persisted), but the backend's state is racy. v1 accepts this; the `voyage.status = DEPLOYING` gate provides some protection but only cross-tier (since one voyage can't be DEPLOYING in two tiers simultaneously without the gate rejecting the second). **Propose**: enforce voyage-level serialization via the `voyage.status != CHARTED` 409 check, same as Shipwright. Cross-tier concurrent deploys are deferred until a `per-tier status` refactor. **Log in decisions.md.**
+- **LLM diagnosis latency on failure.** Adds an LLM round-trip to the error path. Acceptable — failure diagnosis is valuable. Wrapped in try/except so a diagnosis-fail doesn't mask the real deploy-fail response.
+- **Token bloat in `backend_log`.** Trunc to last 4000 chars (same constant Shipwright uses) before sending to LLM and before persisting.
+
+## Decisions Locked (confirmed 2026-04-17)
+
+1. ✅ **Simulated v1 backend** behind `DeploymentBackend` ABC. Modular so `DockerDeploymentBackend`/`KubernetesDeploymentBackend` slot in later without changing service code.
+2. ✅ **Approval via `approved_by: UUID` field** on `DeployRequest`. Check encapsulated in a single `_require_production_approval(tier, approved_by)` helper so Phase 17 replaces it by swapping that one function.
+3. ✅ **No git merge orchestration in Helmsman** — caller provides `git_ref`; service only resolves `git_ref → git_sha` for audit.
+4. ✅ **Single `Deployment` table** with `action` column (`deploy` | `rollback`).
+5. ✅ **Voyage-level status gate** — `voyage.status == CHARTED` required; transitions to `DEPLOYING` during call, restores to `CHARTED` on both success and failure. 409 if already `DEPLOYING`.
+6. ✅ **LLM diagnosis on failure only** — `deploy → (if fail) diagnose → END`. Zero LLM calls on success. Diagnosis wrapped in best-effort try/except.
+
+## Scope cuts proposed (all logged in decisions.md if confirmed)
+
+- No real cluster deploy in v1 (simulated backend)
+- No per-voyage config overrides (hardcoded defaults)
+- No approval workflow endpoint (simple `approved_by` field)
+- No git merge orchestration (caller provides git_ref)
+- No LLM-generated infrastructure files
+- No retry loop (single-shot, explicit rollback)
+- No cross-tier concurrency (one deploy-in-flight per voyage)
+
+## Next step
+
+Once you confirm the six decisions above (or redirect any of them), I'll run `/pdd-skill:pdd-prompts` to produce `pdd/prompts/features/crew/grandline-14-helmsman.md` and we start implementing TDD-first.

--- a/pdd/prompts/features/crew/grandline-14-helmsman.md
+++ b/pdd/prompts/features/crew/grandline-14-helmsman.md
@@ -1,0 +1,993 @@
+# Phase 14: Helmsman Agent (DevOps)
+
+## Context
+
+The Helmsman is the fifth crew agent. It's the **DevOps agent** — takes a
+voyage + a deployment tier (`preview` | `staging` | `production`) and
+triggers a deploy via a swappable `DeploymentBackend`. On success, it
+records a `Deployment` row and publishes events. On failure, it asks the
+Dial System (once, best-effort) to diagnose the failure into a structured
+summary and records it alongside the failed deployment.
+
+Unlike Navigator (multi-phase LLM batch), Doctor (per-phase LLM batch),
+and Shipwright (iterative LLM loop), the Helmsman is mostly
+**imperative**. The only LLM call is **failure diagnosis**, and it only
+fires on `status != "completed"`. A successful deploy makes zero LLM
+calls.
+
+Same three-layer crew agent pattern as Captain/Navigator/Doctor/Shipwright
+(`graph → service → API` with `reader()` factory), atomic DB commit that
+includes a `VivreCard` checkpoint, best-effort event publishing after
+commit. Reuse `strip_fences` from `app/crew/utils.py`.
+
+**Key architectural note**: v1 does **not** deploy to real clusters. It
+ships with an `InProcessDeploymentBackend` (simulated — dict-backed, no
+Docker/k8s) behind a `DeploymentBackend` ABC that mirrors
+`ExecutionBackend`. This lets Phase 15 Pipeline wire the Helmsman in as
+the `DEPLOYING` step immediately. Real backends (`DockerDeploymentBackend`,
+`KubernetesDeploymentBackend`) slot in later without changing the service
+layer. This is locked in `pdd/prompts/features/crew/PLAN-helmsman-agent.md`
+(2026-04-17).
+
+**Second architectural note**: the production approval gate is an
+explicit `approved_by: UUID | None` field on `DeployRequest`. If
+`tier == production` and `approved_by` is not set, the service raises
+`HelmsmanError("APPROVAL_REQUIRED")` → 403. The check is encapsulated in a
+single helper `_require_production_approval(tier, approved_by)` so
+Phase 17 (User Intervention) can replace the approval mechanism by
+swapping that one function — nothing else in the service needs to change.
+
+**Third architectural note**: Helmsman does **not** orchestrate git
+branches or merges. The caller provides `git_ref`; the service only
+resolves `git_ref → git_sha` via `GitService.get_head_sha(...)` for
+audit. External orchestration (Phase 15 Pipeline) handles the git flow
+between tiers.
+
+### Existing Infrastructure
+
+| System | Module | Key Interfaces |
+|--------|--------|----------------|
+| **Dial System** | `app.dial_system.router.DialSystemRouter` | `route(role, CompletionRequest) -> CompletionResult` |
+| **Den Den Mushi** | `app.den_den_mushi.mushi.DenDenMushi` | `publish(stream, event)` |
+| **Git Service** | `app.services.git_service.GitService` | `create_branch`, `commit`, `push`, etc. — **NEEDS `get_head_sha` added** (see Deliverable #8) |
+| **VivreCard Service** | `app.services.vivre_card_service.VivreCardService` | `checkpoint(session, voyage_id, crew_member, state_data, checkpoint_reason)` |
+| **Voyage Model** | `app.models.voyage.Voyage` | Has `status`, `target_repo`, etc. |
+| **Enums** | `app.models.enums` | `CrewRole.HELMSMAN`, `VoyageStatus.DEPLOYING`, `VoyageStatus.CHARTED` (all already defined) |
+| **Events** | `app.den_den_mushi.events` | `DeploymentCompletedEvent` already exists; `DeploymentStartedEvent` + `DeploymentFailedEvent` need to be ADDED to events.py + `AnyEvent` union |
+| **Constants** | `app.den_den_mushi.constants` | `stream_key(voyage_id)` |
+| **Shared helpers** | `app.crew.utils` | `strip_fences(text)` |
+| **Execution Backend ABC (pattern reference)** | `app.execution.backend.ExecutionBackend` | Mirror this exact shape for `DeploymentBackend` |
+| **Shipwright service (pattern reference)** | `app.services.shipwright_service` | `TRUNCATE = 4000`, atomic commit + best-effort events, `reader()` factory |
+
+Current alembic head is `b2c3d4e5f6a1` (Shipwright). New migration's
+`down_revision = "b2c3d4e5f6a1"`.
+
+## Deliverables
+
+### 1. Database — new `Deployment` model + migration
+
+One new table. Single migration file under
+`src/backend/alembic/versions/`. `down_revision = "b2c3d4e5f6a1"`.
+
+```python
+op.create_table(
+    "deployments",
+    sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+    sa.Column("voyage_id", postgresql.UUID(as_uuid=True),
+              sa.ForeignKey("voyages.id"), nullable=False, index=True),
+    sa.Column("tier", sa.String(20), nullable=False),        # preview | staging | production
+    sa.Column("action", sa.String(20), nullable=False),      # deploy | rollback
+    sa.Column("git_ref", sa.String(255), nullable=False),
+    sa.Column("git_sha", sa.String(64), nullable=True),
+    sa.Column("status", sa.String(20), nullable=False),      # running | completed | failed
+    sa.Column("approved_by", postgresql.UUID(as_uuid=True), nullable=True),
+    sa.Column("url", sa.String(500), nullable=True),
+    sa.Column("backend_log", sa.Text(), nullable=True),
+    sa.Column("diagnosis", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+    sa.Column("previous_deployment_id", postgresql.UUID(as_uuid=True),
+              sa.ForeignKey("deployments.id"), nullable=True, index=True),
+    sa.Column("created_at", sa.DateTime(timezone=True), nullable=False,
+              server_default=sa.func.now()),
+    sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False,
+              server_default=sa.func.now()),
+)
+op.create_index(
+    "ix_deployments_voyage_tier_created",
+    "deployments",
+    ["voyage_id", "tier", sa.text("created_at DESC")],
+)
+```
+
+Downgrade drops the index then the table.
+
+SQLAlchemy model in `app/models/deployment.py`:
+
+```python
+class Deployment(Base):
+    __tablename__ = "deployments"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    voyage_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("voyages.id"), index=True, nullable=False
+    )
+    tier: Mapped[str] = mapped_column(String(20), nullable=False)
+    action: Mapped[str] = mapped_column(String(20), nullable=False)
+    git_ref: Mapped[str] = mapped_column(String(255), nullable=False)
+    git_sha: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    status: Mapped[str] = mapped_column(String(20), nullable=False)
+    approved_by: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), nullable=True
+    )
+    url: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    backend_log: Mapped[str | None] = mapped_column(Text, nullable=True)
+    diagnosis: Mapped[dict[str, Any] | None] = mapped_column(JSONB, nullable=True)
+    previous_deployment_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("deployments.id"), index=True, nullable=True
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),  # SQLAlchemy-level only; migration omits onupdate intentionally.
+        nullable=False,
+    )
+```
+
+Export from `app/models/__init__.py`.
+
+### 2. Pydantic Schemas — `app/schemas/deployment.py`
+
+```python
+DeploymentTier = Literal["preview", "staging", "production"]
+DeploymentAction = Literal["deploy", "rollback"]
+DeploymentStatus = Literal["running", "completed", "failed"]
+
+
+class DeploymentDiagnosisSpec(BaseModel):
+    """Structured LLM diagnosis of a deployment failure."""
+    summary: str = Field(min_length=1, max_length=500)
+    likely_cause: str = Field(min_length=1, max_length=1000)
+    suggested_action: str = Field(min_length=1, max_length=1000)
+
+
+class DeployRequest(BaseModel):
+    tier: DeploymentTier
+    git_ref: str | None = Field(default=None, max_length=255)
+    approved_by: uuid.UUID | None = None
+
+
+class RollbackRequest(BaseModel):
+    tier: DeploymentTier
+
+
+class DeploymentRead(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+    id: uuid.UUID
+    voyage_id: uuid.UUID
+    tier: DeploymentTier
+    action: DeploymentAction
+    git_ref: str
+    git_sha: str | None
+    status: DeploymentStatus
+    approved_by: uuid.UUID | None
+    url: str | None
+    backend_log: str | None
+    diagnosis: dict[str, Any] | None
+    previous_deployment_id: uuid.UUID | None
+    created_at: datetime
+    updated_at: datetime
+
+
+class DeploymentResponse(BaseModel):
+    voyage_id: uuid.UUID
+    deployment_id: uuid.UUID
+    tier: DeploymentTier
+    action: DeploymentAction
+    status: DeploymentStatus
+    git_ref: str
+    git_sha: str | None
+    url: str | None
+    diagnosis: dict[str, Any] | None
+
+
+class DeploymentListResponse(BaseModel):
+    voyage_id: uuid.UUID
+    tier: DeploymentTier | None
+    deployments: list[DeploymentRead]
+```
+
+Note: `git_ref` is optional in `DeployRequest`; the service fills the
+default per tier (see Deliverable #5). `tier` on `RollbackRequest` must
+be provided — the caller picks which tier to roll back.
+
+### 3. DeploymentBackend ABC + dataclasses — `app/deployment/backend.py`
+
+Mirror `ExecutionBackend`. New package `app/deployment/` with an empty
+`__init__.py`.
+
+```python
+from __future__ import annotations
+
+import uuid
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Literal
+
+
+@dataclass(frozen=True)
+class DeploymentArtifact:
+    voyage_id: uuid.UUID
+    tier: Literal["preview", "staging", "production"]
+    git_ref: str
+    git_sha: str | None
+    # Reserved for future real backends (Docker/k8s manifest path).
+    # v1 callers always pass None; field kept on the ABC for forward-compat.
+    manifest_path: str | None = None
+
+
+@dataclass(frozen=True)
+class DeploymentResult:
+    status: Literal["completed", "failed"]
+    url: str | None
+    backend_log: str
+    error: str | None = None
+
+
+class DeploymentError(Exception):
+    """Raised when a backend operation fails internally."""
+
+
+class DeploymentBackend(ABC):
+    @abstractmethod
+    async def deploy(self, artifact: DeploymentArtifact) -> DeploymentResult:
+        """Deploy the artifact to the given tier. Never raises on deploy
+        failure — returns status='failed' with a log instead. Raises
+        DeploymentError only for backend-internal errors (e.g. client
+        connection failure)."""
+        ...
+
+    @abstractmethod
+    async def status(
+        self,
+        voyage_id: uuid.UUID,
+        tier: Literal["preview", "staging", "production"],
+    ) -> DeploymentResult | None:
+        """Return the last deploy result for (voyage, tier), or None."""
+        ...
+
+    async def close(self) -> None:
+        """Release resources (e.g. HTTP client session)."""
+```
+
+### 4. InProcessDeploymentBackend — `app/deployment/in_process.py`
+
+Dict-backed, synchronous simulation. Used for v1 and for tests.
+
+```python
+from __future__ import annotations
+
+import uuid
+from typing import Literal
+
+from app.deployment.backend import (
+    DeploymentArtifact,
+    DeploymentBackend,
+    DeploymentResult,
+)
+
+
+TierLiteral = Literal["preview", "staging", "production"]
+
+
+class InProcessDeploymentBackend(DeploymentBackend):
+    """Simulated deployment backend. Records deploys in an in-memory
+    dict and returns synthetic URLs. Used for v1 (no real cluster) and
+    for tests.
+
+    Fail-injection: if `fail_tiers` contains the tier being deployed,
+    `deploy()` returns status='failed' with a synthetic log. Useful for
+    exercising the diagnose path in tests without patching."""
+
+    def __init__(self, *, fail_tiers: set[str] | None = None) -> None:
+        self._records: dict[tuple[uuid.UUID, str], DeploymentResult] = {}
+        self._fail_tiers = fail_tiers or set()
+
+    async def deploy(self, artifact: DeploymentArtifact) -> DeploymentResult:
+        if artifact.tier in self._fail_tiers:
+            result = DeploymentResult(
+                status="failed",
+                url=None,
+                backend_log=(
+                    f"simulated failure for tier={artifact.tier} "
+                    f"ref={artifact.git_ref} sha={artifact.git_sha}"
+                ),
+                error="SimulatedFailure",
+            )
+        else:
+            url = (
+                f"http://{artifact.tier}.voyage-{artifact.voyage_id.hex[:8]}.local"
+            )
+            result = DeploymentResult(
+                status="completed",
+                url=url,
+                backend_log=(
+                    f"deployed tier={artifact.tier} ref={artifact.git_ref} "
+                    f"sha={artifact.git_sha} url={url}"
+                ),
+                error=None,
+            )
+        self._records[(artifact.voyage_id, artifact.tier)] = result
+        return result
+
+    async def status(
+        self,
+        voyage_id: uuid.UUID,
+        tier: TierLiteral,
+    ) -> DeploymentResult | None:
+        return self._records.get((voyage_id, tier))
+```
+
+### 5. LangGraph graph — `app/crew/helmsman_graph.py`
+
+A minimal **two-node** StateGraph with one conditional edge. Graph nodes
+are **side-effect-free at the DB layer** — they call the deployment
+backend and the dial router only. The service layer owns DB writes,
+voyage status transitions, and events.
+
+```
+START → deploy → (status == "completed"? END : diagnose) → END
+```
+
+**State schema:**
+
+```python
+class HelmsmanState(TypedDict):
+    voyage_id: uuid.UUID
+    user_id: uuid.UUID
+    tier: Literal["preview", "staging", "production"]
+    git_ref: str
+    git_sha: str | None
+    # filled by deploy node:
+    status: Literal["completed", "failed"]
+    url: str | None
+    backend_log: str
+    error: str | None
+    # filled by diagnose node (only on failure):
+    diagnosis: dict[str, Any] | None
+```
+
+`manifest_path` is **not** in state for v1 — the simulated backend does
+not need it. When a real backend lands, add `manifest_path` to state +
+`DeployRequest` schema in one go.
+
+**Nodes:**
+
+- `deploy`: imperative. Builds `DeploymentArtifact(voyage_id, tier,
+  git_ref, git_sha)` from the state. Calls
+  `deployment_backend.deploy(artifact)`. Stores `status`, `url`,
+  `backend_log`, `error` on the state. Sets `diagnosis=None` up front so
+  the END branch always has the key populated. Wraps the backend call in
+  `try/except DeploymentError`: on `DeploymentError`, the node itself
+  **does not raise** — it converts to `status="failed", url=None,
+  backend_log=str(exc), error=exc.__class__.__name__` so the conditional
+  edge routes to `diagnose` and the service's commit path still runs.
+  The ABC contract says `deploy()` returns `status="failed"` on deploy
+  failures, so `DeploymentError` is an internal-backend escape hatch
+  only; the node handles it defensively.
+
+- `diagnose`: LLM node. **Only runs on `status != "completed"`.** Builds
+  a user message containing the `tier`, `git_ref`, `git_sha`, and the
+  tail of `backend_log` (last 4000 chars — `backend_log[-TRUNCATE:]`).
+  Calls `DialSystemRouter.route(CrewRole.HELMSMAN, CompletionRequest(...))`.
+  Runs `strip_fences` + `json.loads` +
+  `DeploymentDiagnosisSpec.model_validate` on the raw output. Stores
+  `diagnosis = spec.model_dump()` on success. On any exception (LLM
+  failure, JSON parse error, validation error), stores `diagnosis = None`
+  and logs a warning — **never raise**. A diagnosis-fail must not mask
+  the real deploy-fail response.
+
+**System prompt** (constant `HELMSMAN_SYSTEM_PROMPT`):
+
+```
+You are a Helmsman — a DevOps agent responsible for diagnosing failed
+deployments. You will receive the tier, git ref/SHA, and the last portion
+of the backend's failure log. Produce a concise diagnosis that helps a
+human operator decide what to do next.
+
+Respond with ONLY a JSON object:
+{"summary": "...", "likely_cause": "...", "suggested_action": "..."}
+
+- summary: one sentence describing what went wrong
+- likely_cause: the most probable root cause, based on the log
+- suggested_action: one concrete next step the operator can take
+
+Do not include any other text, markdown formatting, or explanation.
+```
+
+**Conditional routing:**
+
+```python
+def _route_after_deploy(state: HelmsmanState) -> str:
+    return "diagnose" if state["status"] != "completed" else END
+```
+
+**Build function:**
+
+```python
+def build_helmsman_graph(
+    dial_router: DialSystemRouter,
+    deployment_backend: DeploymentBackend,
+) -> CompiledStateGraph: ...
+```
+
+### 6. Events — add `DeploymentStartedEvent` + `DeploymentFailedEvent`
+
+`DeploymentCompletedEvent` already exists in
+`app/den_den_mushi/events.py` — **reuse it, do not redefine**.
+
+Add two new event classes:
+
+```python
+class DeploymentStartedEvent(DenDenMushiEvent):
+    event_type: Literal["deployment_started"] = "deployment_started"
+
+
+class DeploymentFailedEvent(DenDenMushiEvent):
+    event_type: Literal["deployment_failed"] = "deployment_failed"
+```
+
+Add both to the `AnyEvent` discriminated union.
+
+### 7. HelmsmanService — `app/services/helmsman_service.py`
+
+```python
+TRUNCATE = 4000  # same constant Shipwright/Doctor use
+
+DEFAULT_GIT_REF_BY_TIER: dict[str, Callable[[uuid.UUID], str]] = {
+    "preview": lambda voyage_id: f"agent/shipwright/{voyage_id.hex[:8]}",
+    "staging": lambda _voyage_id: "staging",
+    "production": lambda _voyage_id: "main",
+}
+
+
+class HelmsmanError(Exception):
+    def __init__(self, code: str, message: str) -> None:
+        self.code = code
+        self.message = message
+        super().__init__(message)
+
+
+class HelmsmanService:
+    def __init__(
+        self,
+        dial_router: DialSystemRouter,
+        mushi: DenDenMushi,
+        session: AsyncSession,
+        deployment_backend: DeploymentBackend,
+        git_service: GitService | None = None,
+    ) -> None:
+        self._dial_router = dial_router
+        self._mushi = mushi
+        self._session = session
+        self._backend = deployment_backend
+        self._git = git_service
+        self._graph = build_helmsman_graph(dial_router, deployment_backend)
+
+    @classmethod
+    def reader(cls, session: AsyncSession) -> HelmsmanService:
+        inst = cls.__new__(cls)
+        inst._session = session
+        inst._dial_router = None   # type: ignore[assignment]
+        inst._mushi = None         # type: ignore[assignment]
+        inst._backend = None       # type: ignore[assignment]
+        inst._git = None           # type: ignore[assignment]
+        inst._graph = None         # type: ignore[assignment]
+        return inst
+
+    async def deploy(
+        self,
+        voyage: Voyage,
+        tier: DeploymentTier,
+        user_id: uuid.UUID,
+        git_ref: str | None = None,
+        approved_by: uuid.UUID | None = None,
+    ) -> DeploymentResponse: ...
+
+    async def rollback(
+        self,
+        voyage: Voyage,
+        tier: DeploymentTier,
+        user_id: uuid.UUID,
+    ) -> DeploymentResponse: ...
+
+    async def get_deployments(
+        self,
+        voyage_id: uuid.UUID,
+        tier: DeploymentTier | None = None,
+    ) -> list[Deployment]: ...
+
+    async def get_latest_deployment(
+        self,
+        voyage_id: uuid.UUID,
+        tier: DeploymentTier,
+    ) -> Deployment | None: ...
+```
+
+**`_require_production_approval` helper (module-level or private method):**
+
+```python
+def _require_production_approval(
+    tier: DeploymentTier,
+    approved_by: uuid.UUID | None,
+) -> None:
+    if tier == "production" and approved_by is None:
+        raise HelmsmanError(
+            "APPROVAL_REQUIRED",
+            "Production deploys require approved_by to be set",
+        )
+```
+
+This is the single swap-point for Phase 17. Do not inline the check.
+
+**`deploy` flow:**
+
+1. `_require_production_approval(tier, approved_by)` — may raise.
+   **Approval is checked BEFORE the status gate.** An unapproved
+   production deploy against a non-CHARTED voyage therefore returns 403
+   `APPROVAL_REQUIRED`, not 409 `VOYAGE_NOT_DEPLOYABLE`. This is
+   intentional — approval is an authorization concern and should fail
+   before any state-machine concern.
+2. **Status gate**: if `voyage.status != VoyageStatus.CHARTED.value`,
+   raise `HelmsmanError("VOYAGE_NOT_DEPLOYABLE", ...)`. (API maps this to
+   409.)
+3. Resolve `git_ref`: use the provided `git_ref` if set, else
+   `DEFAULT_GIT_REF_BY_TIER[tier](voyage.id)`.
+4. Resolve `git_sha`: if `self._git is not None` and
+   `voyage.target_repo` is set, call
+   `await self._git.get_head_sha(voyage.id, user_id, git_ref)`. On
+   `GitError`, raise `HelmsmanError("GIT_REF_UNRESOLVABLE", ...)`.
+   Otherwise `git_sha = None` (still allow the deploy — simulated
+   backend doesn't need a SHA).
+5. Transition `voyage.status = VoyageStatus.DEPLOYING.value`, flush.
+6. Insert a `Deployment` row with
+   `action="deploy", status="running", git_ref, git_sha,
+   approved_by, previous_deployment_id=None`. Flush to get `deployment.id`.
+7. Build initial graph state. Invoke `await self._graph.ainvoke(state)`.
+8. Update the `Deployment` row with `status`, `url`, `backend_log`
+   (truncated to `TRUNCATE`), `diagnosis`.
+9. Create a `VivreCard` (`crew_member="helmsman"`,
+   `state_data={"tier": tier, "action": "deploy", "status": status,
+   "deployment_id": deployment.id, "git_sha": git_sha}`,
+   `checkpoint_reason="deployment"`).
+10. Restore `voyage.status = VoyageStatus.CHARTED.value`.
+11. `await session.commit()`, refresh rows.
+12. **Best-effort event publish** (in this order):
+    - `DeploymentStartedEvent(voyage_id, source_role=CrewRole.HELMSMAN,
+      payload={"tier": tier, "deployment_id": str(deployment.id),
+      "git_ref": git_ref, "git_sha": git_sha})`
+    - On `status=="completed"`:
+      `DeploymentCompletedEvent(voyage_id, source_role=CrewRole.HELMSMAN,
+      payload={"tier": tier, "deployment_id": str(deployment.id),
+      "url": url})`
+    - On `status=="failed"`:
+      `DeploymentFailedEvent(voyage_id, source_role=CrewRole.HELMSMAN,
+      payload={"tier": tier, "deployment_id": str(deployment.id),
+      "diagnosis": diagnosis})`
+    Each publish in its own try/except — one failure must not prevent the
+    others. Never raise from the publish block.
+13. If `status == "failed"`, raise `HelmsmanError("DEPLOYMENT_FAILED",
+    diagnosis.get("summary") if diagnosis else "Deployment failed")`
+    **after** the commit + events, so the row + events are persisted
+    before the API returns 422.
+14. Otherwise, return `DeploymentResponse(...)`.
+
+Any exception during steps 2-11 must reset `voyage.status = CHARTED.value`
+and flush before re-raising, so a client retry sees a clean state.
+
+**`rollback` flow:**
+
+1. **Status gate**: if `voyage.status != VoyageStatus.CHARTED.value`,
+   raise `HelmsmanError("VOYAGE_NOT_DEPLOYABLE", ...)` → 409.
+2. Find the previous deployment to roll back to:
+   `SELECT * FROM deployments WHERE voyage_id = :v AND tier = :t
+   AND status = 'completed' AND action = 'deploy'
+   ORDER BY created_at DESC LIMIT 1`.
+3. If none → raise `HelmsmanError("NO_PREVIOUS_DEPLOYMENT", ...)` → 404
+   at API layer.
+4. Transition to `DEPLOYING`, flush.
+5. Insert a `Deployment` row with `action="rollback", status="running",
+   git_ref=<prev.git_ref>, git_sha=<prev.git_sha>,
+   previous_deployment_id=prev.id, approved_by=None`.
+6. Invoke the graph with the previous deployment's `git_ref`/`git_sha`.
+7. Same update/checkpoint/commit/publish flow as `deploy` — events use
+   `action="rollback"` in the payload. If the rollback itself fails,
+   raise `HelmsmanError("DEPLOYMENT_FAILED", ...)` after commit + events.
+8. Return `DeploymentResponse`.
+
+Rollback does **not** require `approved_by` in v1 — rollbacks are an
+emergency mechanism. (Log as a known limitation in decisions.md —
+Phase 17 can gate rollbacks later.)
+
+**`get_deployments` flow:**
+
+- `SELECT * FROM deployments WHERE voyage_id = :v`.
+- If `tier is not None`, add `AND tier = :t`.
+- Return ordered by `created_at DESC`.
+
+**`get_latest_deployment` flow:**
+
+- `SELECT * FROM deployments WHERE voyage_id = :v AND tier = :t
+  ORDER BY created_at DESC LIMIT 1`.
+
+### 8. GitService — add `get_head_sha`
+
+Add a small method to `app.services.git_service.GitService` (if it does
+not already exist — **check `git_service.py` first**, and if a helper
+with the same intent exists under a different name, reuse that and skip
+this deliverable).
+
+```python
+async def get_head_sha(
+    self,
+    voyage_id: uuid.UUID,
+    user_id: uuid.UUID,
+    ref: str,
+) -> str:
+    """Resolve a branch/tag/SHA-ish to a full commit SHA for audit.
+    Raises GitError if the ref cannot be resolved."""
+    _validate_branch_component(ref)
+    sandbox_id = self._get_sandbox(voyage_id)
+    stdout = await self._run(
+        sandbox_id,
+        f"cd {REPO_PATH} && git rev-parse {shlex.quote(ref)}^{{commit}}",
+    )
+    sha = stdout.strip()
+    if not sha:
+        raise GitError(f"GIT_REF_UNRESOLVABLE: {ref!r}")
+    return sha
+```
+
+Unit test: extend `tests/test_git_service.py` with two cases — resolves
+a branch to a 40-char SHA; raises `GitError` when the ref doesn't
+exist. Mock the `ExecutionBackend` response.
+
+### 9. REST API — `app/api/v1/helmsman.py`
+
+Router with prefix `/voyages/{voyage_id}`, tag `helmsman`.
+
+| Method | Path | Handler | Response |
+|--------|------|---------|----------|
+| POST | `/deploy` | `deploy_voyage` | 201 → `DeploymentResponse` |
+| POST | `/rollback` | `rollback_voyage` | 201 → `DeploymentResponse` |
+| GET  | `/deployments` | `list_deployments` | 200 → `DeploymentListResponse` |
+
+**POST `/deploy` body**: `DeployRequest`. Response: 201 on success.
+Error mapping:
+
+| `HelmsmanError.code` | HTTP status |
+|----------------------|-------------|
+| `APPROVAL_REQUIRED` | 403 |
+| `VOYAGE_NOT_DEPLOYABLE` | 409 |
+| `GIT_REF_UNRESOLVABLE` | 422 |
+| `DEPLOYMENT_FAILED` | 422 |
+| `UNKNOWN_TIER` | 422 |
+| (anything else) | 422 |
+
+Error body: `{"error": {"code": exc.code, "message": exc.message}}`.
+
+**POST `/rollback` body**: `RollbackRequest`. Same status mapping
+plus:
+
+| `HelmsmanError.code` | HTTP status |
+|----------------------|-------------|
+| `NO_PREVIOUS_DEPLOYMENT` | 404 |
+
+**GET `/deployments`**: optional query param `tier: DeploymentTier | None
+= None`. Returns `DeploymentListResponse` (empty list OK). Uses
+`get_helmsman_reader` (session-only).
+
+**Dependencies:**
+
+```python
+def get_deployment_backend(request: Request) -> DeploymentBackend:
+    return request.app.state.deployment_backend
+
+
+async def get_helmsman_service(
+    voyage_id: uuid.UUID,
+    dial_router: DialSystemRouter = Depends(get_dial_router),
+    mushi: DenDenMushi = Depends(get_den_den_mushi),
+    session: AsyncSession = Depends(get_db),
+    deployment_backend: DeploymentBackend = Depends(get_deployment_backend),
+    git_service: GitService = Depends(get_git_service),
+) -> HelmsmanService:
+    return HelmsmanService(
+        dial_router, mushi, session,
+        deployment_backend=deployment_backend,
+        git_service=git_service,
+    )
+
+
+async def get_helmsman_reader(
+    session: AsyncSession = Depends(get_db),
+) -> HelmsmanService:
+    return HelmsmanService.reader(session)
+```
+
+Put `get_deployment_backend` in `app/api/v1/dependencies.py` alongside
+the other `get_*` helpers.
+
+### 10. Wiring
+
+- Register `Deployment` import in `app/models/__init__.py`.
+- Add `helmsman.router` include in `app/api/v1/router.py`.
+- In `app/main.py` lifespan — instantiate `InProcessDeploymentBackend()`
+  and store at `app.state.deployment_backend = InProcessDeploymentBackend()`.
+  On shutdown, `await app.state.deployment_backend.close()` (added
+  **before** the existing backend cleanup, in reverse creation order so
+  resources tear down cleanly).
+- Add `DeploymentStartedEvent` + `DeploymentFailedEvent` to
+  `app/den_den_mushi/events.py` and the `AnyEvent` union.
+
+## Test Plan
+
+All tests use mocked dependencies (no real LLM, DB, sandbox, or git).
+Use `InProcessDeploymentBackend` directly for backend-layer tests — no
+need to mock the ABC.
+
+### Model/Migration Tests — extend `tests/test_models.py`
+
+1. `deployments` appears in `Base.metadata.tables`.
+2. `test_deployment_table_columns` — full column set matches.
+3. `test_deployment_voyage_tier_created_indexed` — composite index exists.
+4. `test_deployment_action_column_values` — only `deploy` / `rollback`
+   are valid string values at the application layer (schema-enforced,
+   not DB-enforced).
+
+### Schema Tests — `tests/test_helmsman_schemas.py`
+
+1. `DeployRequest` accepts `tier="preview"` with no `git_ref`.
+2. `DeployRequest` accepts explicit `git_ref`.
+3. `DeployRequest` rejects `tier="invalid"`.
+4. `DeployRequest` accepts `approved_by` as a UUID.
+5. `DeployRequest` accepts `approved_by=None`.
+6. `RollbackRequest` requires `tier`.
+7. `DeploymentDiagnosisSpec` accepts valid shape.
+8. `DeploymentDiagnosisSpec` rejects empty `summary`.
+9. `DeploymentResponse` accepts `status="failed"` with `url=None`.
+10. `DeploymentResponse` rejects `status="other"`.
+
+### Backend ABC Tests — `tests/test_deployment_backend.py`
+
+1. `InProcessDeploymentBackend.deploy` returns `status="completed"` with
+   a synthetic URL by default.
+2. `InProcessDeploymentBackend.deploy` returns `status="failed"` when
+   tier is in `fail_tiers`.
+3. `InProcessDeploymentBackend.status` returns the last deploy result for
+   a `(voyage, tier)` pair.
+4. `InProcessDeploymentBackend.status` returns `None` when no deploy has
+   happened for that `(voyage, tier)`.
+5. `deploy` stores per-`(voyage, tier)` records — two different voyages
+   deploying to `preview` don't overwrite each other.
+6. `deploy` overwrites the record when the same `(voyage, tier)` is
+   re-deployed.
+7. `backend_log` contains the tier, git_ref, git_sha, and (on success)
+   the URL.
+
+### Graph Tests — `tests/test_helmsman_graph.py`
+
+1. `deploy` node sends `DeploymentArtifact` built from state to the
+   backend.
+2. `deploy` node stores `status`, `url`, `backend_log`, `error` on
+   state.
+3. `deploy` node sets `diagnosis=None` on state so END sees the key.
+4. `diagnose` node is **not invoked** when `status == "completed"` —
+   assert the conditional routes to END.
+5. `diagnose` node **is** invoked when `status == "failed"`.
+6. `diagnose` node sends `CrewRole.HELMSMAN` to the dial router.
+7. `diagnose` node includes the tail of `backend_log` (last 4000 chars)
+   in the user message.
+8. `diagnose` node stores `diagnosis` dict on valid JSON output.
+9. `diagnose` node stores `diagnosis=None` and logs a warning on
+   malformed JSON — **does not raise**.
+10. `diagnose` node stores `diagnosis=None` and logs a warning when the
+    LLM call itself raises — **does not raise**.
+11. `diagnose` node strips ```json fences.
+12. Full graph returns a full state dict with both nodes' outputs on
+    failure path.
+13. Full graph returns a state dict with only `deploy` node's outputs on
+    success path (plus `diagnosis=None`).
+14. `deploy` node converts `DeploymentError` raised by the backend into
+    `status="failed"` state (does not propagate the exception). Assert
+    `state["backend_log"]` contains the exception message and
+    `state["error"]` is set.
+
+### Service Tests — `tests/test_helmsman_service.py`
+
+Fixtures: mock session (`.add`, `.flush`, `.commit`, `.execute`,
+`.refresh`), mock dial_router, mock mushi, mock git_service (optional),
+real `InProcessDeploymentBackend`, mock graph `.ainvoke` that returns a
+preset state. `_mock_voyage(status="CHARTED", target_repo=...)` helper.
+
+**`deploy` — happy path (preview):**
+
+1. Sets voyage status to `DEPLOYING` during the call.
+2. Resolves `git_ref = "agent/shipwright/<hex>"` when none provided.
+3. Calls `git_service.get_head_sha` when `voyage.target_repo` is set.
+4. Skips `get_head_sha` and stores `git_sha=None` when `git_service` is
+   `None`.
+5. Skips `get_head_sha` and stores `git_sha=None` when `voyage.target_repo`
+   is unset.
+6. Invokes the graph once with a complete state dict.
+7. Persists one `Deployment` row with `action="deploy", status="completed",
+   url` populated.
+8. Creates a `VivreCard` with `checkpoint_reason="deployment"`.
+9. Calls `session.commit()` exactly once.
+10. Restores voyage status to `CHARTED`.
+11. Publishes `DeploymentStartedEvent` then `DeploymentCompletedEvent`.
+12. Does **not** publish `DeploymentFailedEvent` on success.
+13. Succeeds when `mushi.publish` raises (best-effort).
+
+**`deploy` — production approval:**
+
+14. Raises `HelmsmanError("APPROVAL_REQUIRED")` when
+    `tier="production"` and `approved_by is None`. Voyage status
+    **unchanged** (CHARTED) — the check happens before any state
+    transition. No graph invocation. No Deployment row inserted.
+15. Succeeds when `tier="production"` with `approved_by=<uuid>` set, and
+    persists `approved_by` on the Deployment row.
+16. `tier="preview"` or `tier="staging"` does **not** require
+    `approved_by` (approval check is a no-op).
+
+**`deploy` — status gate:**
+
+17. Raises `HelmsmanError("VOYAGE_NOT_DEPLOYABLE")` when
+    `voyage.status == "DEPLOYING"` (already in flight). No graph
+    invocation.
+18. Raises `HelmsmanError("VOYAGE_NOT_DEPLOYABLE")` when
+    `voyage.status == "FAILED"`.
+
+**`deploy` — failure path:**
+
+19. When the graph returns `status="failed"`, raises
+    `HelmsmanError("DEPLOYMENT_FAILED")` **after** committing.
+20. On failure, the `Deployment` row is still persisted with
+    `status="failed"` and `diagnosis` stored.
+21. On failure, publishes `DeploymentStartedEvent` and
+    `DeploymentFailedEvent` (not Completed) in that order.
+22. On failure, voyage status is restored to `CHARTED`.
+23. On failure, a `VivreCard` is still written.
+
+**`deploy` — git failure:**
+
+24. When `git_service.get_head_sha` raises `GitError`, the service
+    raises `HelmsmanError("GIT_REF_UNRESOLVABLE")`, voyage status is
+    restored to `CHARTED`, no Deployment row is persisted, no graph
+    invocation.
+
+**`rollback` — happy path:**
+
+25. Finds the most recent `status=completed action=deploy` row for
+    `(voyage, tier)` and uses its `git_ref`/`git_sha`.
+26. Persists a new `Deployment` row with `action="rollback"`,
+    `previous_deployment_id` pointing to the found row.
+27. Publishes `DeploymentStartedEvent` + `DeploymentCompletedEvent` on
+    rollback success.
+28. Restores voyage status to `CHARTED`.
+
+**`rollback` — no previous deployment:**
+
+29. Raises `HelmsmanError("NO_PREVIOUS_DEPLOYMENT")` when no prior
+    `status=completed action=deploy` row exists. Voyage status
+    unchanged. No graph invocation. No Deployment row inserted.
+
+**`rollback` — status gate:**
+
+30. Raises `HelmsmanError("VOYAGE_NOT_DEPLOYABLE")` when
+    `voyage.status != "CHARTED"`.
+
+**`get_deployments` / `get_latest_deployment`:**
+
+31. `get_deployments` returns rows ordered by `created_at DESC`.
+32. `get_deployments` filters by `tier` when supplied.
+33. `get_deployments` returns empty list when none.
+34. `get_latest_deployment` returns the most recent row.
+35. `get_latest_deployment` returns `None` when no row exists.
+36. Reader instance (`HelmsmanService.reader(session)`) can call both
+    query methods.
+
+**`_require_production_approval` helper:**
+
+37. No-op when `tier="preview"` and `approved_by=None`.
+38. No-op when `tier="staging"` and `approved_by=None`.
+39. No-op when `tier="production"` and `approved_by=<uuid>`.
+40. Raises `HelmsmanError("APPROVAL_REQUIRED")` when `tier="production"`
+    and `approved_by=None`.
+
+### API Tests — `tests/test_helmsman_api.py`
+
+1. POST `/deploy` returns 201 with `DeploymentResponse` (preview).
+2. POST `/deploy` returns 409 `VOYAGE_NOT_DEPLOYABLE` when voyage not
+   `CHARTED`.
+3. POST `/deploy` returns 403 `APPROVAL_REQUIRED` for production without
+   `approved_by`; asserts `deploy` was **not** awaited (fail-fast at
+   service entry is fine — just assert the error code + status).
+4. POST `/deploy` returns **403** (not 409) for a production deploy
+   with no `approved_by` against a voyage whose status is not CHARTED —
+   approval precedence test.
+5. POST `/deploy` returns 201 for production with `approved_by` set.
+6. POST `/deploy` returns 422 `DEPLOYMENT_FAILED` when the backend fails
+   (use `InProcessDeploymentBackend(fail_tiers={"preview"})`).
+7. POST `/deploy` returns 422 `GIT_REF_UNRESOLVABLE` when git resolution
+   fails.
+8. POST `/rollback` returns 201 with `DeploymentResponse`.
+9. POST `/rollback` returns 404 `NO_PREVIOUS_DEPLOYMENT` when no prior
+   deploy exists.
+10. POST `/rollback` returns 409 `VOYAGE_NOT_DEPLOYABLE` when voyage not
+    `CHARTED`.
+11. GET `/deployments` returns 200 with list.
+12. GET `/deployments?tier=preview` filters by tier.
+13. GET `/deployments` returns 200 with empty list.
+
+## Constraints
+
+- Mock every external: no real LLM, no real DB, no real cluster. The
+  `InProcessDeploymentBackend` is a real class used in tests — no
+  mocking needed for it.
+- **v1 backend is simulated.** Real Docker/k8s backends slot in behind
+  the same `DeploymentBackend` ABC later. Do not add Docker/k8s code
+  paths in this PR.
+- Graph is a thin orchestrator: `deploy` (imperative) →
+  conditional → `diagnose` (LLM, best-effort). Zero LLM calls on
+  success. Graph nodes have **no DB writes**.
+- Follow Navigator/Doctor/Shipwright patterns exactly: `strip_fences`
+  from `app/crew/utils.py`, `reader()` factory, atomic DB commit before
+  events, best-effort publish, `TRUNCATE = 4000` for `backend_log`.
+- **Approval gate is encapsulated.** The `_require_production_approval`
+  helper is the single swap-point for Phase 17. Do not inline the
+  `tier == "production"` check anywhere else.
+- **Status lifecycle** — transient `DEPLOYING`, restored to `CHARTED` on
+  both success and failure paths, **including** all error exits
+  (approval failure exits before the transition; all others must reset).
+  v1 serializes deploys per voyage via this gate — the `voyage.status !=
+  CHARTED` 409 check blocks concurrent deploys across tiers. True
+  per-tier concurrency waits for a future `deployment_status` refactor.
+- **Git is audit-only.** Helmsman calls `GitService.get_head_sha(...)`
+  to resolve `git_ref → git_sha` for the Deployment row. No branch
+  creation, no merges, no commits. If `voyage.target_repo` is unset or
+  `git_service` is `None`, `git_sha=None` is acceptable.
+- **Rollback = find-previous-completed-deploy-and-redeploy.** One
+  `deployments` table with an `action` column. Rollback rows reference
+  the target via `previous_deployment_id` for audit.
+- **Diagnosis is best-effort.** If the LLM call or JSON parse fails,
+  persist `diagnosis=None` and log a warning. The deploy-fail response
+  still returns 422 with whatever diagnosis is available. A
+  diagnosis-fail must NEVER mask the real deploy-fail response.
+- **Events are best-effort.** Each publish in its own try/except. One
+  failure must not block the others.
+- `Deployment.backend_log` is truncated to the last 4000 chars before
+  persistence. `Deployment.diagnosis` is stored as JSONB (nullable).
+- `HelmsmanError.code` → HTTP mapping is non-negotiable:
+  `APPROVAL_REQUIRED` → 403, `VOYAGE_NOT_DEPLOYABLE` → 409,
+  `NO_PREVIOUS_DEPLOYMENT` → 404, everything else → 422.
+- **404 vs 422**: 404 for missing prerequisite resources (no prior
+  deployment on rollback). 422 for service-layer invariant violations
+  (`DEPLOYMENT_FAILED`, `GIT_REF_UNRESOLVABLE`, `UNKNOWN_TIER`). 403
+  specifically for the approval gate. 409 specifically for the voyage
+  status gate.
+- **GitService.get_head_sha** — check if it (or an equivalent helper)
+  already exists in `git_service.py` before adding. If it exists under
+  another name, reuse it.
+- **Production approval in v1 is trust-the-caller.** `approved_by: UUID`
+  is not cross-checked against a separate approval record. This is a
+  known limitation; Phase 17 replaces it. Log in `decisions.md`.
+- **Rollback does not require approval in v1.** Rollbacks are an
+  emergency mechanism. Log this as a known limitation.
+- Single Dial System call per deploy, **only on failure**. Zero LLM
+  calls on success.
+- Wire `InProcessDeploymentBackend` via `app.main.py` lifespan matching
+  the `ExecutionBackend` pattern exactly. Cleanup in reverse order.

--- a/src/backend/alembic/versions/c3d4e5f6a1b2_deployments.py
+++ b/src/backend/alembic/versions/c3d4e5f6a1b2_deployments.py
@@ -1,0 +1,71 @@
+"""deployments
+
+Revision ID: c3d4e5f6a1b2
+Revises: b2c3d4e5f6a1
+Create Date: 2026-04-18
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "c3d4e5f6a1b2"
+down_revision: str | None = "b2c3d4e5f6a1"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "deployments",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "voyage_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("voyages.id"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column("tier", sa.String(20), nullable=False),
+        sa.Column("action", sa.String(20), nullable=False),
+        sa.Column("git_ref", sa.String(255), nullable=False),
+        sa.Column("git_sha", sa.String(64), nullable=True),
+        sa.Column("status", sa.String(20), nullable=False),
+        sa.Column("approved_by", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("url", sa.String(500), nullable=True),
+        sa.Column("backend_log", sa.Text(), nullable=True),
+        sa.Column("diagnosis", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column(
+            "previous_deployment_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("deployments.id"),
+            nullable=True,
+            index=True,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+    op.create_index(
+        "ix_deployments_voyage_tier_created",
+        "deployments",
+        ["voyage_id", "tier", sa.text("created_at DESC")],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_deployments_voyage_tier_created", table_name="deployments")
+    op.drop_table("deployments")

--- a/src/backend/app/api/v1/dependencies.py
+++ b/src/backend/app/api/v1/dependencies.py
@@ -12,6 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.config import settings
 from app.core.security import JWTError, decode_token
 from app.den_den_mushi.mushi import DenDenMushi
+from app.deployment.backend import DeploymentBackend
 from app.dial_system.factory import build_router_from_config
 from app.dial_system.rate_limiter import RateLimiter
 from app.dial_system.router import DialSystemRouter
@@ -110,6 +111,11 @@ def get_execution_service(request: Request) -> ExecutionService:
 def get_git_service(request: Request) -> GitService:
     svc: GitService = request.app.state.git_service
     return svc
+
+
+def get_deployment_backend(request: Request) -> DeploymentBackend:
+    backend: DeploymentBackend = request.app.state.deployment_backend
+    return backend
 
 
 async def get_dial_router(

--- a/src/backend/app/api/v1/helmsman.py
+++ b/src/backend/app/api/v1/helmsman.py
@@ -1,0 +1,135 @@
+"""Helmsman Agent REST API endpoints."""
+
+from __future__ import annotations
+
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.v1.dependencies import (
+    get_authorized_voyage,
+    get_current_user,
+    get_den_den_mushi,
+    get_deployment_backend,
+    get_dial_router,
+    get_git_service,
+)
+from app.den_den_mushi.mushi import DenDenMushi
+from app.deployment.backend import DeploymentBackend
+from app.dial_system.router import DialSystemRouter
+from app.models import get_db
+from app.models.user import User
+from app.models.voyage import Voyage
+from app.schemas.deployment import (
+    DeploymentListResponse,
+    DeploymentRead,
+    DeploymentResponse,
+    DeploymentTier,
+    DeployRequest,
+    RollbackRequest,
+)
+from app.services.git_service import GitService
+from app.services.helmsman_service import HelmsmanError, HelmsmanService
+
+router = APIRouter(prefix="/voyages/{voyage_id}", tags=["helmsman"])
+
+
+_HELMSMAN_ERROR_STATUS: dict[str, int] = {
+    "APPROVAL_REQUIRED": status.HTTP_403_FORBIDDEN,
+    "VOYAGE_NOT_DEPLOYABLE": status.HTTP_409_CONFLICT,
+    "NO_PREVIOUS_DEPLOYMENT": status.HTTP_404_NOT_FOUND,
+}
+
+
+def _helmsman_http_exception(exc: HelmsmanError) -> HTTPException:
+    code = _HELMSMAN_ERROR_STATUS.get(exc.code, status.HTTP_422_UNPROCESSABLE_ENTITY)
+    return HTTPException(
+        status_code=code,
+        detail={"error": {"code": exc.code, "message": exc.message}},
+    )
+
+
+async def get_helmsman_service(
+    voyage_id: uuid.UUID,
+    dial_router: DialSystemRouter = Depends(get_dial_router),
+    mushi: DenDenMushi = Depends(get_den_den_mushi),
+    session: AsyncSession = Depends(get_db),
+    deployment_backend: DeploymentBackend = Depends(get_deployment_backend),
+    git_service: GitService = Depends(get_git_service),
+) -> HelmsmanService:
+    return HelmsmanService(
+        dial_router,
+        mushi,
+        session,
+        deployment_backend=deployment_backend,
+        git_service=git_service,
+    )
+
+
+async def get_helmsman_reader(
+    session: AsyncSession = Depends(get_db),
+) -> HelmsmanService:
+    return HelmsmanService.reader(session)
+
+
+@router.post(
+    "/deploy",
+    response_model=DeploymentResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def deploy_voyage(
+    voyage_id: uuid.UUID,
+    body: DeployRequest,
+    user: User = Depends(get_current_user),
+    voyage: Voyage = Depends(get_authorized_voyage),
+    helmsman_service: HelmsmanService = Depends(get_helmsman_service),
+) -> DeploymentResponse:
+    try:
+        return await helmsman_service.deploy(
+            voyage=voyage,
+            tier=body.tier,
+            user_id=user.id,
+            git_ref=body.git_ref,
+            approved_by=body.approved_by,
+        )
+    except HelmsmanError as exc:
+        raise _helmsman_http_exception(exc) from exc
+
+
+@router.post(
+    "/rollback",
+    response_model=DeploymentResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def rollback_voyage(
+    voyage_id: uuid.UUID,
+    body: RollbackRequest,
+    user: User = Depends(get_current_user),
+    voyage: Voyage = Depends(get_authorized_voyage),
+    helmsman_service: HelmsmanService = Depends(get_helmsman_service),
+) -> DeploymentResponse:
+    try:
+        return await helmsman_service.rollback(
+            voyage=voyage,
+            tier=body.tier,
+            user_id=user.id,
+        )
+    except HelmsmanError as exc:
+        raise _helmsman_http_exception(exc) from exc
+
+
+@router.get("/deployments", response_model=DeploymentListResponse)
+async def list_deployments(
+    voyage_id: uuid.UUID,
+    tier: DeploymentTier | None = None,
+    user: User = Depends(get_current_user),
+    voyage: Voyage = Depends(get_authorized_voyage),
+    helmsman_reader: HelmsmanService = Depends(get_helmsman_reader),
+) -> DeploymentListResponse:
+    rows = await helmsman_reader.get_deployments(voyage_id, tier)
+    return DeploymentListResponse(
+        voyage_id=voyage_id,
+        tier=tier,
+        deployments=[DeploymentRead.model_validate(r) for r in rows],
+    )

--- a/src/backend/app/api/v1/router.py
+++ b/src/backend/app/api/v1/router.py
@@ -7,6 +7,7 @@ from app.api.v1.doctor import router as doctor_router
 from app.api.v1.execution import router as execution_router
 from app.api.v1.git import router as git_router
 from app.api.v1.health import router as health_router
+from app.api.v1.helmsman import router as helmsman_router
 from app.api.v1.navigator import router as navigator_router
 from app.api.v1.shipwright import router as shipwright_router
 from app.api.v1.vivre_cards import router as vivre_cards_router
@@ -22,3 +23,4 @@ v1_router.include_router(captain_router)
 v1_router.include_router(navigator_router)
 v1_router.include_router(doctor_router)
 v1_router.include_router(shipwright_router)
+v1_router.include_router(helmsman_router)

--- a/src/backend/app/crew/helmsman_graph.py
+++ b/src/backend/app/crew/helmsman_graph.py
@@ -1,0 +1,159 @@
+"""Helmsman Agent LangGraph — deploys a voyage artifact and (on failure) asks the
+Dial System to diagnose the error. A successful deploy makes zero LLM calls;
+the `diagnose` node only runs when the backend reports `status != "completed"`.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+from typing import Any, Literal, TypedDict
+
+from langgraph.graph import END, StateGraph
+from langgraph.graph.state import CompiledStateGraph
+
+from app.crew.utils import strip_fences
+from app.deployment.backend import (
+    DeploymentArtifact,
+    DeploymentBackend,
+    DeploymentError,
+)
+from app.dial_system.router import DialSystemRouter
+from app.models.enums import CrewRole
+from app.schemas.deployment import DeploymentDiagnosisSpec
+from app.schemas.dial_system import CompletionRequest
+
+logger = logging.getLogger(__name__)
+
+DIAGNOSIS_LOG_TAIL = 4000
+
+HELMSMAN_SYSTEM_PROMPT = """\
+You are a Helmsman — a DevOps agent responsible for diagnosing failed \
+deployments. You will receive the tier, git ref/SHA, and the last portion of \
+the backend's failure log. Produce a concise diagnosis that helps a human \
+operator decide what to do next.
+
+Respond with ONLY a JSON object:
+{"summary": "...", "likely_cause": "...", "suggested_action": "..."}
+
+- summary: one sentence describing what went wrong
+- likely_cause: the most probable root cause, based on the log
+- suggested_action: one concrete next step the operator can take
+
+Do not include any other text, markdown formatting, or explanation."""
+
+
+class HelmsmanState(TypedDict):
+    voyage_id: uuid.UUID
+    user_id: uuid.UUID
+    tier: Literal["preview", "staging", "production"]
+    git_ref: str
+    git_sha: str | None
+    # filled by deploy node:
+    status: Literal["completed", "failed"]
+    url: str | None
+    backend_log: str
+    error: str | None
+    # filled by diagnose node (only on failure):
+    diagnosis: dict[str, Any] | None
+
+
+async def deploy_node(
+    state: HelmsmanState,
+    backend: DeploymentBackend,
+) -> dict[str, Any]:
+    artifact = DeploymentArtifact(
+        voyage_id=state["voyage_id"],
+        tier=state["tier"],
+        git_ref=state["git_ref"],
+        git_sha=state.get("git_sha"),
+    )
+    try:
+        result = await backend.deploy(artifact)
+    except DeploymentError as exc:
+        return {
+            "status": "failed",
+            "url": None,
+            "backend_log": str(exc),
+            "error": exc.__class__.__name__,
+            "diagnosis": None,
+        }
+    return {
+        "status": result.status,
+        "url": result.url,
+        "backend_log": result.backend_log,
+        "error": result.error,
+        "diagnosis": None,
+    }
+
+
+def _build_diagnose_message(state: HelmsmanState) -> str:
+    log_tail = (state.get("backend_log") or "")[-DIAGNOSIS_LOG_TAIL:]
+    return (
+        f"## Deployment\n"
+        f"- tier: {state['tier']}\n"
+        f"- git_ref: {state['git_ref']}\n"
+        f"- git_sha: {state.get('git_sha')}\n"
+        f"- error: {state.get('error')}\n\n"
+        f"## Backend log (tail)\n```\n{log_tail}\n```"
+    )
+
+
+async def diagnose_node(
+    state: HelmsmanState,
+    dial_router: DialSystemRouter,
+) -> dict[str, Any]:
+    try:
+        user_message = _build_diagnose_message(state)
+        request = CompletionRequest(
+            messages=[
+                {"role": "system", "content": HELMSMAN_SYSTEM_PROMPT},
+                {"role": "user", "content": user_message},
+            ],
+            role=CrewRole.HELMSMAN,
+            voyage_id=state["voyage_id"],
+        )
+        result = await dial_router.route(CrewRole.HELMSMAN, request)
+        stripped = strip_fences(result.content)
+        data = json.loads(stripped)
+        spec = DeploymentDiagnosisSpec.model_validate(data)
+        return {"diagnosis": spec.model_dump()}
+    except Exception:
+        logger.warning(
+            "Helmsman diagnosis failed for voyage %s tier %s — persisting null",
+            state["voyage_id"],
+            state["tier"],
+            exc_info=True,
+        )
+        return {"diagnosis": None}
+
+
+def _route_after_deploy(state: HelmsmanState) -> str:
+    return "diagnose" if state["status"] != "completed" else END
+
+
+def build_helmsman_graph(
+    dial_router: DialSystemRouter,
+    deployment_backend: DeploymentBackend,
+) -> CompiledStateGraph:  # type: ignore[type-arg]
+    graph = StateGraph(HelmsmanState)
+
+    async def _deploy(state: HelmsmanState) -> dict[str, Any]:
+        return await deploy_node(state, deployment_backend)
+
+    async def _diagnose(state: HelmsmanState) -> dict[str, Any]:
+        return await diagnose_node(state, dial_router)
+
+    graph.add_node("deploy", _deploy)
+    graph.add_node("diagnose", _diagnose)
+
+    graph.set_entry_point("deploy")
+    graph.add_conditional_edges(
+        "deploy",
+        _route_after_deploy,
+        {"diagnose": "diagnose", END: END},
+    )
+    graph.add_edge("diagnose", END)
+
+    return graph.compile()

--- a/src/backend/app/den_den_mushi/events.py
+++ b/src/backend/app/den_den_mushi/events.py
@@ -48,8 +48,16 @@ class ValidationFailedEvent(DenDenMushiEvent):
     event_type: Literal["validation_failed"] = "validation_failed"
 
 
+class DeploymentStartedEvent(DenDenMushiEvent):
+    event_type: Literal["deployment_started"] = "deployment_started"
+
+
 class DeploymentCompletedEvent(DenDenMushiEvent):
     event_type: Literal["deployment_completed"] = "deployment_completed"
+
+
+class DeploymentFailedEvent(DenDenMushiEvent):
+    event_type: Literal["deployment_failed"] = "deployment_failed"
 
 
 class ProviderSwitchedEvent(DenDenMushiEvent):
@@ -68,7 +76,9 @@ AnyEvent = Annotated[
     | TestsPassedEvent
     | ValidationPassedEvent
     | ValidationFailedEvent
+    | DeploymentStartedEvent
     | DeploymentCompletedEvent
+    | DeploymentFailedEvent
     | ProviderSwitchedEvent
     | CheckpointCreatedEvent,
     Field(discriminator="event_type"),

--- a/src/backend/app/deployment/backend.py
+++ b/src/backend/app/deployment/backend.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import uuid
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Literal
+
+TierLiteral = Literal["preview", "staging", "production"]
+
+
+@dataclass(frozen=True)
+class DeploymentArtifact:
+    voyage_id: uuid.UUID
+    tier: TierLiteral
+    git_ref: str
+    git_sha: str | None
+    # Reserved for future real backends (Docker/k8s manifest path). v1 callers
+    # always pass None; kept on the ABC for forward-compat so real backends can
+    # opt into it without changing the service layer signature.
+    manifest_path: str | None = None
+
+
+@dataclass(frozen=True)
+class DeploymentResult:
+    status: Literal["completed", "failed"]
+    url: str | None
+    backend_log: str
+    error: str | None = None
+
+
+class DeploymentError(Exception):
+    """Raised for backend-internal errors only (e.g. client connection failure).
+    A deploy that fails should return DeploymentResult(status='failed', ...)
+    rather than raising."""
+
+
+class DeploymentBackend(ABC):
+    @abstractmethod
+    async def deploy(self, artifact: DeploymentArtifact) -> DeploymentResult:
+        """Deploy the artifact to the given tier."""
+        ...
+
+    @abstractmethod
+    async def status(
+        self,
+        voyage_id: uuid.UUID,
+        tier: TierLiteral,
+    ) -> DeploymentResult | None:
+        """Return the last deploy result for (voyage, tier), or None."""
+        ...
+
+    async def close(self) -> None:
+        """Release resources (e.g. HTTP client session)."""

--- a/src/backend/app/deployment/in_process.py
+++ b/src/backend/app/deployment/in_process.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import uuid
+
+from app.deployment.backend import (
+    DeploymentArtifact,
+    DeploymentBackend,
+    DeploymentResult,
+    TierLiteral,
+)
+
+
+class InProcessDeploymentBackend(DeploymentBackend):
+    """Simulated deployment backend. Records deploys in an in-memory dict and
+    returns synthetic URLs. Used for v1 (no real cluster) and tests.
+
+    Fail-injection: if `fail_tiers` contains the tier being deployed,
+    `deploy()` returns status='failed' with a synthetic log — useful for
+    exercising the diagnose path in tests without patching."""
+
+    def __init__(self, *, fail_tiers: set[str] | None = None) -> None:
+        self._records: dict[tuple[uuid.UUID, str], DeploymentResult] = {}
+        self._fail_tiers = fail_tiers or set()
+
+    async def deploy(self, artifact: DeploymentArtifact) -> DeploymentResult:
+        if artifact.tier in self._fail_tiers:
+            result = DeploymentResult(
+                status="failed",
+                url=None,
+                backend_log=(
+                    f"simulated failure for tier={artifact.tier} "
+                    f"ref={artifact.git_ref} sha={artifact.git_sha}"
+                ),
+                error="SimulatedFailure",
+            )
+        else:
+            url = f"http://{artifact.tier}.voyage-{artifact.voyage_id.hex[:8]}.local"
+            result = DeploymentResult(
+                status="completed",
+                url=url,
+                backend_log=(
+                    f"deployed tier={artifact.tier} ref={artifact.git_ref} "
+                    f"sha={artifact.git_sha} url={url}"
+                ),
+                error=None,
+            )
+        self._records[(artifact.voyage_id, artifact.tier)] = result
+        return result
+
+    async def status(
+        self,
+        voyage_id: uuid.UUID,
+        tier: TierLiteral,
+    ) -> DeploymentResult | None:
+        return self._records.get((voyage_id, tier))

--- a/src/backend/app/main.py
+++ b/src/backend/app/main.py
@@ -9,6 +9,7 @@ from app.api.v1.router import v1_router
 from app.core.config import settings
 from app.core.middleware import DefaultDenyMiddleware
 from app.den_den_mushi.mushi import DenDenMushi
+from app.deployment.in_process import InProcessDeploymentBackend
 from app.execution.factory import create_backend, create_git_backend
 from app.services.execution_service import ExecutionService
 from app.services.git_service import GitService
@@ -26,8 +27,11 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     git_backend = create_git_backend(settings)
     app.state.git_service = GitService(git_backend, settings)
 
+    app.state.deployment_backend = InProcessDeploymentBackend()
+
     yield
 
+    await app.state.deployment_backend.close()
     await app.state.git_service.cleanup_all()
     await git_backend.close()
     await app.state.execution_service.cleanup_all()

--- a/src/backend/app/models/__init__.py
+++ b/src/backend/app/models/__init__.py
@@ -19,6 +19,7 @@ async def get_db() -> AsyncSession:  # type: ignore[misc]
 # Import all models so Alembic can detect them
 from app.models.build_artifact import BuildArtifact  # noqa: E402, F401
 from app.models.crew_action import CrewAction  # noqa: E402, F401
+from app.models.deployment import Deployment  # noqa: E402, F401
 from app.models.dial_config import DialConfig  # noqa: E402, F401
 from app.models.health_check import HealthCheck  # noqa: E402, F401
 from app.models.poneglyph import Poneglyph  # noqa: E402, F401

--- a/src/backend/app/models/deployment.py
+++ b/src/backend/app/models/deployment.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import DateTime, ForeignKey, Index, String, Text, func, text
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models import Base
+
+
+class Deployment(Base):
+    __tablename__ = "deployments"
+    __table_args__ = (
+        Index(
+            "ix_deployments_voyage_tier_created",
+            "voyage_id",
+            "tier",
+            text("created_at DESC"),
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    voyage_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("voyages.id"), index=True, nullable=False
+    )
+    tier: Mapped[str] = mapped_column(String(20), nullable=False)
+    action: Mapped[str] = mapped_column(String(20), nullable=False)
+    git_ref: Mapped[str] = mapped_column(String(255), nullable=False)
+    git_sha: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    status: Mapped[str] = mapped_column(String(20), nullable=False)
+    approved_by: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    url: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    backend_log: Mapped[str | None] = mapped_column(Text, nullable=True)
+    diagnosis: Mapped[dict[str, Any] | None] = mapped_column(JSONB, nullable=True)
+    previous_deployment_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("deployments.id"), index=True, nullable=True
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )

--- a/src/backend/app/schemas/deployment.py
+++ b/src/backend/app/schemas/deployment.py
@@ -1,0 +1,68 @@
+"""Schemas for Helmsman Agent (DevOps)."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+DeploymentTier = Literal["preview", "staging", "production"]
+DeploymentAction = Literal["deploy", "rollback"]
+DeploymentStatus = Literal["running", "completed", "failed"]
+
+
+class DeploymentDiagnosisSpec(BaseModel):
+    """Structured LLM diagnosis of a deployment failure."""
+
+    summary: str = Field(min_length=1, max_length=500)
+    likely_cause: str = Field(min_length=1, max_length=1000)
+    suggested_action: str = Field(min_length=1, max_length=1000)
+
+
+class DeployRequest(BaseModel):
+    tier: DeploymentTier
+    git_ref: str | None = Field(default=None, max_length=255)
+    approved_by: uuid.UUID | None = None
+
+
+class RollbackRequest(BaseModel):
+    tier: DeploymentTier
+
+
+class DeploymentRead(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    voyage_id: uuid.UUID
+    tier: DeploymentTier
+    action: DeploymentAction
+    git_ref: str
+    git_sha: str | None
+    status: DeploymentStatus
+    approved_by: uuid.UUID | None
+    url: str | None
+    backend_log: str | None
+    diagnosis: dict[str, Any] | None
+    previous_deployment_id: uuid.UUID | None
+    created_at: datetime
+    updated_at: datetime
+
+
+class DeploymentResponse(BaseModel):
+    voyage_id: uuid.UUID
+    deployment_id: uuid.UUID
+    tier: DeploymentTier
+    action: DeploymentAction
+    status: DeploymentStatus
+    git_ref: str
+    git_sha: str | None
+    url: str | None
+    diagnosis: dict[str, Any] | None
+
+
+class DeploymentListResponse(BaseModel):
+    voyage_id: uuid.UUID
+    tier: DeploymentTier | None
+    deployments: list[DeploymentRead]

--- a/src/backend/app/services/git_service.py
+++ b/src/backend/app/services/git_service.py
@@ -270,6 +270,24 @@ class GitService:
             base=data["base"]["ref"],
         )
 
+    async def get_head_sha(
+        self,
+        voyage_id: uuid.UUID,
+        user_id: uuid.UUID,
+        ref: str,
+    ) -> str:
+        """Resolve a branch/tag/SHA-ish to a full commit SHA for audit."""
+        _validate_branch_component(ref)
+        sandbox_id = self._get_sandbox(voyage_id)
+        stdout = await self._run(
+            sandbox_id,
+            f"cd {REPO_PATH} && git rev-parse {shlex.quote(ref)}^{{commit}}",
+        )
+        sha = stdout.strip()
+        if not sha:
+            raise GitError(f"GIT_REF_UNRESOLVABLE: {ref!r}")
+        return sha
+
     async def get_log(
         self,
         voyage_id: uuid.UUID,

--- a/src/backend/app/services/helmsman_service.py
+++ b/src/backend/app/services/helmsman_service.py
@@ -1,0 +1,373 @@
+"""HelmsmanService — orchestrates voyage deployments via a swappable
+DeploymentBackend. One invocation covers one (voyage, tier) action.
+
+Unlike Shipwright, Helmsman is mostly imperative. Its LangGraph is a thin
+orchestrator that makes a single backend call and (on failure only) a single
+LLM diagnosis call. The service owns DB writes, voyage status transitions,
+VivreCard checkpoints, and best-effort event publishing.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from collections.abc import Callable
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.crew.helmsman_graph import build_helmsman_graph
+from app.den_den_mushi.constants import stream_key
+from app.den_den_mushi.events import (
+    DeploymentCompletedEvent,
+    DeploymentFailedEvent,
+    DeploymentStartedEvent,
+)
+from app.den_den_mushi.mushi import DenDenMushi
+from app.deployment.backend import DeploymentBackend
+from app.dial_system.router import DialSystemRouter
+from app.models.deployment import Deployment
+from app.models.enums import CrewRole, VoyageStatus
+from app.models.vivre_card import VivreCard
+from app.models.voyage import Voyage
+from app.schemas.deployment import (
+    DeploymentResponse,
+    DeploymentTier,
+)
+from app.services.git_service import GitError, GitService
+
+logger = logging.getLogger(__name__)
+
+TRUNCATE = 4000
+
+DEFAULT_GIT_REF_BY_TIER: dict[str, Callable[[uuid.UUID], str]] = {
+    "preview": lambda voyage_id: f"agent/shipwright/{voyage_id.hex[:8]}",
+    "staging": lambda _voyage_id: "staging",
+    "production": lambda _voyage_id: "main",
+}
+
+
+class HelmsmanError(Exception):
+    """Raised when Helmsman agent operations fail at the service layer."""
+
+    def __init__(self, code: str, message: str) -> None:
+        self.code = code
+        self.message = message
+        super().__init__(message)
+
+
+def _require_production_approval(
+    tier: DeploymentTier,
+    approved_by: uuid.UUID | None,
+) -> None:
+    """Phase 17 swap-point: replace this function to change approval semantics."""
+    if tier == "production" and approved_by is None:
+        raise HelmsmanError(
+            "APPROVAL_REQUIRED",
+            "Production deploys require approved_by to be set",
+        )
+
+
+class HelmsmanService:
+    def __init__(
+        self,
+        dial_router: DialSystemRouter,
+        mushi: DenDenMushi,
+        session: AsyncSession,
+        deployment_backend: DeploymentBackend,
+        git_service: GitService | None = None,
+    ) -> None:
+        self._dial_router = dial_router
+        self._mushi = mushi
+        self._session = session
+        self._backend = deployment_backend
+        self._git = git_service
+        self._graph = build_helmsman_graph(dial_router, deployment_backend)
+
+    @classmethod
+    def reader(cls, session: AsyncSession) -> HelmsmanService:
+        """Create a read-only instance that only needs a DB session."""
+        inst = cls.__new__(cls)
+        inst._session = session
+        inst._dial_router = None  # type: ignore[assignment]
+        inst._mushi = None  # type: ignore[assignment]
+        inst._backend = None  # type: ignore[assignment]
+        inst._git = None
+        inst._graph = None  # type: ignore[assignment]
+        return inst
+
+    async def deploy(
+        self,
+        voyage: Voyage,
+        tier: DeploymentTier,
+        user_id: uuid.UUID,
+        git_ref: str | None = None,
+        approved_by: uuid.UUID | None = None,
+    ) -> DeploymentResponse:
+        # Approval is checked BEFORE the status gate. An unapproved production
+        # request against a non-CHARTED voyage returns 403, not 409.
+        _require_production_approval(tier, approved_by)
+
+        if voyage.status != VoyageStatus.CHARTED.value:
+            raise HelmsmanError(
+                "VOYAGE_NOT_DEPLOYABLE",
+                f"Voyage status is {voyage.status}, expected CHARTED",
+            )
+
+        resolved_ref = git_ref or DEFAULT_GIT_REF_BY_TIER[tier](voyage.id)
+        resolved_sha = await self._resolve_git_sha(voyage, user_id, resolved_ref)
+
+        return await self._run_deployment(
+            voyage=voyage,
+            tier=tier,
+            action="deploy",
+            git_ref=resolved_ref,
+            git_sha=resolved_sha,
+            user_id=user_id,
+            approved_by=approved_by,
+            previous_deployment_id=None,
+        )
+
+    async def rollback(
+        self,
+        voyage: Voyage,
+        tier: DeploymentTier,
+        user_id: uuid.UUID,
+    ) -> DeploymentResponse:
+        if voyage.status != VoyageStatus.CHARTED.value:
+            raise HelmsmanError(
+                "VOYAGE_NOT_DEPLOYABLE",
+                f"Voyage status is {voyage.status}, expected CHARTED",
+            )
+
+        previous = await self._find_previous_deployment(voyage.id, tier)
+        if previous is None:
+            raise HelmsmanError(
+                "NO_PREVIOUS_DEPLOYMENT",
+                f"No completed deploy found for voyage {voyage.id} tier {tier}",
+            )
+
+        return await self._run_deployment(
+            voyage=voyage,
+            tier=tier,
+            action="rollback",
+            git_ref=previous.git_ref,
+            git_sha=previous.git_sha,
+            user_id=user_id,
+            approved_by=None,
+            previous_deployment_id=previous.id,
+        )
+
+    async def _resolve_git_sha(
+        self,
+        voyage: Voyage,
+        user_id: uuid.UUID,
+        ref: str,
+    ) -> str | None:
+        if self._git is None or not voyage.target_repo:
+            return None
+        try:
+            return await self._git.get_head_sha(voyage.id, user_id, ref)
+        except GitError as exc:
+            raise HelmsmanError(
+                "GIT_REF_UNRESOLVABLE",
+                f"Could not resolve git_ref {ref!r}: {exc}",
+            ) from exc
+
+    async def _find_previous_deployment(
+        self,
+        voyage_id: uuid.UUID,
+        tier: DeploymentTier,
+    ) -> Deployment | None:
+        stmt = (
+            select(Deployment)
+            .where(
+                Deployment.voyage_id == voyage_id,
+                Deployment.tier == tier,
+                Deployment.status == "completed",
+                Deployment.action == "deploy",
+            )
+            .order_by(Deployment.created_at.desc())
+            .limit(1)
+        )
+        result = await self._session.execute(stmt)
+        return result.scalars().first()
+
+    async def _run_deployment(
+        self,
+        *,
+        voyage: Voyage,
+        tier: DeploymentTier,
+        action: str,
+        git_ref: str,
+        git_sha: str | None,
+        user_id: uuid.UUID,
+        approved_by: uuid.UUID | None,
+        previous_deployment_id: uuid.UUID | None,
+    ) -> DeploymentResponse:
+        voyage.status = VoyageStatus.DEPLOYING.value
+        await self._session.flush()
+
+        deployment = Deployment(
+            id=uuid.uuid4(),
+            voyage_id=voyage.id,
+            tier=tier,
+            action=action,
+            git_ref=git_ref,
+            git_sha=git_sha,
+            status="running",
+            approved_by=approved_by,
+            previous_deployment_id=previous_deployment_id,
+        )
+        self._session.add(deployment)
+
+        try:
+            await self._session.flush()
+
+            state: dict[str, Any] = {
+                "voyage_id": voyage.id,
+                "user_id": user_id,
+                "tier": tier,
+                "git_ref": git_ref,
+                "git_sha": git_sha,
+                "status": "failed",
+                "url": None,
+                "backend_log": "",
+                "error": None,
+                "diagnosis": None,
+            }
+            final_state = await self._graph.ainvoke(state)
+        except Exception:
+            voyage.status = VoyageStatus.CHARTED.value
+            await self._session.flush()
+            raise
+
+        deployment.status = final_state["status"]
+        deployment.url = final_state.get("url")
+        deployment.backend_log = (final_state.get("backend_log") or "")[-TRUNCATE:]
+        deployment.diagnosis = final_state.get("diagnosis")
+
+        card = VivreCard(
+            voyage_id=voyage.id,
+            crew_member="helmsman",
+            state_data={
+                "tier": tier,
+                "action": action,
+                "status": deployment.status,
+                "deployment_id": str(deployment.id),
+                "git_sha": git_sha,
+            },
+            checkpoint_reason="deployment",
+        )
+        self._session.add(card)
+
+        voyage.status = VoyageStatus.CHARTED.value
+        await self._session.commit()
+        await self._session.refresh(deployment)
+
+        await self._publish_events(voyage.id, deployment)
+
+        if deployment.status == "failed":
+            summary = "Deployment failed"
+            if deployment.diagnosis and deployment.diagnosis.get("summary"):
+                summary = str(deployment.diagnosis["summary"])
+            raise HelmsmanError("DEPLOYMENT_FAILED", summary)
+
+        return DeploymentResponse(
+            voyage_id=voyage.id,
+            deployment_id=deployment.id,
+            tier=tier,
+            action=action,
+            status=deployment.status,
+            git_ref=deployment.git_ref,
+            git_sha=deployment.git_sha,
+            url=deployment.url,
+            diagnosis=deployment.diagnosis,
+        )
+
+    async def _publish_events(
+        self,
+        voyage_id: uuid.UUID,
+        deployment: Deployment,
+    ) -> None:
+        """Best-effort event publish. Each event publishes in its own try/except
+        so one failure does not block the others."""
+        base_payload = {
+            "tier": deployment.tier,
+            "action": deployment.action,
+            "deployment_id": str(deployment.id),
+            "git_ref": deployment.git_ref,
+            "git_sha": deployment.git_sha,
+        }
+        started = DeploymentStartedEvent(
+            voyage_id=voyage_id,
+            source_role=CrewRole.HELMSMAN,
+            payload=base_payload,
+        )
+        try:
+            await self._mushi.publish(stream_key(voyage_id), started)
+        except Exception:
+            logger.warning(
+                "Failed to publish DeploymentStartedEvent for voyage %s",
+                voyage_id,
+                exc_info=True,
+            )
+
+        if deployment.status == "completed":
+            completed = DeploymentCompletedEvent(
+                voyage_id=voyage_id,
+                source_role=CrewRole.HELMSMAN,
+                payload={**base_payload, "url": deployment.url},
+            )
+            try:
+                await self._mushi.publish(stream_key(voyage_id), completed)
+            except Exception:
+                logger.warning(
+                    "Failed to publish DeploymentCompletedEvent for voyage %s",
+                    voyage_id,
+                    exc_info=True,
+                )
+        else:
+            failed = DeploymentFailedEvent(
+                voyage_id=voyage_id,
+                source_role=CrewRole.HELMSMAN,
+                payload={**base_payload, "diagnosis": deployment.diagnosis},
+            )
+            try:
+                await self._mushi.publish(stream_key(voyage_id), failed)
+            except Exception:
+                logger.warning(
+                    "Failed to publish DeploymentFailedEvent for voyage %s",
+                    voyage_id,
+                    exc_info=True,
+                )
+
+    async def get_deployments(
+        self,
+        voyage_id: uuid.UUID,
+        tier: DeploymentTier | None = None,
+    ) -> list[Deployment]:
+        stmt = select(Deployment).where(Deployment.voyage_id == voyage_id)
+        if tier is not None:
+            stmt = stmt.where(Deployment.tier == tier)
+        stmt = stmt.order_by(Deployment.created_at.desc())
+        result = await self._session.execute(stmt)
+        return list(result.scalars().all())
+
+    async def get_latest_deployment(
+        self,
+        voyage_id: uuid.UUID,
+        tier: DeploymentTier,
+    ) -> Deployment | None:
+        stmt = (
+            select(Deployment)
+            .where(
+                Deployment.voyage_id == voyage_id,
+                Deployment.tier == tier,
+            )
+            .order_by(Deployment.created_at.desc())
+            .limit(1)
+        )
+        result = await self._session.execute(stmt)
+        return result.scalars().first()

--- a/src/backend/tests/test_deployment_backend.py
+++ b/src/backend/tests/test_deployment_backend.py
@@ -1,0 +1,89 @@
+"""Tests for DeploymentBackend ABC contract and InProcessDeploymentBackend."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from app.deployment.backend import DeploymentArtifact, DeploymentResult
+from app.deployment.in_process import InProcessDeploymentBackend
+
+
+@pytest.fixture
+def voyage_id() -> uuid.UUID:
+    return uuid.uuid4()
+
+
+@pytest.fixture
+def artifact(voyage_id: uuid.UUID) -> DeploymentArtifact:
+    return DeploymentArtifact(
+        voyage_id=voyage_id,
+        tier="preview",
+        git_ref="agent/shipwright/abc",
+        git_sha="deadbeef",
+    )
+
+
+class TestInProcessDeployHappyPath:
+    async def test_deploy_returns_completed(self, artifact: DeploymentArtifact) -> None:
+        backend = InProcessDeploymentBackend()
+        result = await backend.deploy(artifact)
+        assert result.status == "completed"
+        assert result.url is not None
+        assert artifact.tier in result.url
+        assert artifact.voyage_id.hex[:8] in result.url
+        assert result.error is None
+
+    async def test_deploy_log_contains_ref_and_sha(self, artifact: DeploymentArtifact) -> None:
+        backend = InProcessDeploymentBackend()
+        result = await backend.deploy(artifact)
+        assert artifact.git_ref in result.backend_log
+        assert artifact.git_sha in result.backend_log  # type: ignore[operator]
+
+
+class TestInProcessFailInjection:
+    async def test_deploy_fails_when_tier_in_fail_tiers(self, artifact: DeploymentArtifact) -> None:
+        backend = InProcessDeploymentBackend(fail_tiers={"preview"})
+        result = await backend.deploy(artifact)
+        assert result.status == "failed"
+        assert result.url is None
+        assert result.error == "SimulatedFailure"
+
+    async def test_deploy_succeeds_when_tier_not_in_fail_tiers(self, voyage_id: uuid.UUID) -> None:
+        backend = InProcessDeploymentBackend(fail_tiers={"production"})
+        staging_artifact = DeploymentArtifact(
+            voyage_id=voyage_id,
+            tier="staging",
+            git_ref="staging",
+            git_sha="abc",
+        )
+        result = await backend.deploy(staging_artifact)
+        assert result.status == "completed"
+
+
+class TestInProcessStatusLookup:
+    async def test_status_none_before_deploy(self, voyage_id: uuid.UUID) -> None:
+        backend = InProcessDeploymentBackend()
+        assert await backend.status(voyage_id, "preview") is None
+
+    async def test_status_returns_last_result(self, artifact: DeploymentArtifact) -> None:
+        backend = InProcessDeploymentBackend()
+        await backend.deploy(artifact)
+        status = await backend.status(artifact.voyage_id, artifact.tier)
+        assert status is not None
+        assert status.status == "completed"
+
+    async def test_status_isolated_per_voyage_and_tier(self, artifact: DeploymentArtifact) -> None:
+        backend = InProcessDeploymentBackend()
+        await backend.deploy(artifact)
+        other_voyage = uuid.uuid4()
+        assert await backend.status(other_voyage, artifact.tier) is None
+        assert await backend.status(artifact.voyage_id, "production") is None
+
+
+class TestDeploymentResult:
+    def test_frozen_dataclass(self) -> None:
+        r = DeploymentResult(status="completed", url="http://x", backend_log="log")
+        with pytest.raises((AttributeError, Exception)):
+            r.status = "failed"  # type: ignore[misc]

--- a/src/backend/tests/test_git_service.py
+++ b/src/backend/tests/test_git_service.py
@@ -452,6 +452,29 @@ class TestBranchNameValidation:
             await service.check_conflicts(VOYAGE_ID, USER_ID, "; cat /etc/passwd", "main")
 
 
+class TestGetHeadSha:
+    @pytest.mark.asyncio
+    async def test_returns_stripped_sha(self, service: GitService, mock_backend: AsyncMock) -> None:
+        await service.clone_repo(VOYAGE_ID, USER_ID, REPO_URL)
+        mock_backend.execute = AsyncMock(return_value=_exec_result(stdout="deadbeef1234\n"))
+
+        sha = await service.get_head_sha(VOYAGE_ID, USER_ID, "main")
+
+        assert sha == "deadbeef1234"
+        cmd = mock_backend.execute.call_args.args[1].command
+        assert "rev-parse" in cmd
+        assert "main" in cmd
+
+    @pytest.mark.asyncio
+    async def test_rejects_shell_metacharacters_in_ref(
+        self, service: GitService, mock_backend: AsyncMock
+    ) -> None:
+        await service.clone_repo(VOYAGE_ID, USER_ID, REPO_URL)
+
+        with pytest.raises(GitError, match="INVALID_BRANCH_NAME"):
+            await service.get_head_sha(VOYAGE_ID, USER_ID, "$(whoami)")
+
+
 class TestInjectToken:
     def test_preserves_port(self) -> None:
         from app.services.git_service import _inject_token

--- a/src/backend/tests/test_helmsman_api.py
+++ b/src/backend/tests/test_helmsman_api.py
@@ -1,0 +1,298 @@
+"""Tests for Helmsman Agent REST API endpoints."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+from app.models.enums import VoyageStatus
+from app.schemas.deployment import DeploymentResponse, DeployRequest, RollbackRequest
+from app.services.helmsman_service import HelmsmanError
+
+VOYAGE_ID = uuid.uuid4()
+USER_ID = uuid.uuid4()
+APPROVER_ID = uuid.uuid4()
+DEPLOY_ID = uuid.uuid4()
+
+
+def _mock_user() -> MagicMock:
+    user = MagicMock()
+    user.id = USER_ID
+    return user
+
+
+def _mock_voyage(status: str = VoyageStatus.CHARTED.value) -> MagicMock:
+    voyage = MagicMock()
+    voyage.id = VOYAGE_ID
+    voyage.user_id = USER_ID
+    voyage.status = status
+    voyage.target_repo = None
+    return voyage
+
+
+def _mock_deployment(
+    tier: str = "preview",
+    action: str = "deploy",
+    status_: str = "completed",
+) -> MagicMock:
+    d = MagicMock()
+    d.id = uuid.uuid4()
+    d.voyage_id = VOYAGE_ID
+    d.tier = tier
+    d.action = action
+    d.git_ref = "main"
+    d.git_sha = "abc"
+    d.status = status_
+    d.approved_by = None
+    d.url = "http://x.local" if status_ == "completed" else None
+    d.backend_log = "log"
+    d.diagnosis = None
+    d.previous_deployment_id = None
+    d.created_at = datetime(2026, 4, 17, tzinfo=UTC)
+    d.updated_at = datetime(2026, 4, 17, tzinfo=UTC)
+    return d
+
+
+def _success_response() -> DeploymentResponse:
+    return DeploymentResponse(
+        voyage_id=VOYAGE_ID,
+        deployment_id=DEPLOY_ID,
+        tier="preview",
+        action="deploy",
+        status="completed",
+        git_ref="main",
+        git_sha="abc",
+        url="http://preview.voyage.local",
+        diagnosis=None,
+    )
+
+
+def _mock_helmsman_service() -> AsyncMock:
+    svc = AsyncMock()
+    svc.deploy = AsyncMock(return_value=_success_response())
+    svc.rollback = AsyncMock(
+        return_value=DeploymentResponse(
+            voyage_id=VOYAGE_ID,
+            deployment_id=DEPLOY_ID,
+            tier="preview",
+            action="rollback",
+            status="completed",
+            git_ref="main",
+            git_sha="abc",
+            url="http://preview.voyage.local",
+            diagnosis=None,
+        )
+    )
+    return svc
+
+
+def _mock_helmsman_reader() -> AsyncMock:
+    svc = AsyncMock()
+    svc.get_deployments = AsyncMock(return_value=[])
+    return svc
+
+
+class TestDeployEndpoint:
+    @pytest.mark.asyncio
+    async def test_returns_201_with_deployment(self) -> None:
+        from app.api.v1.helmsman import deploy_voyage
+
+        svc = _mock_helmsman_service()
+        body = DeployRequest(tier="preview")
+
+        result = await deploy_voyage(VOYAGE_ID, body, _mock_user(), _mock_voyage(), svc)
+
+        assert result.status == "completed"
+        assert result.action == "deploy"
+        svc.deploy.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_returns_403_on_approval_required(self) -> None:
+        from app.api.v1.helmsman import deploy_voyage
+
+        svc = _mock_helmsman_service()
+        svc.deploy.side_effect = HelmsmanError(
+            "APPROVAL_REQUIRED", "Production deploys require approved_by"
+        )
+        body = DeployRequest(tier="production")
+
+        with pytest.raises(HTTPException) as exc_info:
+            await deploy_voyage(VOYAGE_ID, body, _mock_user(), _mock_voyage(), svc)
+
+        assert exc_info.value.status_code == 403
+        assert exc_info.value.detail["error"]["code"] == "APPROVAL_REQUIRED"
+
+    @pytest.mark.asyncio
+    async def test_returns_409_when_voyage_not_charted(self) -> None:
+        from app.api.v1.helmsman import deploy_voyage
+
+        svc = _mock_helmsman_service()
+        svc.deploy.side_effect = HelmsmanError(
+            "VOYAGE_NOT_DEPLOYABLE", "Voyage status is DEPLOYING"
+        )
+        body = DeployRequest(tier="preview")
+
+        with pytest.raises(HTTPException) as exc_info:
+            await deploy_voyage(
+                VOYAGE_ID,
+                body,
+                _mock_user(),
+                _mock_voyage(status=VoyageStatus.DEPLOYING.value),
+                svc,
+            )
+
+        assert exc_info.value.status_code == 409
+        assert exc_info.value.detail["error"]["code"] == "VOYAGE_NOT_DEPLOYABLE"
+
+    @pytest.mark.asyncio
+    async def test_approval_takes_precedence_over_status(self) -> None:
+        """Production deploy to a non-CHARTED voyage without approval should return
+        403 (APPROVAL_REQUIRED), not 409 (VOYAGE_NOT_DEPLOYABLE) — service enforces
+        ordering."""
+        from app.api.v1.helmsman import deploy_voyage
+
+        svc = _mock_helmsman_service()
+        svc.deploy.side_effect = HelmsmanError(
+            "APPROVAL_REQUIRED", "Production deploys require approved_by"
+        )
+        body = DeployRequest(tier="production")
+
+        with pytest.raises(HTTPException) as exc_info:
+            await deploy_voyage(
+                VOYAGE_ID,
+                body,
+                _mock_user(),
+                _mock_voyage(status=VoyageStatus.DEPLOYING.value),
+                svc,
+            )
+
+        assert exc_info.value.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_returns_422_on_deployment_failed(self) -> None:
+        from app.api.v1.helmsman import deploy_voyage
+
+        svc = _mock_helmsman_service()
+        svc.deploy.side_effect = HelmsmanError("DEPLOYMENT_FAILED", "Build error")
+        body = DeployRequest(tier="preview")
+
+        with pytest.raises(HTTPException) as exc_info:
+            await deploy_voyage(VOYAGE_ID, body, _mock_user(), _mock_voyage(), svc)
+
+        assert exc_info.value.status_code == 422
+        assert exc_info.value.detail["error"]["code"] == "DEPLOYMENT_FAILED"
+
+    @pytest.mark.asyncio
+    async def test_returns_422_on_git_ref_unresolvable(self) -> None:
+        from app.api.v1.helmsman import deploy_voyage
+
+        svc = _mock_helmsman_service()
+        svc.deploy.side_effect = HelmsmanError("GIT_REF_UNRESOLVABLE", "Could not resolve git_ref")
+        body = DeployRequest(tier="preview", git_ref="nonexistent")
+
+        with pytest.raises(HTTPException) as exc_info:
+            await deploy_voyage(VOYAGE_ID, body, _mock_user(), _mock_voyage(), svc)
+
+        assert exc_info.value.status_code == 422
+        assert exc_info.value.detail["error"]["code"] == "GIT_REF_UNRESOLVABLE"
+
+    @pytest.mark.asyncio
+    async def test_passes_approved_by_to_service(self) -> None:
+        from app.api.v1.helmsman import deploy_voyage
+
+        svc = _mock_helmsman_service()
+        body = DeployRequest(tier="production", approved_by=APPROVER_ID)
+
+        await deploy_voyage(VOYAGE_ID, body, _mock_user(), _mock_voyage(), svc)
+
+        assert svc.deploy.call_args.kwargs["approved_by"] == APPROVER_ID
+
+
+class TestRollbackEndpoint:
+    @pytest.mark.asyncio
+    async def test_returns_201_on_success(self) -> None:
+        from app.api.v1.helmsman import rollback_voyage
+
+        svc = _mock_helmsman_service()
+        body = RollbackRequest(tier="preview")
+
+        result = await rollback_voyage(VOYAGE_ID, body, _mock_user(), _mock_voyage(), svc)
+
+        assert result.action == "rollback"
+        svc.rollback.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_returns_404_no_previous_deployment(self) -> None:
+        from app.api.v1.helmsman import rollback_voyage
+
+        svc = _mock_helmsman_service()
+        svc.rollback.side_effect = HelmsmanError(
+            "NO_PREVIOUS_DEPLOYMENT", "No completed deploy found"
+        )
+        body = RollbackRequest(tier="preview")
+
+        with pytest.raises(HTTPException) as exc_info:
+            await rollback_voyage(VOYAGE_ID, body, _mock_user(), _mock_voyage(), svc)
+
+        assert exc_info.value.status_code == 404
+        assert exc_info.value.detail["error"]["code"] == "NO_PREVIOUS_DEPLOYMENT"
+
+    @pytest.mark.asyncio
+    async def test_returns_409_when_voyage_not_charted(self) -> None:
+        from app.api.v1.helmsman import rollback_voyage
+
+        svc = _mock_helmsman_service()
+        svc.rollback.side_effect = HelmsmanError(
+            "VOYAGE_NOT_DEPLOYABLE", "Voyage status is BUILDING"
+        )
+        body = RollbackRequest(tier="preview")
+
+        with pytest.raises(HTTPException) as exc_info:
+            await rollback_voyage(
+                VOYAGE_ID,
+                body,
+                _mock_user(),
+                _mock_voyage(status=VoyageStatus.BUILDING.value),
+                svc,
+            )
+
+        assert exc_info.value.status_code == 409
+
+
+class TestListDeploymentsEndpoint:
+    @pytest.mark.asyncio
+    async def test_returns_list(self) -> None:
+        from app.api.v1.helmsman import list_deployments
+
+        reader = _mock_helmsman_reader()
+        reader.get_deployments.return_value = [_mock_deployment()]
+
+        result = await list_deployments(VOYAGE_ID, None, _mock_user(), _mock_voyage(), reader)
+
+        assert len(result.deployments) == 1
+        assert result.tier is None
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_list(self) -> None:
+        from app.api.v1.helmsman import list_deployments
+
+        reader = _mock_helmsman_reader()
+
+        result = await list_deployments(VOYAGE_ID, None, _mock_user(), _mock_voyage(), reader)
+
+        assert result.deployments == []
+
+    @pytest.mark.asyncio
+    async def test_filters_by_tier(self) -> None:
+        from app.api.v1.helmsman import list_deployments
+
+        reader = _mock_helmsman_reader()
+
+        result = await list_deployments(VOYAGE_ID, "preview", _mock_user(), _mock_voyage(), reader)
+
+        reader.get_deployments.assert_awaited_once_with(VOYAGE_ID, "preview")
+        assert result.tier == "preview"

--- a/src/backend/tests/test_helmsman_graph.py
+++ b/src/backend/tests/test_helmsman_graph.py
@@ -1,0 +1,280 @@
+"""Tests for Helmsman LangGraph graph (mocked backend + mocked LLM)."""
+
+from __future__ import annotations
+
+import json
+import uuid
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.crew.helmsman_graph import (
+    DIAGNOSIS_LOG_TAIL,
+    build_helmsman_graph,
+    deploy_node,
+    diagnose_node,
+)
+from app.deployment.backend import DeploymentError, DeploymentResult
+from app.models.enums import CrewRole
+from app.schemas.dial_system import CompletionResult, TokenUsage
+
+
+def _base_state(**overrides: Any) -> dict[str, Any]:
+    state: dict[str, Any] = {
+        "voyage_id": uuid.uuid4(),
+        "user_id": uuid.uuid4(),
+        "tier": "preview",
+        "git_ref": "agent/shipwright/deadbeef",
+        "git_sha": "deadbeef",
+        "status": "failed",
+        "url": None,
+        "backend_log": "",
+        "error": None,
+        "diagnosis": None,
+    }
+    state.update(overrides)
+    return state
+
+
+def _llm_result(content: str) -> CompletionResult:
+    return CompletionResult(
+        content=content,
+        provider="anthropic",
+        model="claude-sonnet-4-20250514",
+        usage=TokenUsage(),
+    )
+
+
+VALID_DIAGNOSIS = json.dumps(
+    {
+        "summary": "Build failed during test stage",
+        "likely_cause": "Missing APP_URL env var",
+        "suggested_action": "Set APP_URL before redeploying",
+    }
+)
+
+
+class TestDeployNode:
+    @pytest.mark.asyncio
+    async def test_maps_completed_result(self) -> None:
+        mock_backend = AsyncMock()
+        mock_backend.deploy = AsyncMock(
+            return_value=DeploymentResult(
+                status="completed",
+                url="http://preview.voyage-abc.local",
+                backend_log="ok",
+                error=None,
+            )
+        )
+
+        result = await deploy_node(_base_state(), mock_backend)  # type: ignore[arg-type]
+
+        assert result["status"] == "completed"
+        assert result["url"] == "http://preview.voyage-abc.local"
+        assert result["backend_log"] == "ok"
+        assert result["error"] is None
+        assert result["diagnosis"] is None
+
+    @pytest.mark.asyncio
+    async def test_maps_failed_result(self) -> None:
+        mock_backend = AsyncMock()
+        mock_backend.deploy = AsyncMock(
+            return_value=DeploymentResult(
+                status="failed",
+                url=None,
+                backend_log="build error",
+                error="BuildFail",
+            )
+        )
+
+        result = await deploy_node(_base_state(), mock_backend)  # type: ignore[arg-type]
+
+        assert result["status"] == "failed"
+        assert result["url"] is None
+        assert result["backend_log"] == "build error"
+        assert result["error"] == "BuildFail"
+
+    @pytest.mark.asyncio
+    async def test_converts_deployment_error_to_failed(self) -> None:
+        mock_backend = AsyncMock()
+        mock_backend.deploy = AsyncMock(side_effect=DeploymentError("connection refused"))
+
+        result = await deploy_node(_base_state(), mock_backend)  # type: ignore[arg-type]
+
+        assert result["status"] == "failed"
+        assert result["url"] is None
+        assert "connection refused" in result["backend_log"]
+        assert result["error"] == "DeploymentError"
+
+    @pytest.mark.asyncio
+    async def test_builds_artifact_from_state(self) -> None:
+        mock_backend = AsyncMock()
+        mock_backend.deploy = AsyncMock(
+            return_value=DeploymentResult(status="completed", url="http://x", backend_log="")
+        )
+        state = _base_state(tier="staging", git_ref="staging", git_sha="abc123")
+
+        await deploy_node(state, mock_backend)  # type: ignore[arg-type]
+
+        artifact = mock_backend.deploy.call_args.args[0]
+        assert artifact.tier == "staging"
+        assert artifact.git_ref == "staging"
+        assert artifact.git_sha == "abc123"
+
+
+class TestDiagnoseNode:
+    @pytest.mark.asyncio
+    async def test_uses_helmsman_role(self) -> None:
+        mock_router = AsyncMock()
+        mock_router.route = AsyncMock(return_value=_llm_result(VALID_DIAGNOSIS))
+
+        await diagnose_node(_base_state(backend_log="err"), mock_router)  # type: ignore[arg-type]
+
+        mock_router.route.assert_awaited_once()
+        assert mock_router.route.call_args.args[0] == CrewRole.HELMSMAN
+
+    @pytest.mark.asyncio
+    async def test_valid_json_populates_diagnosis(self) -> None:
+        mock_router = AsyncMock()
+        mock_router.route = AsyncMock(return_value=_llm_result(VALID_DIAGNOSIS))
+
+        result = await diagnose_node(_base_state(backend_log="err"), mock_router)  # type: ignore[arg-type]
+
+        assert result["diagnosis"] is not None
+        assert result["diagnosis"]["summary"] == "Build failed during test stage"
+        assert result["diagnosis"]["likely_cause"] == "Missing APP_URL env var"
+
+    @pytest.mark.asyncio
+    async def test_strips_markdown_fences(self) -> None:
+        mock_router = AsyncMock()
+        fenced = f"```json\n{VALID_DIAGNOSIS}\n```"
+        mock_router.route = AsyncMock(return_value=_llm_result(fenced))
+
+        result = await diagnose_node(_base_state(backend_log="err"), mock_router)  # type: ignore[arg-type]
+
+        assert result["diagnosis"] is not None
+
+    @pytest.mark.asyncio
+    async def test_malformed_json_returns_none_diagnosis(self) -> None:
+        mock_router = AsyncMock()
+        mock_router.route = AsyncMock(return_value=_llm_result("not valid json"))
+
+        result = await diagnose_node(_base_state(backend_log="err"), mock_router)  # type: ignore[arg-type]
+
+        assert result["diagnosis"] is None
+
+    @pytest.mark.asyncio
+    async def test_schema_violation_returns_none_diagnosis(self) -> None:
+        mock_router = AsyncMock()
+        empty = json.dumps({"summary": "", "likely_cause": "", "suggested_action": ""})
+        mock_router.route = AsyncMock(return_value=_llm_result(empty))
+
+        result = await diagnose_node(_base_state(backend_log="err"), mock_router)  # type: ignore[arg-type]
+
+        assert result["diagnosis"] is None
+
+    @pytest.mark.asyncio
+    async def test_dial_router_exception_returns_none_diagnosis(self) -> None:
+        mock_router = AsyncMock()
+        mock_router.route = AsyncMock(side_effect=RuntimeError("rate limited"))
+
+        result = await diagnose_node(_base_state(backend_log="err"), mock_router)  # type: ignore[arg-type]
+
+        assert result["diagnosis"] is None
+
+    @pytest.mark.asyncio
+    async def test_user_message_contains_log_tail(self) -> None:
+        mock_router = AsyncMock()
+        mock_router.route = AsyncMock(return_value=_llm_result(VALID_DIAGNOSIS))
+
+        long_log = "X" * (DIAGNOSIS_LOG_TAIL + 500) + "END_MARKER"
+        await diagnose_node(_base_state(backend_log=long_log), mock_router)  # type: ignore[arg-type]
+
+        request = mock_router.route.call_args.args[1]
+        user_msg = next(m for m in request.messages if m["role"] == "user")
+        assert "END_MARKER" in user_msg["content"]
+        assert len(user_msg["content"]) < len(long_log) + 500
+
+    @pytest.mark.asyncio
+    async def test_user_message_includes_tier_and_ref(self) -> None:
+        mock_router = AsyncMock()
+        mock_router.route = AsyncMock(return_value=_llm_result(VALID_DIAGNOSIS))
+
+        state = _base_state(tier="production", git_ref="main", backend_log="err")
+        await diagnose_node(state, mock_router)  # type: ignore[arg-type]
+
+        request = mock_router.route.call_args.args[1]
+        user_msg = next(m for m in request.messages if m["role"] == "user")
+        assert "production" in user_msg["content"]
+        assert "main" in user_msg["content"]
+
+
+class TestFullGraph:
+    @pytest.mark.asyncio
+    async def test_successful_deploy_skips_diagnose(self) -> None:
+        mock_router = AsyncMock()
+        mock_backend = AsyncMock()
+        mock_backend.deploy = AsyncMock(
+            return_value=DeploymentResult(
+                status="completed", url="http://x.local", backend_log="ok"
+            )
+        )
+
+        graph = build_helmsman_graph(mock_router, mock_backend)  # type: ignore[arg-type]
+        final = await graph.ainvoke(_base_state())
+
+        assert final["status"] == "completed"
+        assert final["diagnosis"] is None
+        mock_router.route.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_failed_deploy_runs_diagnose(self) -> None:
+        mock_router = AsyncMock()
+        mock_router.route = AsyncMock(return_value=_llm_result(VALID_DIAGNOSIS))
+        mock_backend = AsyncMock()
+        mock_backend.deploy = AsyncMock(
+            return_value=DeploymentResult(
+                status="failed", url=None, backend_log="broken", error="Oops"
+            )
+        )
+
+        graph = build_helmsman_graph(mock_router, mock_backend)  # type: ignore[arg-type]
+        final = await graph.ainvoke(_base_state())
+
+        assert final["status"] == "failed"
+        assert final["diagnosis"] is not None
+        assert final["diagnosis"]["summary"] == "Build failed during test stage"
+        mock_router.route.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_deployment_error_routes_to_diagnose(self) -> None:
+        mock_router = AsyncMock()
+        mock_router.route = AsyncMock(return_value=_llm_result(VALID_DIAGNOSIS))
+        mock_backend = AsyncMock()
+        mock_backend.deploy = AsyncMock(side_effect=DeploymentError("boom"))
+
+        graph = build_helmsman_graph(mock_router, mock_backend)  # type: ignore[arg-type]
+        final = await graph.ainvoke(_base_state())
+
+        assert final["status"] == "failed"
+        assert final["diagnosis"] is not None
+        assert "boom" in final["backend_log"]
+
+    @pytest.mark.asyncio
+    async def test_diagnose_failure_does_not_mask_deploy_failure(self) -> None:
+        mock_router = AsyncMock()
+        mock_router.route = AsyncMock(side_effect=RuntimeError("llm down"))
+        mock_backend = AsyncMock()
+        mock_backend.deploy = AsyncMock(
+            return_value=DeploymentResult(
+                status="failed", url=None, backend_log="broken", error="Oops"
+            )
+        )
+
+        graph = build_helmsman_graph(mock_router, mock_backend)  # type: ignore[arg-type]
+        final = await graph.ainvoke(_base_state())
+
+        assert final["status"] == "failed"
+        assert final["diagnosis"] is None
+        assert final["backend_log"] == "broken"

--- a/src/backend/tests/test_helmsman_schemas.py
+++ b/src/backend/tests/test_helmsman_schemas.py
@@ -1,0 +1,105 @@
+"""Tests for Helmsman Agent Pydantic schemas."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from pydantic import ValidationError
+
+from app.schemas.deployment import (
+    DeploymentDiagnosisSpec,
+    DeploymentListResponse,
+    DeploymentResponse,
+    DeployRequest,
+    RollbackRequest,
+)
+
+
+class TestDeployRequest:
+    def test_accepts_valid_preview(self) -> None:
+        req = DeployRequest(tier="preview")
+        assert req.tier == "preview"
+        assert req.git_ref is None
+        assert req.approved_by is None
+
+    def test_accepts_valid_production_with_approval(self) -> None:
+        approver = uuid.uuid4()
+        req = DeployRequest(tier="production", git_ref="main", approved_by=approver)
+        assert req.approved_by == approver
+
+    def test_rejects_unknown_tier(self) -> None:
+        with pytest.raises(ValidationError):
+            DeployRequest(tier="yolo")  # type: ignore[arg-type]
+
+    def test_accepts_staging_without_approval(self) -> None:
+        req = DeployRequest(tier="staging")
+        assert req.approved_by is None
+
+
+class TestRollbackRequest:
+    def test_accepts_any_tier(self) -> None:
+        req = RollbackRequest(tier="staging")
+        assert req.tier == "staging"
+
+    def test_rejects_unknown_tier(self) -> None:
+        with pytest.raises(ValidationError):
+            RollbackRequest(tier="yolo")  # type: ignore[arg-type]
+
+
+class TestDeploymentDiagnosisSpec:
+    def test_accepts_valid(self) -> None:
+        spec = DeploymentDiagnosisSpec(
+            summary="Build failed",
+            likely_cause="Missing env var",
+            suggested_action="Set APP_URL",
+        )
+        assert spec.summary == "Build failed"
+
+    def test_rejects_empty_summary(self) -> None:
+        with pytest.raises(ValidationError):
+            DeploymentDiagnosisSpec(
+                summary="",
+                likely_cause="x",
+                suggested_action="y",
+            )
+
+
+class TestDeploymentResponse:
+    def test_accepts_valid(self) -> None:
+        resp = DeploymentResponse(
+            voyage_id=uuid.uuid4(),
+            deployment_id=uuid.uuid4(),
+            tier="preview",
+            action="deploy",
+            status="completed",
+            git_ref="main",
+            git_sha="abc123",
+            url="http://x.local",
+            diagnosis=None,
+        )
+        assert resp.status == "completed"
+
+    def test_rejects_invalid_status(self) -> None:
+        with pytest.raises(ValidationError):
+            DeploymentResponse(
+                voyage_id=uuid.uuid4(),
+                deployment_id=uuid.uuid4(),
+                tier="preview",
+                action="deploy",
+                status="weird",  # type: ignore[arg-type]
+                git_ref="main",
+                git_sha=None,
+                url=None,
+                diagnosis=None,
+            )
+
+
+class TestDeploymentListResponse:
+    def test_accepts_empty_list(self) -> None:
+        resp = DeploymentListResponse(
+            voyage_id=uuid.uuid4(),
+            tier=None,
+            deployments=[],
+        )
+        assert resp.deployments == []

--- a/src/backend/tests/test_helmsman_service.py
+++ b/src/backend/tests/test_helmsman_service.py
@@ -1,0 +1,483 @@
+"""Tests for HelmsmanService (mocked dependencies)."""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.den_den_mushi.events import (
+    DeploymentCompletedEvent,
+    DeploymentFailedEvent,
+    DeploymentStartedEvent,
+)
+from app.models.deployment import Deployment
+from app.models.enums import VoyageStatus
+from app.models.vivre_card import VivreCard
+from app.services.git_service import GitError
+from app.services.helmsman_service import (
+    HelmsmanError,
+    HelmsmanService,
+    _require_production_approval,
+)
+
+VOYAGE_ID = uuid.uuid4()
+USER_ID = uuid.uuid4()
+APPROVER_ID = uuid.uuid4()
+
+
+def _mock_voyage(
+    status: str = VoyageStatus.CHARTED.value,
+    target_repo: str | None = "git@github.com:user/repo.git",
+) -> MagicMock:
+    voyage = MagicMock()
+    voyage.id = VOYAGE_ID
+    voyage.user_id = USER_ID
+    voyage.status = status
+    voyage.target_repo = target_repo
+    return voyage
+
+
+def _graph_state(
+    *,
+    status: str = "completed",
+    url: str | None = "http://preview.voyage-abc.local",
+    backend_log: str = "ok",
+    error: str | None = None,
+    diagnosis: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    return {
+        "voyage_id": VOYAGE_ID,
+        "user_id": USER_ID,
+        "tier": "preview",
+        "git_ref": "agent/shipwright/abc",
+        "git_sha": "deadbeef",
+        "status": status,
+        "url": url,
+        "backend_log": backend_log,
+        "error": error,
+        "diagnosis": diagnosis,
+    }
+
+
+@pytest.fixture
+def mock_dial_router() -> AsyncMock:
+    return AsyncMock()
+
+
+@pytest.fixture
+def mock_mushi() -> AsyncMock:
+    m = AsyncMock()
+    m.publish = AsyncMock(return_value="msg-1")
+    return m
+
+
+@pytest.fixture
+def mock_session() -> AsyncMock:
+    session = AsyncMock()
+    session.add = MagicMock()
+    session.flush = AsyncMock()
+    session.commit = AsyncMock()
+    session.refresh = AsyncMock()
+    result_mock = MagicMock()
+    result_mock.scalars.return_value.all.return_value = []
+    result_mock.scalars.return_value.first.return_value = None
+    session.execute = AsyncMock(return_value=result_mock)
+    return session
+
+
+@pytest.fixture
+def mock_backend() -> AsyncMock:
+    return AsyncMock()
+
+
+@pytest.fixture
+def mock_git() -> AsyncMock:
+    g = AsyncMock()
+    g.get_head_sha = AsyncMock(return_value="deadbeef")
+    return g
+
+
+@pytest.fixture
+def service(
+    mock_dial_router: AsyncMock,
+    mock_mushi: AsyncMock,
+    mock_session: AsyncMock,
+    mock_backend: AsyncMock,
+    mock_git: AsyncMock,
+) -> HelmsmanService:
+    svc = HelmsmanService(
+        mock_dial_router,
+        mock_mushi,
+        mock_session,
+        deployment_backend=mock_backend,
+        git_service=mock_git,
+    )
+    svc._graph = AsyncMock()  # type: ignore[assignment]
+    svc._graph.ainvoke = AsyncMock(return_value=_graph_state())  # type: ignore[attr-defined]
+    return svc
+
+
+class TestApprovalGate:
+    def test_production_without_approval_raises(self) -> None:
+        with pytest.raises(HelmsmanError) as exc:
+            _require_production_approval("production", None)
+        assert exc.value.code == "APPROVAL_REQUIRED"
+
+    def test_production_with_approval_passes(self) -> None:
+        _require_production_approval("production", APPROVER_ID)
+
+    def test_preview_without_approval_passes(self) -> None:
+        _require_production_approval("preview", None)
+
+    def test_staging_without_approval_passes(self) -> None:
+        _require_production_approval("staging", None)
+
+
+class TestDeployHappyPath:
+    @pytest.mark.asyncio
+    async def test_returns_completed_response(self, service: HelmsmanService) -> None:
+        voyage = _mock_voyage()
+        resp = await service.deploy(voyage, "preview", USER_ID)
+        assert resp.status == "completed"
+        assert resp.url == "http://preview.voyage-abc.local"
+        assert resp.action == "deploy"
+        assert resp.diagnosis is None
+
+    @pytest.mark.asyncio
+    async def test_sets_status_to_deploying_during_call(
+        self, service: HelmsmanService, mock_session: AsyncMock
+    ) -> None:
+        voyage = _mock_voyage()
+        observed: list[str] = []
+
+        async def record() -> None:
+            observed.append(voyage.status)
+
+        mock_session.flush.side_effect = record
+        await service.deploy(voyage, "preview", USER_ID)
+        assert VoyageStatus.DEPLOYING.value in observed
+
+    @pytest.mark.asyncio
+    async def test_restores_charted_after_success(self, service: HelmsmanService) -> None:
+        voyage = _mock_voyage()
+        await service.deploy(voyage, "preview", USER_ID)
+        assert voyage.status == VoyageStatus.CHARTED.value
+
+    @pytest.mark.asyncio
+    async def test_persists_deployment_and_vivre_card(
+        self, service: HelmsmanService, mock_session: AsyncMock
+    ) -> None:
+        voyage = _mock_voyage()
+        await service.deploy(voyage, "preview", USER_ID)
+
+        added = [c.args[0] for c in mock_session.add.call_args_list]
+        assert any(isinstance(x, Deployment) for x in added)
+        assert any(isinstance(x, VivreCard) for x in added)
+
+    @pytest.mark.asyncio
+    async def test_commits_atomically(
+        self, service: HelmsmanService, mock_session: AsyncMock
+    ) -> None:
+        voyage = _mock_voyage()
+        await service.deploy(voyage, "preview", USER_ID)
+        mock_session.commit.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_uses_default_git_ref_for_preview(
+        self, service: HelmsmanService, mock_git: AsyncMock
+    ) -> None:
+        voyage = _mock_voyage()
+        await service.deploy(voyage, "preview", USER_ID)
+        mock_git.get_head_sha.assert_awaited_once()
+        ref = mock_git.get_head_sha.call_args.args[2]
+        assert "agent/shipwright/" in ref
+
+    @pytest.mark.asyncio
+    async def test_uses_provided_git_ref(
+        self, service: HelmsmanService, mock_git: AsyncMock
+    ) -> None:
+        voyage = _mock_voyage()
+        await service.deploy(voyage, "preview", USER_ID, git_ref="custom-branch")
+        ref = mock_git.get_head_sha.call_args.args[2]
+        assert ref == "custom-branch"
+
+    @pytest.mark.asyncio
+    async def test_uses_default_git_ref_for_staging(
+        self, service: HelmsmanService, mock_git: AsyncMock
+    ) -> None:
+        voyage = _mock_voyage()
+        await service.deploy(voyage, "staging", USER_ID)
+        assert mock_git.get_head_sha.call_args.args[2] == "staging"
+
+    @pytest.mark.asyncio
+    async def test_uses_default_git_ref_for_production(
+        self, service: HelmsmanService, mock_git: AsyncMock
+    ) -> None:
+        voyage = _mock_voyage()
+        await service.deploy(voyage, "production", USER_ID, approved_by=APPROVER_ID)
+        assert mock_git.get_head_sha.call_args.args[2] == "main"
+
+
+class TestApprovalEnforcement:
+    @pytest.mark.asyncio
+    async def test_production_without_approval_raises(self, service: HelmsmanService) -> None:
+        voyage = _mock_voyage()
+        with pytest.raises(HelmsmanError) as exc:
+            await service.deploy(voyage, "production", USER_ID)
+        assert exc.value.code == "APPROVAL_REQUIRED"
+
+    @pytest.mark.asyncio
+    async def test_production_with_approval_succeeds(self, service: HelmsmanService) -> None:
+        voyage = _mock_voyage()
+        resp = await service.deploy(voyage, "production", USER_ID, approved_by=APPROVER_ID)
+        assert resp.status == "completed"
+
+    @pytest.mark.asyncio
+    async def test_approval_checked_before_status_gate(self, service: HelmsmanService) -> None:
+        # voyage NOT in CHARTED — but since no approval is provided, approval
+        # error should fire first (403 vs 409 precedence)
+        voyage = _mock_voyage(status=VoyageStatus.DEPLOYING.value)
+        with pytest.raises(HelmsmanError) as exc:
+            await service.deploy(voyage, "production", USER_ID)
+        assert exc.value.code == "APPROVAL_REQUIRED"
+
+
+class TestStatusGate:
+    @pytest.mark.asyncio
+    async def test_non_charted_voyage_raises(self, service: HelmsmanService) -> None:
+        voyage = _mock_voyage(status=VoyageStatus.DEPLOYING.value)
+        with pytest.raises(HelmsmanError) as exc:
+            await service.deploy(voyage, "preview", USER_ID)
+        assert exc.value.code == "VOYAGE_NOT_DEPLOYABLE"
+
+    @pytest.mark.asyncio
+    async def test_rollback_non_charted_voyage_raises(self, service: HelmsmanService) -> None:
+        voyage = _mock_voyage(status=VoyageStatus.BUILDING.value)
+        with pytest.raises(HelmsmanError) as exc:
+            await service.rollback(voyage, "preview", USER_ID)
+        assert exc.value.code == "VOYAGE_NOT_DEPLOYABLE"
+
+
+class TestDeployFailurePath:
+    @pytest.mark.asyncio
+    async def test_failed_graph_raises_deployment_failed(self, service: HelmsmanService) -> None:
+        service._graph.ainvoke = AsyncMock(  # type: ignore[attr-defined]
+            return_value=_graph_state(
+                status="failed",
+                url=None,
+                diagnosis={
+                    "summary": "Build error",
+                    "likely_cause": "x",
+                    "suggested_action": "y",
+                },
+            )
+        )
+        voyage = _mock_voyage()
+        with pytest.raises(HelmsmanError) as exc:
+            await service.deploy(voyage, "preview", USER_ID)
+        assert exc.value.code == "DEPLOYMENT_FAILED"
+        assert "Build error" in exc.value.message
+
+    @pytest.mark.asyncio
+    async def test_failed_deploy_still_commits_row(
+        self, service: HelmsmanService, mock_session: AsyncMock
+    ) -> None:
+        service._graph.ainvoke = AsyncMock(  # type: ignore[attr-defined]
+            return_value=_graph_state(status="failed", url=None)
+        )
+        voyage = _mock_voyage()
+        with pytest.raises(HelmsmanError):
+            await service.deploy(voyage, "preview", USER_ID)
+        mock_session.commit.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_failed_deploy_restores_charted(self, service: HelmsmanService) -> None:
+        service._graph.ainvoke = AsyncMock(  # type: ignore[attr-defined]
+            return_value=_graph_state(status="failed", url=None)
+        )
+        voyage = _mock_voyage()
+        with pytest.raises(HelmsmanError):
+            await service.deploy(voyage, "preview", USER_ID)
+        assert voyage.status == VoyageStatus.CHARTED.value
+
+    @pytest.mark.asyncio
+    async def test_graph_exception_restores_charted(self, service: HelmsmanService) -> None:
+        service._graph.ainvoke = AsyncMock(side_effect=RuntimeError("boom"))  # type: ignore[attr-defined]
+        voyage = _mock_voyage()
+        with pytest.raises(RuntimeError):
+            await service.deploy(voyage, "preview", USER_ID)
+        assert voyage.status == VoyageStatus.CHARTED.value
+
+
+class TestGitRefResolution:
+    @pytest.mark.asyncio
+    async def test_git_error_raises_git_ref_unresolvable(
+        self, service: HelmsmanService, mock_git: AsyncMock
+    ) -> None:
+        mock_git.get_head_sha = AsyncMock(side_effect=GitError("bad ref"))
+        voyage = _mock_voyage()
+        with pytest.raises(HelmsmanError) as exc:
+            await service.deploy(voyage, "preview", USER_ID)
+        assert exc.value.code == "GIT_REF_UNRESOLVABLE"
+
+    @pytest.mark.asyncio
+    async def test_null_target_repo_skips_git_resolution(
+        self,
+        mock_dial_router: AsyncMock,
+        mock_mushi: AsyncMock,
+        mock_session: AsyncMock,
+        mock_backend: AsyncMock,
+        mock_git: AsyncMock,
+    ) -> None:
+        svc = HelmsmanService(
+            mock_dial_router,
+            mock_mushi,
+            mock_session,
+            deployment_backend=mock_backend,
+            git_service=mock_git,
+        )
+        svc._graph = AsyncMock()  # type: ignore[assignment]
+        svc._graph.ainvoke = AsyncMock(return_value=_graph_state())  # type: ignore[attr-defined]
+        voyage = _mock_voyage(target_repo=None)
+        await svc.deploy(voyage, "preview", USER_ID)
+        mock_git.get_head_sha.assert_not_awaited()
+
+
+class TestRollback:
+    @pytest.mark.asyncio
+    async def test_no_previous_deploy_raises(self, service: HelmsmanService) -> None:
+        voyage = _mock_voyage()
+        with pytest.raises(HelmsmanError) as exc:
+            await service.rollback(voyage, "preview", USER_ID)
+        assert exc.value.code == "NO_PREVIOUS_DEPLOYMENT"
+
+    @pytest.mark.asyncio
+    async def test_finds_previous_and_redeploys_sha(
+        self, service: HelmsmanService, mock_session: AsyncMock, mock_git: AsyncMock
+    ) -> None:
+        previous = Deployment(
+            id=uuid.uuid4(),
+            voyage_id=VOYAGE_ID,
+            tier="preview",
+            action="deploy",
+            git_ref="agent/shipwright/old",
+            git_sha="oldsha",
+            status="completed",
+        )
+        result_mock = MagicMock()
+        result_mock.scalars.return_value.first.return_value = previous
+        mock_session.execute = AsyncMock(return_value=result_mock)
+
+        voyage = _mock_voyage()
+        resp = await service.rollback(voyage, "preview", USER_ID)
+
+        assert resp.action == "rollback"
+        assert resp.git_ref == "agent/shipwright/old"
+        # rollback does NOT re-resolve the sha via git — uses the previous sha
+        mock_git.get_head_sha.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_rollback_sets_previous_deployment_id(
+        self, service: HelmsmanService, mock_session: AsyncMock
+    ) -> None:
+        prev_id = uuid.uuid4()
+        previous = Deployment(
+            id=prev_id,
+            voyage_id=VOYAGE_ID,
+            tier="preview",
+            action="deploy",
+            git_ref="ref",
+            git_sha="sha",
+            status="completed",
+        )
+        result_mock = MagicMock()
+        result_mock.scalars.return_value.first.return_value = previous
+        mock_session.execute = AsyncMock(return_value=result_mock)
+
+        voyage = _mock_voyage()
+        await service.rollback(voyage, "preview", USER_ID)
+
+        deployments = [
+            c.args[0] for c in mock_session.add.call_args_list if isinstance(c.args[0], Deployment)
+        ]
+        assert any(d.previous_deployment_id == prev_id for d in deployments)
+
+
+class TestEventPublishing:
+    @pytest.mark.asyncio
+    async def test_publishes_started_and_completed_on_success(
+        self, service: HelmsmanService, mock_mushi: AsyncMock
+    ) -> None:
+        voyage = _mock_voyage()
+        await service.deploy(voyage, "preview", USER_ID)
+
+        published = [c.args[1] for c in mock_mushi.publish.call_args_list]
+        assert any(isinstance(e, DeploymentStartedEvent) for e in published)
+        assert any(isinstance(e, DeploymentCompletedEvent) for e in published)
+        assert not any(isinstance(e, DeploymentFailedEvent) for e in published)
+
+    @pytest.mark.asyncio
+    async def test_publishes_started_and_failed_on_failure(
+        self, service: HelmsmanService, mock_mushi: AsyncMock
+    ) -> None:
+        service._graph.ainvoke = AsyncMock(  # type: ignore[attr-defined]
+            return_value=_graph_state(status="failed", url=None)
+        )
+        voyage = _mock_voyage()
+        with pytest.raises(HelmsmanError):
+            await service.deploy(voyage, "preview", USER_ID)
+
+        published = [c.args[1] for c in mock_mushi.publish.call_args_list]
+        assert any(isinstance(e, DeploymentStartedEvent) for e in published)
+        assert any(isinstance(e, DeploymentFailedEvent) for e in published)
+        assert not any(isinstance(e, DeploymentCompletedEvent) for e in published)
+
+    @pytest.mark.asyncio
+    async def test_publish_failure_does_not_raise(
+        self, service: HelmsmanService, mock_mushi: AsyncMock
+    ) -> None:
+        mock_mushi.publish = AsyncMock(side_effect=RuntimeError("redis down"))
+        voyage = _mock_voyage()
+        # Should still return successfully — best-effort events
+        resp = await service.deploy(voyage, "preview", USER_ID)
+        assert resp.status == "completed"
+
+
+class TestReaderFactory:
+    def test_reader_creates_read_only_instance(self, mock_session: AsyncMock) -> None:
+        reader = HelmsmanService.reader(mock_session)
+        assert reader._session is mock_session
+
+    @pytest.mark.asyncio
+    async def test_reader_get_deployments_works(self, mock_session: AsyncMock) -> None:
+        reader = HelmsmanService.reader(mock_session)
+        rows = await reader.get_deployments(VOYAGE_ID)
+        assert rows == []
+
+    @pytest.mark.asyncio
+    async def test_get_deployments_filters_by_tier(self, mock_session: AsyncMock) -> None:
+        reader = HelmsmanService.reader(mock_session)
+        await reader.get_deployments(VOYAGE_ID, tier="preview")
+        mock_session.execute.assert_awaited()
+
+
+class TestBackendLogTruncation:
+    @pytest.mark.asyncio
+    async def test_long_log_truncated_to_4000(
+        self, service: HelmsmanService, mock_session: AsyncMock
+    ) -> None:
+        long_log = "X" * 10000
+        service._graph.ainvoke = AsyncMock(  # type: ignore[attr-defined]
+            return_value=_graph_state(backend_log=long_log)
+        )
+        voyage = _mock_voyage()
+        await service.deploy(voyage, "preview", USER_ID)
+
+        deployments = [
+            c.args[0] for c in mock_session.add.call_args_list if isinstance(c.args[0], Deployment)
+        ]
+        assert len(deployments) == 1
+        assert len(deployments[0].backend_log) == 4000  # type: ignore[arg-type]

--- a/src/backend/tests/test_models.py
+++ b/src/backend/tests/test_models.py
@@ -5,6 +5,7 @@ from sqlalchemy import inspect
 from app.models import Base
 from app.models.build_artifact import BuildArtifact
 from app.models.crew_action import CrewAction
+from app.models.deployment import Deployment
 from app.models.dial_config import DialConfig
 from app.models.enums import CheckpointReason, CrewRole, VoyageStatus
 from app.models.health_check import HealthCheck
@@ -30,6 +31,7 @@ def test_all_models_registered_in_metadata() -> None:
         "validation_runs",
         "shipwright_runs",
         "build_artifacts",
+        "deployments",
     }
     assert expected == table_names
 
@@ -267,3 +269,30 @@ def test_build_artifact_voyage_phase_indexed() -> None:
     table = BuildArtifact.__table__
     index_names = {idx.name for idx in table.indexes}
     assert "ix_build_artifacts_voyage_phase" in index_names
+
+
+def test_deployment_table_columns() -> None:
+    mapper = inspect(Deployment)
+    column_names = {c.key for c in mapper.columns}
+    assert column_names == {
+        "id",
+        "voyage_id",
+        "tier",
+        "action",
+        "git_ref",
+        "git_sha",
+        "status",
+        "approved_by",
+        "url",
+        "backend_log",
+        "diagnosis",
+        "previous_deployment_id",
+        "created_at",
+        "updated_at",
+    }
+
+
+def test_deployment_composite_index() -> None:
+    table = Deployment.__table__
+    index_names = {idx.name for idx in table.indexes}
+    assert "ix_deployments_voyage_tier_created" in index_names


### PR DESCRIPTION
## Summary

- Introduces the Helmsman crew member — DevOps agent that handles voyage deployments across preview/staging/production with LLM-based failure diagnosis on failure only
- Simulated `InProcessDeploymentBackend` behind a swappable `DeploymentBackend` ABC (mirrors `ExecutionBackend`); real backends drop in without touching the service layer
- Single `deployments` table with `action` column — rollback redeploys the previous completed deploy's `git_sha` for the same `(voyage, tier)`
- Approval gate via `approved_by` UUID, checked **before** the voyage status gate so unapproved production requests return **403 regardless of voyage state**; encapsulated in `_require_production_approval` as a Phase 17 swap point
- LangGraph flow: deploy → conditional → (if failed) diagnose → END. Diagnose is best-effort — LLM failure does not mask the deploy failure
- Atomic DB commit (deployment row + VivreCard + voyage status) **before** best-effort event publishing (`deployment_started` + `deployment_completed`|`deployment_failed`, each in its own `try/except`)
- `GitService.get_head_sha` added for audit-only `git_ref` → `git_sha` resolution (rejects shell metacharacters via existing branch validator)

Closes #15

## Test plan

- [x] Schema validation (tier/action/status Literals, approval matrix) — 11 tests
- [x] `DeploymentBackend` ABC contract + `InProcessDeploymentBackend` semantics (success, `fail_tiers` injection, status lookup isolation) — 8 tests
- [x] Graph deploy-node imperative / diagnose-node LLM-only-on-fail / `DeploymentError` → `status=failed` / JSON parse resilience / log tail — 16 tests
- [x] Service approval enforcement + 403-over-409 precedence, status transitions, rollback finds previous, git error mapping, atomic commit ordering, event publishing on success + failure separately, best-effort publish — 34 tests
- [x] API 201/403/404/409/422 matrix, rollback 404, approval-passed-through — 13 tests
- [x] Model schema + composite index `(voyage_id, tier, created_at DESC)` — 2 tests
- [x] `get_head_sha` happy path + shell-injection rejection — 2 tests
- [x] Full suite: **633 passed**, ruff clean, mypy clean on `app/`