### PR TITLE
Phase 15.1: per-phase Shipwright status gate (parallel-safety) #16

### DIFF
--- a/pdd/context/decisions.md
+++ b/pdd/context/decisions.md
@@ -185,6 +185,23 @@
 **What was decided**: v1 of the Shipwright enforces a single in-flight invocation per voyage via the `voyage.status == CHARTED` gate (transitions to `BUILDING` during the call). True per-phase parallelism is deferred until a `phase_status` map is added to the voyage model.
 **Why**: Shipping a correct sequential path first. Concurrent invocations on the same voyage would race the `voyage.status` transition and the `delete-before-insert` step for `BuildArtifact`. A `phase_status` refactor is the right long-term fix but premature for the first Shipwright cut. Phase 15's voyage pipeline will sequence phase builds; user-level fan-out across phases waits for the refactor.
 **Don't suggest**: Removing the 409 gate, introducing a voyage-level lock in Redis (heavier than needed), bolting on a phase_status column without a migration plan
+**Superseded by**: 2026-04-19 — Shipwright per-phase status gate (Phase 15.1 refactor)
+
+---
+
+## Decision: Shipwright per-phase status gate (Phase 15.1 refactor)
+**Date**: 2026-04-19
+**What was decided**: Replaced `voyage.status` gate with a `Voyage.phase_status` JSONB map keyed by `str(phase_number)` with values `PENDING | BUILDING | BUILT | FAILED` (module-level string constants in `shipwright_service.py`, no SQLAlchemy enum). `ShipwrightService.build_code` gates on `phase_status.get(key, "PENDING") in {"PENDING", "FAILED"}` and raises `ShipwrightError("PHASE_NOT_BUILDABLE")` → HTTP 409 when the phase is already `BUILDING` or `BUILT`. `voyage.status` is no longer touched by the service. `BuildArtifact` delete-before-insert remains scoped to `(voyage_id, phase_number)`.
+**Why**: Phase 15's voyage pipeline wants to build independent phases in parallel (topological layers bounded by `asyncio.Semaphore`). The voyage-level gate made concurrent phase builds impossible — any second invocation 409'd, even for a different phase. Keeping `voyage.status` untouched lets the master pipeline own the outer `CHARTED → BUILDING → COMPLETED` transitions without racing the Shipwright. JSONB over a new table avoids a join on every gate check; dict-copy-before-assign keeps SQLAlchemy's JSONB dirty-tracking happy without `flag_modified`. Per-phase re-buildability (FAILED → buildable) is a pipeline-retry requirement.
+**Don't suggest**: Reinstating the `voyage.status` gate, using a SQLAlchemy Enum column (JSONB values are more flexible and cheaper to migrate), introducing `flag_modified` everywhere instead of fresh-dict-assign, adding per-phase row locks (the status map is a single row update)
+
+---
+
+## Decision: Configurable Shipwright concurrency via DialConfig (not env/global)
+**Date**: 2026-04-19
+**What was decided**: Added `ShipwrightRoleConfig.max_concurrency: int | None` (Pydantic `ge=1 le=10`) to `DialConfig.role_mapping.shipwright`. `resolve_shipwright_max_concurrency()` reads the value at pipeline-start time and falls back to `1` on any missing key, non-dict shape, validation failure, or `None`. No migration — piggybacks on the existing `role_mapping` JSONB.
+**Why**: Different users have different provider plans — a free-tier Anthropic key can't sustain 5 concurrent Shipwrights, a Tier-4 key easily can. Hard-coding a global max would either starve high-tier users or overload low-tier ones. Per-voyage scoping (via DialConfig) means the knob sits next to the other provider choices the user already tunes. The `1..10` range is a safety rail — parallelism beyond 10 typically hits rate limits anyway and burns tokens on retries. Fail-safe-to-1 means a malformed config never triggers a fan-out storm.
+**Don't suggest**: Global env var, per-request query param, removing the upper bound, raising on invalid config (silent fallback preserves "voyages always progress")
 
 ---
 

--- a/pdd/prompts/features/pipeline/PLAN-voyage-pipeline.md
+++ b/pdd/prompts/features/pipeline/PLAN-voyage-pipeline.md
@@ -1,0 +1,251 @@
+# Implementation Plan: Voyage Pipeline (Phase 15)
+
+**Created**: 2026-04-18
+**Revised**: 2026-04-19 — add parallel Shipwright + `phase_status` refactor + configurable concurrency
+**Issue**: #16
+**Complexity**: High — first integration across all five crew services; new state machine + guard helpers; parallel-safe Shipwright refactor; background runner; SSE forwarding; end-to-end integration test.
+**Estimated prompts**: 5
+
+## Summary
+
+The master LangGraph wires the existing five crew services (Captain → Navigator → Doctor-writes → Shipwright-per-phase-in-parallel → Doctor-validates → Helmsman) into one end-to-end pipeline with a formal state machine and transition guards.
+
+Nodes are **thin service adapters** — each service owns its DB commit, VivreCard checkpoints, and best-effort event publishing. The master graph's job is: check pre-conditions, invoke the service, translate failures into a `FAILED` voyage, and emit pipeline-level events.
+
+Shipwright gains a **per-phase status gate** (`Voyage.phase_status` JSONB) so multiple phases can build concurrently without racing. The pipeline runs Shipwright phases in **topological layers** — all dep-free phases in parallel, wait, next layer, etc. Concurrency is bounded by a user-configurable `max_concurrency` setting stored in `DialConfig.role_mapping.shipwright` (default 1, ceiling 10).
+
+`POST /voyages/{id}/start` kicks the graph off as a background task (`asyncio.create_task`). `GET /voyages/{id}/status` returns current status + progress summary. `GET /voyages/{id}/stream` is an SSE forwarder that tails the voyage's existing Den Den Mushi stream key.
+
+## Locked-in design decisions
+
+These are the seven design decisions resolved. Each needs a line logged in `pdd/context/decisions.md` as part of the relevant phase.
+
+### (1) Master graph invokes services directly (not sub-graphs)
+
+**Decision**: Graph nodes are thin async wrappers that call `CaptainService.chart_course(...)`, `NavigatorService.draft_poneglyphs(...)`, etc. Each service already owns DB writes, status transitions, VivreCard checkpointing, and best-effort event publishing.
+
+**Why**: The sub-graphs are pure LLM/sandbox flows — they don't know about DB or events. The services are the composable unit. The master graph is just a scheduler.
+
+### (2) Shipwright gets a parallel-safety refactor + configurable concurrency
+
+**Decision**: Phase 15 ships with **parallel Shipwright execution**, bounded by a user-configurable `max_concurrency`. The correctness dependency is a per-phase status gate on `Voyage.phase_status` (JSONB map: `{phase_number: "PENDING" | "BUILDING" | "BUILT" | "FAILED"}`). Shipwright refactors to gate on `phase_status[phase_number]` instead of `voyage.status`.
+
+**Concurrency knob**:
+- Storage: `DialConfig.role_mapping.shipwright.max_concurrency: int | None`. Default `1`, ceiling `10`. JSONB — no migration needed.
+- Request override: `POST /voyages/{id}/start` accepts optional `max_parallel_shipwrights` for per-run tuning.
+- Resolution order: request override → DialConfig value → default 1.
+
+**Scheduling**: `building_node` runs phases in **topological layers** (dep-free phases → wait → phases whose deps just completed → wait → ...). Each layer uses `asyncio.Semaphore(max_concurrency)` + `asyncio.gather`. First failure cancels the remaining tasks in the layer; voyage → `FAILED`.
+
+**Delete-before-insert scoping**: `ShipwrightService.build_code` changes its `BuildArtifact` deletion from `WHERE voyage_id = ?` to `WHERE voyage_id = ? AND phase_number = ?`. Matches the per-phase gate.
+
+**Why**: Clock-time win (5-phase voyage goes from ~225s serial → ~75-90s at N=3). Zero token impact. User self-serves for their API plan — N=1 on free-tier keys, N=5+ on Enterprise.
+
+**Log in decisions.md** (Phase 1): *"Shipwright gates on `Voyage.phase_status[phase_number]`, not `voyage.status`. `max_concurrency` lives in `DialConfig.role_mapping.shipwright`; default 1, ceiling 10. The pipeline schedules phases in topological layers bounded by a semaphore."*
+
+### (3) Pause/resume via DB status flag; no LangGraph checkpointer
+
+**Decision**: "Pause" sets `voyage.status = PAUSED`. The graph re-reads voyage status at the start of each stage node; if `PAUSED`, exits cleanly. Resume = re-invoke `POST /voyages/{id}/start`, which reads current status, sees which artifacts already exist, and picks up from the next stage (skip-already-satisfied-stages on resume).
+
+**Why**: Product state is already in Postgres. LangGraph's checkpointer would duplicate it. Mid-stage pause is not supported — services are atomic units.
+
+**Log in decisions.md**: *"Pipeline pause/resume is DB-status-driven and between-stage. Mid-service interruption is not supported in v1."*
+
+### (4) SSE stream: forward existing Den Den Mushi events + add 5 pipeline-level events
+
+**Decision**:
+- Existing per-service events continue to be published unchanged.
+- **Add** five pipeline-level events to `den_den_mushi/events.py`: `PipelineStartedEvent`, `PipelineStageEnteredEvent`, `PipelineStageCompletedEvent`, `PipelineCompletedEvent`, `PipelineFailedEvent`. Emitted by `PipelineService` around each stage transition.
+- SSE endpoint (`GET /voyages/{id}/stream`) subscribes to the existing `stream_key(voyage_id)` with a fresh consumer name, forwards every event as `data: {json}\n\n`, closes when the voyage reaches a terminal status.
+
+**Why**: Reuse the existing bus — one Redis stream per voyage. Real-time Observation Deck visibility for free.
+
+### (5) VoyageStatus enum: reuse existing, do NOT add PARKED
+
+**Decision**: All statuses needed by the state machine already exist. `PARKED` is dropped — `PAUSED` + `CANCELLED` cover the required UX.
+
+**Why**: New enum values require migrations. Nothing in the pipeline actually needs `PARKED`; easy to add later if a real use case emerges.
+
+### (6) Transition guards live in a centralized helper
+
+**Decision**: New file `app/services/pipeline_guards.py` with one function per transition:
+- `require_can_enter_planning(voyage)` — voyage.status in {CHARTED, PAUSED, FAILED}
+- `require_can_enter_pdd(voyage, plan)` — plan exists
+- `require_can_enter_tdd(voyage, poneglyphs)` — poneglyphs cover every planned phase
+- `require_can_enter_building(voyage, health_checks)` — health_checks exist for every planned phase
+- `require_can_enter_reviewing(voyage, build_artifacts)` — artifacts exist for every planned phase
+- `require_can_enter_deploying(voyage, validation_run)` — most-recent validation_run.status == "passed"
+
+Each raises `PipelineError(code, message)` on violation.
+
+**Bonus**: guards also drive **skip-already-satisfied-stages** on resume — if artifacts exist, skip the stage + its LLM call. Token savings on re-run after a fix.
+
+**Why**: Centralized, declarative, testable in isolation. One place to reason about invariants.
+
+### (7) Services directly own final status, pipeline overrides for COMPLETED/FAILED
+
+**Decision**: Each crew service still restores `voyage.status = CHARTED` on success/failure. The **pipeline** overrides after Helmsman returns: on success → `COMPLETED`, on any stage failure → `FAILED`. Helmsman's internal CHARTED-restore is harmless because the pipeline writes COMPLETED right after.
+
+**Why**: Keeps services independently invokable (manual `POST /deploy` still works). Pipeline owns end-state because it's the only component that knows "we're done with the whole voyage, not just one stage".
+
+## Service invocation reference
+
+| Stage | Service call | Transient status | Scope |
+|---|---|---|---|
+| PLANNING | `CaptainService.chart_course(voyage, task)` | PLANNING | voyage |
+| PDD | `NavigatorService.draft_poneglyphs(voyage, plan)` | PDD | voyage |
+| TDD | `DoctorService.write_health_checks(voyage, poneglyphs, user_id)` | TDD | voyage |
+| BUILDING | `ShipwrightService.build_code(voyage, phase_number)` × N (parallel, layer-scheduled) | `phase_status[phase] = BUILDING` | per-phase |
+| REVIEWING | `DoctorService.validate_code(voyage, user_id, shipwright_files)` | REVIEWING | voyage |
+| DEPLOYING | `HelmsmanService.deploy(voyage, tier="preview", user_id=...)` | DEPLOYING | voyage |
+
+## Phases
+
+### Phase 1: Shipwright parallel-safety refactor + `phase_status` + `max_concurrency`
+
+**Produces**:
+- `alembic/versions/<rev>_voyage_phase_status.py` — migration adding `Voyage.phase_status: JSONB` (default `{}`)
+- `app/models/voyage.py` — add `phase_status: Mapped[dict[str, Any]]` column
+- `app/services/shipwright_service.py` — refactor `build_code` to:
+  - Gate on `voyage.phase_status.get(str(phase_number), "PENDING") in {"PENDING", "FAILED"}` instead of `voyage.status == CHARTED`
+  - Transition `phase_status[phase_number] = "BUILDING"` at entry, `"BUILT"` on success, `"FAILED"` on exception
+  - Remove the voyage-level `voyage.status` transition (voyage stays `CHARTED`; phase_status is the gate)
+  - Scope `BuildArtifact` delete-before-insert to `(voyage_id, phase_number)`
+  - New `ShipwrightError("PHASE_NOT_BUILDABLE")` for phase already in `BUILDING` or `BUILT`
+- `app/schemas/dial_config.py` (or equivalent) — add optional `max_concurrency: int | None` (validated: `1 <= x <= 10`) to the `shipwright` role_mapping sub-schema
+- Tests: update `tests/test_shipwright_service.py` + `tests/test_shipwright_api.py` for the new gate. Add new tests: two concurrent `build_code` calls on different phases succeed; two concurrent calls on the same phase → one wins, one gets 409. Add `tests/test_dial_config_schemas.py` for the `max_concurrency` validation.
+
+**Depends on**: nothing (touches landed Phase 13 code — verify existing tests pass after refactor)
+
+**Risk**: Medium-High — refactoring landed code. Careful test migration required.
+
+**Prompt**: `pdd/prompts/features/pipeline/grandline-15-01-shipwright-parallel-safety.md`
+
+**Key decisions locked here**:
+- `phase_status` values: `"PENDING"`, `"BUILDING"`, `"BUILT"`, `"FAILED"`. No enum class (JSONB string); list them in a module-level constant for readability.
+- `PHASE_NOT_BUILDABLE` → 409 at API (same precedent as voyage-not-CHARTED).
+- Voyage.status stays `CHARTED` during per-phase builds. Only the pipeline will later wrap the BUILDING stage with a `voyage.status = BUILDING` transition.
+- `max_concurrency` is **validated at schema level** (Pydantic Field with `ge=1, le=10`). If DialConfig JSONB contains an invalid value at read time, log a warning + fall back to 1.
+
+### Phase 2: Transition guards + PipelineError
+
+**Produces**:
+- `app/services/pipeline_guards.py` — the six `require_can_enter_*` helpers + `PipelineError(code, message)` exception
+- `tests/test_pipeline_guards.py` — one test class per guard covering happy path + each failure mode
+
+**Depends on**: Phase 1 (guards reference `phase_status` for the "can enter reviewing" check — all phases must be `"BUILT"`)
+
+**Risk**: Low — pure predicates over DB-loaded objects.
+
+**Prompt**: `pdd/prompts/features/pipeline/grandline-15-02-guards.md`
+
+### Phase 3: Master graph + PipelineService + pipeline events + parallel building_node
+
+**Produces**:
+- `app/crew/pipeline_graph.py` — master LangGraph `StateGraph` with `PipelineState` TypedDict. Nodes: `planning_node`, `pdd_node`, `tdd_node`, `building_node` (parallel inner scheduler over phases), `reviewing_node`, `deploying_node`, `finalize_node`. Linear edges + conditional routing to `pause_end` / `fail_end`.
+- `app/services/pipeline_service.py` — `PipelineService` composing the five crew services. Methods: `start(voyage, user_id, deploy_tier="preview", max_parallel_shipwrights=None)`, `pause(voyage)`, `cancel(voyage)`, `get_status(voyage)` + `reader(session)`. Emits pipeline-level events. Writes a `VivreCard` at each stage transition.
+- `app/den_den_mushi/events.py` — add 5 pipeline events + include in `AnyEvent` union
+- `app/services/pipeline_service.py` includes the topological-layer scheduler:
+  ```
+  resolve max_concurrency (request → DialConfig → default 1)
+  semaphore = asyncio.Semaphore(max_concurrency)
+  layers = topological_layers(plan.phases)
+  for layer in layers:
+      await asyncio.gather(*[_build_with_semaphore(phase) for phase in layer])
+  ```
+  On any phase exception in a layer: cancel remaining tasks, re-raise.
+- Tests: `tests/test_pipeline_graph.py` (mocked services, per-node happy + failure; pause-between-stages; full-graph smoke), `tests/test_pipeline_service.py` (status transitions, VivreCard writes, event publishing, final COMPLETED/FAILED override, resume from PAUSED, concurrency respects semaphore, dep ordering, skip-already-satisfied-stages), `tests/test_events.py` extended
+
+**Depends on**: Phases 1 + 2
+
+**Risk**: Medium-High — first cross-service composition + parallel scheduler + pause/resume semantics all in one prompt.
+
+**Prompt**: `pdd/prompts/features/pipeline/grandline-15-03-graph-service.md`
+
+**Design details locked here**:
+- **PipelineState TypedDict**: `voyage_id`, `user_id`, `deploy_tier`, `max_parallel_shipwrights`, `task`, `plan`, `poneglyphs`, `health_checks`, `shipwright_files`, `validation_result`, `deployment`, `error`, `paused`.
+- **Background runner**: `asyncio.create_task` on the running event loop (not FastAPI `BackgroundTasks`). The task opens its own `AsyncSession` via `async_session_factory()`. Task handle stored on `app.state.pipeline_tasks: dict[voyage_id, asyncio.Task]` for test introspection + future cancel support.
+- **Pause check**: at the top of every stage node, re-read voyage from DB, check `voyage.status == PAUSED`, route to `pause_end`.
+- **Error translation**: catch each service's `<Agent>Error`, set `state["error"] = {"code", "message", "stage"}`, route to `fail_end` → `finalize_node` sets `voyage.status = FAILED` + publishes `PipelineFailedEvent`.
+- **Parallel scheduler**: `topological_layers(phases) -> list[list[int]]` is a helper. Returns `[[1, 2], [3], [4, 5]]` style layers. Inside `building_node`, per layer: `asyncio.gather(*[build_one(p) for p in layer])`. Semaphore bounds total concurrent calls across all layers.
+- **Skip-already-satisfied**: each stage node first checks if its output artifacts exist. If yes, skip to next stage (no service call, no LLM call). Token savings on resume.
+- **Concurrency resolution**: read from `DialConfig.role_mapping.shipwright.max_concurrency`. Fall back to 1 if absent/invalid. Request `max_parallel_shipwrights` overrides.
+
+### Phase 4: REST + SSE endpoints
+
+**Produces**:
+- `app/api/v1/pipeline.py` — `POST /voyages/{id}/start`, `POST /voyages/{id}/pause`, `POST /voyages/{id}/cancel`, `GET /voyages/{id}/status`, `GET /voyages/{id}/stream` (SSE)
+- `app/api/v1/router.py` — include router
+- `app/schemas/pipeline.py` — `StartVoyageRequest` (with optional `max_parallel_shipwrights: int | None` validated `1 <= x <= 10`, optional `deploy_tier: Literal["preview"]` defaulting to `"preview"`), `VoyageStatusResponse`, `PipelineEventEnvelope`
+- `app/api/v1/dependencies.py` — `get_pipeline_service` + `get_pipeline_service_reader`
+- Tests: `tests/test_pipeline_api.py` — full endpoint matrix + SSE streaming test with httpx streaming client
+
+**Depends on**: Phase 3
+
+**Risk**: Medium — SSE semantics + background-task scheduling test hygiene.
+
+**Prompt**: `pdd/prompts/features/pipeline/grandline-15-04-api-sse.md`
+
+**Design details locked here**:
+- **SSE format**: `data: {json}\n\n`. No named events.
+- **SSE consumer lifecycle**: fresh consumer per connection (`f"sse-{uuid.uuid4().hex}"`). Short block timeout (~1s) with disconnect check each loop.
+- **SSE termination**: poll `voyage.status`; close on terminal (`COMPLETED` | `FAILED` | `CANCELLED`).
+- **POST /start**: accepts optional `max_parallel_shipwrights`. Idempotency: running stage → 409; COMPLETED → 409 (use `/cancel` + re-run out of scope for v1); PAUSED / CHARTED / FAILED → accept.
+- **Status response**: `{status, plan_exists, poneglyph_count, health_check_count, build_artifact_count, phase_status, last_validation, last_deployment, error}`.
+
+### Phase 5: End-to-end integration test
+
+**Produces**:
+- `tests/test_pipeline_integration.py` — full pipeline test:
+  - Real Postgres + Redis (existing fixtures)
+  - Mocked `DialSystemRouter.route` with a role-keyed response helper (maps `CrewRole → pre-canned JSON`)
+  - Real `InProcessDeploymentBackend` + `DockerExecutionBackend` (test fixture seeds it with a passing pytest fixture)
+  - Top-level assertions: voyage reaches `COMPLETED`, all artifacts exist, event sequence on Redis stream is correct
+- Failure-path tests:
+  - Doctor validate returns failed → voyage `FAILED`, no Deployment row
+  - Helmsman deploy fails → voyage `FAILED` with diagnosis in Deployment
+  - Parallel Shipwright respects `max_concurrency=2` (patch Semaphore, assert no more than 2 concurrent enters)
+  - Dep ordering respected (phase 3 depending on phase 1+2 doesn't start before both complete)
+  - Resume skips already-satisfied stages (pre-seed Poneglyphs, run pipeline, assert Captain+Navigator not called)
+
+**Depends on**: Phases 1-4
+
+**Risk**: Medium-High — first full-path test through real Postgres + Redis for this pipeline. Fixture churn expected.
+
+**Prompt**: `pdd/prompts/features/pipeline/grandline-15-05-integration.md`
+
+## Risks & Unknowns
+
+- **Shipwright refactor regression risk**: Phase 1 touches landed Phase 13 code. Every existing Shipwright test must be re-reasoned against the new `phase_status` semantics. Mitigation: run full suite after Phase 1 before starting Phase 2.
+
+- **Background task lifecycle**: `asyncio.create_task` without shutdown coordination leaks if the app shuts down mid-voyage. V1 acceptable — voyage resumes via `POST /start` on next run. Track tasks on `app.state.pipeline_tasks`.
+
+- **Session per background task**: spawned task opens its own `AsyncSession` via `async_session_factory`. The request's session is closed when the response returns.
+
+- **Parallel rate-limit blowups**: a user mis-configures `max_concurrency=10` on a free-tier key. Mitigation: Dial System's existing fallback_chain handles 429s per-adapter. Document the risk; let the user self-serve the knob.
+
+- **Dep-graph correctness**: topological layers assume the plan's deps are acyclic. Captain validates this; if somehow a bad plan leaks through, the layer scheduler deadlocks (never produces layer 2). Mitigation: `topological_layers` raises `PipelineError("INVALID_DEP_GRAPH")` on cycle detection.
+
+- **Fail-fast vs fail-slow in parallel builds**: one phase fails in a layer — do we cancel running tasks or let them finish? Decision: **cancel** (fail-fast). Rationale: the voyage is going to `FAILED` anyway; wasted LLM tokens on in-flight phases are a pure loss. Semaphore release on cancel is handled by `asyncio`.
+
+- **LLM cost for integration test**: fully mocked via `DialSystemRouter.route` patch. Role-keyed helper returns canned JSON per `CrewRole`.
+
+- **Resume-skips-satisfied vs "I want to force re-run"**: v1 skip is aggressive — if Poneglyphs exist, never re-draft. Force re-run = `POST /cancel` (status → CANCELLED), then... ? Deferred. Log as scope cut.
+
+- **SSE client disconnect detection**: short block timeout with disconnect check each loop.
+
+## Decisions Needed (none — all resolved)
+
+All seven design decisions locked. Scope cuts accepted:
+- ✅ `PARKED` dropped (reuse existing enum)
+- ✅ No mid-stage pause
+- ✅ No forcible restart from CANCELLED in v1
+- ✅ Preview tier only for pipeline deploys
+- ✅ Skip-already-satisfied-stages on resume
+- ✅ Parallel Shipwright with configurable concurrency (1-10, default 1)
+- ✅ Fail-fast on parallel phase failure
+- ✅ `DialConfig.role_mapping.shipwright.max_concurrency` as storage; request override allowed
+
+## Next step
+
+Run `/pdd-prompts` for Phase 1 → produce `pdd/prompts/features/pipeline/grandline-15-01-shipwright-parallel-safety.md`. Implement TDD-first, review, commit. Then iterate through Phases 2-5.

--- a/pdd/prompts/features/pipeline/grandline-15-01-shipwright-parallel-safety.md
+++ b/pdd/prompts/features/pipeline/grandline-15-01-shipwright-parallel-safety.md
@@ -1,0 +1,402 @@
+# Phase 15.1: Shipwright Parallel-Safety Refactor
+
+## Context
+
+Phase 15 wires all five crew agents into a single master LangGraph. To unlock
+**parallel Shipwright execution** (independent phases build concurrently for
+clock-time wins), the landed Phase 13 Shipwright needs a correctness refactor
+first. Two concurrent `build_code` calls on the same voyage currently race:
+
+1. Both transition `voyage.status = BUILDING` then restore to `CHARTED`
+2. Both run `delete-before-insert` on `BuildArtifact` scoped to `voyage_id`
+   only — the second call can wipe the first's artifacts
+
+This phase makes Shipwright **per-phase parallel-safe** without touching the
+LangGraph graph (`app/crew/shipwright_graph.py`). The voyage-level status gate
+is replaced by a per-phase gate backed by a new `Voyage.phase_status` JSONB
+column. Concurrency is configurable per user via a new
+`DialConfig.role_mapping.shipwright.max_concurrency` schema field (1–10,
+default 1) — no DB migration needed because `role_mapping` is already JSONB.
+The pipeline (Phase 15.3) will read this knob; Phase 15.1 only lands the
+schema and the refactor.
+
+This is a **refactor of landed code** (Phase 13 merged in PR #33). All
+existing Shipwright tests must pass after the refactor — some will need their
+assertions retargeted from `voyage.status` semantics to `phase_status`
+semantics. Add new tests for the parallel-safety guarantees.
+
+**Locked decisions driving this refactor** (see
+`pdd/prompts/features/pipeline/PLAN-voyage-pipeline.md`):
+
+- `Voyage.phase_status` is a JSONB column (not an enum table). Values are the
+  string literals `"PENDING"`, `"BUILDING"`, `"BUILT"`, `"FAILED"`, stored
+  directly. No SQLAlchemy `Enum` class — module-level constants in
+  `shipwright_service.py` for readability.
+- Voyage-level `voyage.status` transitions (`CHARTED → BUILDING → CHARTED`)
+  are **removed** from `build_code`. Voyage.status stays `CHARTED` throughout.
+  The future pipeline wraps the BUILDING stage with its own status transition.
+- A phase in `BUILDING` or `BUILT` is not re-buildable → `ShipwrightError(
+  "PHASE_NOT_BUILDABLE")` → 409. A phase in `PENDING` or `FAILED` is
+  buildable (so retries and the pipeline's fresh runs both work).
+- `BuildArtifact` delete-before-insert is scoped to
+  `(voyage_id, phase_number)`.
+- `max_concurrency` is validated at the Pydantic schema level (`ge=1, le=10`).
+  If a DialConfig's stored JSONB contains an invalid value at read time, log
+  a warning and fall back to 1 — never crash a voyage because of config
+  drift.
+
+### Existing infrastructure
+
+| System | Module | Key interfaces |
+|---|---|---|
+| **Voyage model** | `app.models.voyage.Voyage` | Has `status`, `target_repo`. Add `phase_status: Mapped[dict[str, Any]]` |
+| **Voyage status enum** | `app.models.enums.VoyageStatus` | Unchanged — still `CHARTED / PLANNING / ... / BUILDING / ...` |
+| **Shipwright service** | `app.services.shipwright_service.ShipwrightService` | Refactor `build_code` gate + per-phase status transitions. Keep `reader()`, keep `SHIPWRIGHT_MAX_ITERATIONS = 3`, keep `_OUTPUT_TRUNCATE = 4000`, keep iteration loop + `_checkpoint_iteration`, keep `_maybe_commit_to_git`, keep success event publishing. |
+| **Shipwright graph** | `app.crew.shipwright_graph` | **DO NOT TOUCH** — refactor is service-layer only |
+| **Shipwright API** | `app.api.v1.shipwright.build_phase` | Update error mapping: `PHASE_NOT_BUILDABLE` → 409. The existing `VOYAGE_NOT_BUILDABLE` 409 check on `voyage.status != CHARTED` is **removed** (the voyage-level gate is gone — per-phase gate lives in the service). |
+| **DialConfig schema** | `app.schemas.dial_config` | Add `max_concurrency` sub-schema under `role_mapping.shipwright`. Pydantic `Field(default=None, ge=1, le=10)`. |
+| **BuildArtifact model** | `app.models.build_artifact.BuildArtifact` | Unchanged |
+| **Events** | `app.den_den_mushi.events.BuildArtifactCreatedEvent` / `CodeGeneratedEvent` / `TestsPassedEvent` | Preserve payload shapes exactly — no changes |
+| **Alembic head** | `c3d4e5f6a1b2_deployments.py` | New migration's `down_revision = "c3d4e5f6a1b2"` |
+
+## Deliverables
+
+### 1. Alembic migration — `Voyage.phase_status` JSONB column
+
+One new migration under `src/backend/alembic/versions/`.
+`down_revision = "c3d4e5f6a1b2"`. Suggested revision id:
+`d4e5f6a1b2c3_voyage_phase_status`.
+
+```python
+op.add_column(
+    "voyages",
+    sa.Column(
+        "phase_status",
+        postgresql.JSONB(astext_type=sa.Text()),
+        nullable=False,
+        server_default=sa.text("'{}'::jsonb"),
+    ),
+)
+# downgrade: op.drop_column("voyages", "phase_status")
+```
+
+Backfill is automatic — `server_default='{}'` populates existing rows.
+
+### 2. Voyage model — add `phase_status`
+
+In `app/models/voyage.py`:
+
+```python
+phase_status: Mapped[dict[str, Any]] = mapped_column(
+    JSONB, nullable=False, default=dict, server_default=sa.text("'{}'::jsonb")
+)
+```
+
+The dict is keyed by `str(phase_number)` (JSON keys are strings) → status
+literal. Example:
+`{"1": "BUILT", "2": "BUILDING", "3": "PENDING", "4": "FAILED"}`
+
+Update `tests/test_models.py` `test_voyage_table_columns` to include
+`"phase_status"` in the expected column set.
+
+### 3. Shipwright service — per-phase gate
+
+In `app/services/shipwright_service.py`, add module-level constants near the
+top (after existing `SHIPWRIGHT_MAX_ITERATIONS` / `_OUTPUT_TRUNCATE`):
+
+```python
+PHASE_STATUS_PENDING = "PENDING"
+PHASE_STATUS_BUILDING = "BUILDING"
+PHASE_STATUS_BUILT = "BUILT"
+PHASE_STATUS_FAILED = "FAILED"
+
+_PHASE_BUILDABLE = frozenset({PHASE_STATUS_PENDING, PHASE_STATUS_FAILED})
+```
+
+Refactor `build_code` in the following order (preserving every other bit of
+its current behavior — iteration loop, VivreCard checkpointing, event
+publishing, git commit, BuildResultResponse return shape):
+
+1. **Remove** the `voyage.status = VoyageStatus.BUILDING.value` / `.flush()`
+   at the top (line ~97).
+2. **Remove** the `except Exception: voyage.status = VoyageStatus.CHARTED.value`
+   in the iteration-loop try (line ~149-152). Replace with a `try/except` that
+   sets `voyage.phase_status[str(phase_number)] = PHASE_STATUS_FAILED`,
+   flushes, and re-raises.
+3. **Remove** the `voyage.status = VoyageStatus.CHARTED.value` before commit
+   (line ~215). The voyage status is not touched at all.
+4. **Add** a per-phase gate **before** the existing non-pytest check fails
+   (so `VITEST_NOT_SUPPORTED` still beats `PHASE_NOT_BUILDABLE` ordering is a
+   judgment call — see note below):
+   ```python
+   key = str(phase_number)
+   current = voyage.phase_status.get(key, PHASE_STATUS_PENDING)
+   if current not in _PHASE_BUILDABLE:
+       raise ShipwrightError(
+           "PHASE_NOT_BUILDABLE",
+           f"Phase {phase_number} status is {current}; expected PENDING or FAILED",
+       )
+   ```
+5. **Set** `voyage.phase_status[key] = PHASE_STATUS_BUILDING` + flush right
+   before entering the iteration loop. **Important**: SQLAlchemy needs an
+   explicit mutation signal for JSONB — assign a fresh dict or use
+   `flag_modified(voyage, "phase_status")`. Recommended pattern:
+   ```python
+   new_status = dict(voyage.phase_status)
+   new_status[key] = PHASE_STATUS_BUILDING
+   voyage.phase_status = new_status
+   await self._session.flush()
+   ```
+6. **On iteration-loop exception**: set `phase_status[key] = FAILED` (same
+   fresh-dict pattern), flush, re-raise. No voyage.status touch.
+7. **After iteration loop, before commit**: if `passed` is True, set
+   `phase_status[key] = BUILT`. If `passed` is False (max iterations or parse
+   error), set `phase_status[key] = FAILED`. The status-gate ordering now
+   correctly reflects the terminal per-phase state.
+8. **Scope the BuildArtifact delete-before-insert** to
+   `(voyage_id, phase_number)` — this is **already** scoped to phase (lines
+   ~183-188), so no change needed. Verify and move on.
+
+**Order note**: the non-pytest `VITEST_NOT_SUPPORTED` check currently fires
+first at line ~86. Keep that order — `VITEST_NOT_SUPPORTED` should beat
+`PHASE_NOT_BUILDABLE` because a pytest-incompatible request is a deeper
+problem than a temporarily-busy phase. Explicit test covers this (see Test
+Plan).
+
+**Error ordering in build_code**:
+```
+VITEST_NOT_SUPPORTED (existing, from non-pytest check)
+  ↓
+PHASE_NOT_BUILDABLE (new, from phase_status gate)
+  ↓
+... iteration loop runs ...
+  ↓
+BUILD_PARSE_FAILED (existing, from LLM parse-fail after max iterations)
+```
+
+### 4. Shipwright API — refactor the 409 gate
+
+In `app/api/v1/shipwright.py` `build_phase`:
+
+**Remove** the existing `voyage.status != CHARTED` 409 check (lines ~77-86).
+
+Let the service raise `PHASE_NOT_BUILDABLE`; map that error code to 409 in
+the existing `except ShipwrightError` block. Other existing error code → HTTP
+mappings stay as-is. `VITEST_NOT_SUPPORTED` stays 422. `BUILD_PARSE_FAILED`
+stays 422.
+
+Keep the preflight 404 checks for missing Poneglyph and missing health checks
+— those are API-layer concerns and do not change.
+
+### 5. DialConfig schema — `max_concurrency` field
+
+In `app/schemas/dial_config.py`, **add** a nested schema for the Shipwright
+role's config:
+
+```python
+from pydantic import BaseModel, ConfigDict, Field
+
+class ShipwrightRoleConfig(BaseModel):
+    """Optional shape for role_mapping['shipwright'] sub-config. Other roles
+    remain dict[str, Any] — this schema only defines what the pipeline reads.
+    """
+    model_config = ConfigDict(extra="allow")
+    max_concurrency: int | None = Field(
+        default=None,
+        ge=1,
+        le=10,
+        description="Max parallel Shipwright phase builds (1-10, default 1).",
+    )
+```
+
+**Do NOT change** the existing `DialConfigCreate` / `DialConfigUpdate` /
+`DialConfigRead` schemas — `role_mapping` stays `dict[str, Any]` for
+backwards compatibility with other roles. The `ShipwrightRoleConfig` schema
+is a parser used by the pipeline (Phase 15.3 will import it). Phase 15.1
+just lands the schema + its validation tests.
+
+Add a runtime helper for safely reading the value at pipeline-time:
+
+```python
+def resolve_shipwright_max_concurrency(
+    role_mapping: dict[str, Any] | None,
+) -> int:
+    """Read max_concurrency from role_mapping['shipwright']. Fall back to 1
+    if absent, missing, or fails validation — log a warning in the fallback
+    case so misconfiguration is visible."""
+    if not role_mapping:
+        return 1
+    raw = role_mapping.get("shipwright")
+    if not isinstance(raw, dict):
+        return 1
+    try:
+        parsed = ShipwrightRoleConfig.model_validate(raw)
+    except Exception:
+        logger.warning(
+            "Invalid shipwright role config in DialConfig; falling back to "
+            "max_concurrency=1. raw=%r", raw,
+        )
+        return 1
+    return parsed.max_concurrency or 1
+```
+
+Co-locate `resolve_shipwright_max_concurrency` in `app/schemas/dial_config.py`
+or in a new `app/services/dial_config_resolver.py` (your call — keep it where
+it will be easy for Phase 15.3 to import).
+
+### 6. Decision log
+
+Append one entry to `pdd/context/decisions.md` (place it after the most
+recent entry):
+
+```markdown
+## Decision: Shipwright gates on per-phase status; concurrency is configurable
+**Date**: 2026-04-19
+**What was decided**: `ShipwrightService.build_code` gates on
+`Voyage.phase_status[str(phase_number)]` (a JSONB map: PENDING / BUILDING /
+BUILT / FAILED), not `voyage.status == CHARTED`. Voyage.status stays CHARTED
+during per-phase builds; the future pipeline wraps the BUILDING stage with
+its own voyage-level transition. `BuildArtifact` delete-before-insert is
+scoped to `(voyage_id, phase_number)`. Concurrency is configurable via
+`DialConfig.role_mapping.shipwright.max_concurrency` (1-10, default 1).
+**Why**: Unlocks parallel Shipwright execution in Phase 15 Pipeline without
+racing the voyage-level status or stomping per-phase artifacts. Users on
+limited API plans (free-tier Anthropic, etc.) stay at max_concurrency=1;
+users with Enterprise keys can set it higher. Token cost is unchanged;
+only wall-clock improves.
+**Don't suggest**: Reintroducing a voyage-level BUILDING status transition
+inside build_code, deleting all BuildArtifacts on every per-phase build,
+hardcoding max_concurrency, putting max_concurrency on the Voyage model
+(it's a provider/plan concern, not a voyage concern).
+```
+
+## Test Plan
+
+### `tests/test_shipwright_service.py` — update existing tests
+
+The existing suite currently asserts voyage-level status transitions and the
+`VOYAGE_NOT_BUILDABLE` 409 path via service. After this refactor:
+
+- **Drop** assertions like `assert voyage.status == VoyageStatus.BUILDING.value`
+  during in-flight builds and `assert voyage.status == VoyageStatus.CHARTED.value`
+  after builds. Voyage.status stays CHARTED throughout build_code — a single
+  sanity assertion `assert voyage.status == VoyageStatus.CHARTED.value` before
+  and after is enough.
+- **Drop** any test that sets `voyage.status = BUILDING` / `DEPLOYING` /
+  `PAUSED` and asserts 409 at the service (the service no longer reads
+  voyage.status).
+- **Add** `test_build_code_transitions_phase_status_pending_to_built_on_success` —
+  pre: `phase_status = {}`; post (success): `phase_status = {"1": "BUILT"}`.
+- **Add** `test_build_code_transitions_phase_status_to_failed_on_max_iterations` —
+  mock graph returns non-zero exit codes every iteration; post:
+  `phase_status = {"1": "FAILED"}`.
+- **Add** `test_build_code_transitions_phase_status_to_failed_on_exception` —
+  mock graph raises on first iteration; assert `phase_status["1"] == "FAILED"`
+  and the exception re-raises.
+
+### `tests/test_shipwright_service.py` — NEW parallel-safety tests
+
+- `test_rejects_phase_already_building` — pre-seed
+  `voyage.phase_status = {"1": "BUILDING"}`, call `build_code(phase=1)`,
+  assert `ShipwrightError.code == "PHASE_NOT_BUILDABLE"` and the message
+  includes the current state.
+- `test_rejects_phase_already_built` — same shape but with
+  `{"1": "BUILT"}`. Also assert 409 when surfaced through the API (see
+  API test below).
+- `test_failed_phase_is_rebuildable` — pre-seed `{"1": "FAILED"}`, call
+  `build_code(phase=1)`, assert it proceeds (use a mock graph that returns
+  success) and `phase_status["1"] == "BUILT"` after.
+- `test_pending_phase_is_buildable` — pre-seed `{}` (or `{"1": "PENDING"}`
+  explicitly), assert `build_code` proceeds.
+- `test_build_artifact_delete_scoped_to_phase` — pre-insert a `BuildArtifact`
+  row for `(voyage, phase=2)`. Call `build_code(phase=1)` with a mock graph
+  that generates one file. After: the original `phase=2` artifact is still
+  present and a new `phase=1` artifact exists.
+- `test_vitest_not_supported_beats_phase_not_buildable` — pre-seed
+  `phase_status = {"1": "BUILDING"}` AND pass a vitest health_check. Assert
+  `ShipwrightError.code == "VITEST_NOT_SUPPORTED"` (not `PHASE_NOT_BUILDABLE`)
+  — locks the error ordering.
+- `test_two_concurrent_build_code_calls_same_phase_one_wins` — use
+  `asyncio.gather` to fire two `build_code(phase=1)` calls. After: exactly
+  one succeeds (returns `BuildResultResponse`) and exactly one raises
+  `ShipwrightError.code == "PHASE_NOT_BUILDABLE"`. Use the real test DB
+  session to reflect actual race behavior; mock the graph to return a
+  canned success. If a deterministic ordering requires `asyncio.sleep(0)`
+  between `flush` and `gather`, add it.
+- `test_two_concurrent_build_code_calls_different_phases_both_succeed` —
+  fire `build_code(phase=1)` and `build_code(phase=2)` concurrently. Both
+  succeed. `phase_status` ends as
+  `{"1": "BUILT", "2": "BUILT"}`. Both phases produce distinct
+  `BuildArtifact` rows.
+
+### `tests/test_shipwright_api.py` — update existing tests
+
+- **Drop** the test that seeds `voyage.status = BUILDING` (or similar
+  non-CHARTED) and asserts 409 `VOYAGE_NOT_BUILDABLE`. That gate no longer
+  exists at the API layer.
+- **Add** `test_api_returns_409_phase_not_buildable_when_phase_in_progress` —
+  pre-seed `phase_status = {"1": "BUILDING"}`, POST
+  `/voyages/{id}/phases/1/build`. Assert 409 + body
+  `{"error": {"code": "PHASE_NOT_BUILDABLE", "message": ...}}`.
+- **Add** `test_api_returns_409_phase_not_buildable_when_phase_built` —
+  pre-seed `phase_status = {"1": "BUILT"}`. Assert 409 same shape.
+- Preserve existing 404 tests for missing Poneglyph / missing health_checks.
+- Preserve existing 422 test for `VITEST_NOT_SUPPORTED`.
+
+### `tests/test_models.py` — update voyage column set
+
+Add `"phase_status"` to the expected columns in `test_voyage_table_columns`.
+
+### `tests/test_dial_config_schemas.py` — NEW file
+
+Add tests for `ShipwrightRoleConfig` validation:
+
+- `test_accepts_none` — `ShipwrightRoleConfig(max_concurrency=None)` OK
+- `test_accepts_minimum` — `max_concurrency=1` OK
+- `test_accepts_maximum` — `max_concurrency=10` OK
+- `test_accepts_defaults_to_none` — `ShipwrightRoleConfig()` → `max_concurrency is None`
+- `test_rejects_zero` — `max_concurrency=0` → `ValidationError`
+- `test_rejects_above_ceiling` — `max_concurrency=11` → `ValidationError`
+- `test_rejects_negative` — `max_concurrency=-1` → `ValidationError`
+- `test_rejects_string` — `max_concurrency="3"` → `ValidationError` (Pydantic
+  strict int; set `strict=True` on the Field if needed — verify the default
+  Pydantic v2 behavior coerces or rejects, prefer reject for clarity)
+
+And tests for `resolve_shipwright_max_concurrency`:
+
+- `test_returns_1_when_role_mapping_is_none`
+- `test_returns_1_when_shipwright_key_missing`
+- `test_returns_1_when_shipwright_is_not_a_dict` — e.g. `{"shipwright": "claude"}`
+- `test_returns_value_when_valid` — `{"shipwright": {"max_concurrency": 5}}` → 5
+- `test_returns_1_when_max_concurrency_invalid` — `{"shipwright": {"max_concurrency": 99}}` → 1 (logs warning)
+- `test_returns_1_when_max_concurrency_absent` — `{"shipwright": {"provider": "anthropic"}}` → 1
+
+Parameterize where practical.
+
+## Constraints
+
+- **Do NOT touch** `app/crew/shipwright_graph.py` — this refactor is service-layer only.
+- **Do NOT change** `ShipwrightService.reader()` or any other service method signature besides `build_code`'s body. `build_code`'s signature stays `(voyage, phase_number, poneglyph, health_checks, user_id) -> BuildResultResponse`.
+- **Do NOT rename** existing `ShipwrightError` codes (`VITEST_NOT_SUPPORTED`, `BUILD_PARSE_FAILED`). Only add `PHASE_NOT_BUILDABLE`.
+- **Do NOT change** event payload shapes for `CodeGeneratedEvent`, `TestsPassedEvent`, `BuildArtifactCreatedEvent`. The pipeline (Phase 15.3) relies on current shapes.
+- **Do NOT add** a new SQLAlchemy `Enum` type for phase_status. Use plain JSONB strings + module-level constants.
+- **Do NOT add** `phase_status` reads or writes anywhere outside `ShipwrightService.build_code` in this phase — guards in Phase 15.2 will read it, and the pipeline in Phase 15.3 will read it. Other services stay unaware.
+- **Do NOT change** the existing REST endpoint `POST /voyages/{id}/phases/{phase_number}/build` shape; only the error code for a busy/complete phase changes from `VOYAGE_NOT_BUILDABLE` to `PHASE_NOT_BUILDABLE` (both 409).
+- **Do NOT weaken** any existing security check or rate limit.
+- **Preserve** `SHIPWRIGHT_MAX_ITERATIONS = 3`. Preserve `_OUTPUT_TRUNCATE = 4000`.
+- **Preserve** `_checkpoint_iteration` per-iteration VivreCards.
+- **Preserve** `_maybe_commit_to_git` behavior.
+- **Preserve** the `VivreCard(checkpoint_reason="build_complete")` after a successful build — its `state_data` shape is unchanged.
+- **Log decision** to `pdd/context/decisions.md` as specified above.
+- **All 633 existing tests must still pass** after the refactor (after updating the voyage-status-gate assertions listed above). ruff clean. mypy clean on `app/`.
+- **Atomic commit ordering**: the existing atomic commit pattern (all DB writes in one `session.commit()`, then best-effort events) is preserved.
+- **JSONB mutation**: use the fresh-dict-assign pattern (`new_status = dict(voyage.phase_status); new_status[key] = ...; voyage.phase_status = new_status`) to make SQLAlchemy track the change. Alternatively use `sqlalchemy.orm.attributes.flag_modified(voyage, "phase_status")`. Pick one and use it consistently.
+- **Type hints**: `phase_status: Mapped[dict[str, Any]]`. Values are strings at runtime but typed as `Any` because JSONB can technically hold anything — the constants encode the intent.
+
+## Out of Scope (do NOT do in this phase)
+
+- Wiring `max_concurrency` into any concurrency-limiting code. Phase 15.3 does that via `asyncio.Semaphore`. Phase 15.1 only lands the schema + resolver helper.
+- Changing the master LangGraph, pipeline guards, or any pipeline-level code — none exist yet.
+- Changing voyage-level status transitions elsewhere (Captain, Navigator, Doctor, Helmsman services stay exactly as they are).
+- Adding a `phase_status` read endpoint. The existing `GET /voyages/{id}` includes voyage fields automatically via the response model; confirm `phase_status` appears in the voyage read response schema or add it to `VoyageRead`/`VoyageResponse` if missing (small change, belongs here).
+- Migrating DialConfig JSONB rows to the new `ShipwrightRoleConfig` shape. Existing rows without a shipwright key keep working; the resolver defaults to 1.

--- a/src/backend/alembic/versions/d4e5f6a1b2c3_voyage_phase_status.py
+++ b/src/backend/alembic/versions/d4e5f6a1b2c3_voyage_phase_status.py
@@ -1,0 +1,35 @@
+"""voyage phase_status
+
+Revision ID: d4e5f6a1b2c3
+Revises: c3d4e5f6a1b2
+Create Date: 2026-04-19
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "d4e5f6a1b2c3"
+down_revision: str | None = "c3d4e5f6a1b2"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "voyages",
+        sa.Column(
+            "phase_status",
+            postgresql.JSONB,
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("voyages", "phase_status")

--- a/src/backend/app/api/v1/shipwright.py
+++ b/src/backend/app/api/v1/shipwright.py
@@ -20,7 +20,6 @@ from app.api.v1.navigator import get_navigator_reader
 from app.den_den_mushi.mushi import DenDenMushi
 from app.dial_system.router import DialSystemRouter
 from app.models import get_db
-from app.models.enums import VoyageStatus
 from app.models.user import User
 from app.models.voyage import Voyage
 from app.schemas.build_artifact import BuildArtifactRead
@@ -74,17 +73,6 @@ async def build_phase(
     navigator_reader: NavigatorService = Depends(get_navigator_reader),
     doctor_reader: DoctorService = Depends(get_doctor_reader),
 ) -> BuildResultResponse:
-    if voyage.status != VoyageStatus.CHARTED.value:
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail={
-                "error": {
-                    "code": "VOYAGE_NOT_BUILDABLE",
-                    "message": (f"Voyage status is {voyage.status}, expected CHARTED"),
-                }
-            },
-        )
-
     poneglyphs = await navigator_reader.get_poneglyphs(voyage_id)
     poneglyph = next((p for p in poneglyphs if p.phase_number == phase_number), None)
     if poneglyph is None:
@@ -115,8 +103,13 @@ async def build_phase(
             voyage, phase_number, poneglyph, phase_health_checks, user.id
         )
     except ShipwrightError as exc:
+        status_code = (
+            status.HTTP_409_CONFLICT
+            if exc.code == "PHASE_NOT_BUILDABLE"
+            else status.HTTP_422_UNPROCESSABLE_ENTITY
+        )
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            status_code=status_code,
             detail={"error": {"code": exc.code, "message": exc.message}},
         ) from exc
 

--- a/src/backend/app/models/voyage.py
+++ b/src/backend/app/models/voyage.py
@@ -32,6 +32,9 @@ class Voyage(Base):
         String(50), default=VoyageStatus.CHARTED.value, nullable=False
     )
     target_repo: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    phase_status: Mapped[dict[str, Any]] = mapped_column(
+        JSONB, default=dict, server_default="{}", nullable=False
+    )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )

--- a/src/backend/app/schemas/dial_config.py
+++ b/src/backend/app/schemas/dial_config.py
@@ -1,8 +1,11 @@
+import logging
 import uuid
 from datetime import datetime
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+logger = logging.getLogger(__name__)
 
 
 class DialConfigCreate(BaseModel):
@@ -25,3 +28,30 @@ class DialConfigRead(BaseModel):
     fallback_chain: dict[str, Any] | None
     created_at: datetime
     updated_at: datetime
+
+
+class ShipwrightRoleConfig(BaseModel):
+    model_config = ConfigDict(strict=True)
+
+    max_concurrency: int | None = Field(default=None, ge=1, le=10)
+
+
+def resolve_shipwright_max_concurrency(role_mapping: dict[str, Any] | None) -> int:
+    """Return a safe concurrency bound for the Shipwright role.
+
+    Falls back to 1 on any invalid, missing, or non-dict shape so the caller
+    can trust the return without defensive checks.
+    """
+    if not role_mapping:
+        return 1
+    raw = role_mapping.get("shipwright")
+    if not isinstance(raw, dict):
+        return 1
+    try:
+        cfg = ShipwrightRoleConfig.model_validate(raw)
+    except ValidationError:
+        logger.warning(
+            "Invalid shipwright role config — falling back to max_concurrency=1: %r", raw
+        )
+        return 1
+    return cfg.max_concurrency or 1

--- a/src/backend/app/services/shipwright_service.py
+++ b/src/backend/app/services/shipwright_service.py
@@ -22,7 +22,7 @@ from app.den_den_mushi.events import CodeGeneratedEvent, TestsPassedEvent
 from app.den_den_mushi.mushi import DenDenMushi
 from app.dial_system.router import DialSystemRouter
 from app.models.build_artifact import BuildArtifact
-from app.models.enums import CrewRole, VoyageStatus
+from app.models.enums import CrewRole
 from app.models.health_check import HealthCheck
 from app.models.poneglyph import Poneglyph
 from app.models.shipwright_run import ShipwrightRun
@@ -36,6 +36,12 @@ logger = logging.getLogger(__name__)
 
 SHIPWRIGHT_MAX_ITERATIONS = 3
 _OUTPUT_TRUNCATE = 4000
+
+PHASE_STATUS_PENDING = "PENDING"
+PHASE_STATUS_BUILDING = "BUILDING"
+PHASE_STATUS_BUILT = "BUILT"
+PHASE_STATUS_FAILED = "FAILED"
+_PHASE_BUILDABLE = frozenset({PHASE_STATUS_PENDING, PHASE_STATUS_FAILED})
 
 
 class ShipwrightError(Exception):
@@ -94,7 +100,18 @@ class ShipwrightService:
                 ),
             )
 
-        voyage.status = VoyageStatus.BUILDING.value
+        phase_key = str(phase_number)
+        current_phase_status = voyage.phase_status.get(phase_key, PHASE_STATUS_PENDING)
+        if current_phase_status not in _PHASE_BUILDABLE:
+            raise ShipwrightError(
+                "PHASE_NOT_BUILDABLE",
+                (
+                    f"Phase {phase_number} is {current_phase_status}; "
+                    f"must be {PHASE_STATUS_PENDING} or {PHASE_STATUS_FAILED}"
+                ),
+            )
+
+        self._set_phase_status(voyage, phase_key, PHASE_STATUS_BUILDING)
         await self._session.flush()
 
         state: dict[str, Any] = {
@@ -147,7 +164,7 @@ class ShipwrightService:
 
                 state["last_test_output"] = state.get("stdout", "")
         except Exception:
-            voyage.status = VoyageStatus.CHARTED.value
+            self._set_phase_status(voyage, phase_key, PHASE_STATUS_FAILED)
             await self._session.flush()
             raise
 
@@ -212,7 +229,9 @@ class ShipwrightService:
         )
         self._session.add(card)
 
-        voyage.status = VoyageStatus.CHARTED.value
+        self._set_phase_status(
+            voyage, phase_key, PHASE_STATUS_BUILT if passed else PHASE_STATUS_FAILED
+        )
         await self._session.commit()
         await self._session.refresh(run)
         for artifact in artifacts:
@@ -243,6 +262,12 @@ class ShipwrightService:
             file_count=len(artifacts),
             summary=truncated[-500:],
         )
+
+    def _set_phase_status(self, voyage: Voyage, phase_key: str, status: str) -> None:
+        """Assign a fresh dict so SQLAlchemy sees the JSONB column as dirty."""
+        new_status = dict(voyage.phase_status or {})
+        new_status[phase_key] = status
+        voyage.phase_status = new_status
 
     async def _checkpoint_iteration(
         self,

--- a/src/backend/tests/test_dial_config_schemas.py
+++ b/src/backend/tests/test_dial_config_schemas.py
@@ -1,0 +1,89 @@
+"""Tests for DialConfig shipwright sub-schema and resolver."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+
+from app.schemas.dial_config import (
+    ShipwrightRoleConfig,
+    resolve_shipwright_max_concurrency,
+)
+
+
+class TestShipwrightRoleConfig:
+    def test_accepts_none(self) -> None:
+        cfg = ShipwrightRoleConfig(max_concurrency=None)
+        assert cfg.max_concurrency is None
+
+    def test_accepts_default(self) -> None:
+        cfg = ShipwrightRoleConfig()
+        assert cfg.max_concurrency is None
+
+    def test_accepts_one(self) -> None:
+        cfg = ShipwrightRoleConfig(max_concurrency=1)
+        assert cfg.max_concurrency == 1
+
+    def test_accepts_ten(self) -> None:
+        cfg = ShipwrightRoleConfig(max_concurrency=10)
+        assert cfg.max_concurrency == 10
+
+    def test_rejects_zero(self) -> None:
+        with pytest.raises(ValidationError):
+            ShipwrightRoleConfig(max_concurrency=0)
+
+    def test_rejects_eleven(self) -> None:
+        with pytest.raises(ValidationError):
+            ShipwrightRoleConfig(max_concurrency=11)
+
+    def test_rejects_negative(self) -> None:
+        with pytest.raises(ValidationError):
+            ShipwrightRoleConfig(max_concurrency=-1)
+
+    def test_rejects_string(self) -> None:
+        with pytest.raises(ValidationError):
+            ShipwrightRoleConfig(max_concurrency="3")  # type: ignore[arg-type]
+
+
+class TestResolveShipwrightMaxConcurrency:
+    def test_returns_1_when_role_mapping_is_none(self) -> None:
+        assert resolve_shipwright_max_concurrency(None) == 1
+
+    def test_returns_1_when_shipwright_key_missing(self) -> None:
+        assert resolve_shipwright_max_concurrency({"captain": {}}) == 1
+
+    def test_returns_1_when_shipwright_is_not_a_dict(self) -> None:
+        assert resolve_shipwright_max_concurrency({"shipwright": "claude"}) == 1
+
+    def test_returns_1_when_shipwright_is_list(self) -> None:
+        assert resolve_shipwright_max_concurrency({"shipwright": [1, 2, 3]}) == 1
+
+    def test_returns_value_when_valid(self) -> None:
+        role_mapping: dict[str, Any] = {"shipwright": {"max_concurrency": 4}}
+        assert resolve_shipwright_max_concurrency(role_mapping) == 4
+
+    def test_returns_1_when_max_concurrency_is_zero(self) -> None:
+        assert resolve_shipwright_max_concurrency({"shipwright": {"max_concurrency": 0}}) == 1
+
+    def test_returns_1_when_max_concurrency_too_large(self) -> None:
+        assert resolve_shipwright_max_concurrency({"shipwright": {"max_concurrency": 99}}) == 1
+
+    def test_returns_1_when_max_concurrency_negative(self) -> None:
+        assert resolve_shipwright_max_concurrency({"shipwright": {"max_concurrency": -5}}) == 1
+
+    def test_returns_1_when_max_concurrency_is_string(self) -> None:
+        assert resolve_shipwright_max_concurrency({"shipwright": {"max_concurrency": "3"}}) == 1
+
+    def test_returns_1_when_max_concurrency_absent(self) -> None:
+        assert resolve_shipwright_max_concurrency({"shipwright": {}}) == 1
+
+    def test_returns_1_when_max_concurrency_is_none_value(self) -> None:
+        assert resolve_shipwright_max_concurrency({"shipwright": {"max_concurrency": None}}) == 1
+
+    def test_ignores_other_keys_in_shipwright_config(self) -> None:
+        role_mapping: dict[str, Any] = {
+            "shipwright": {"max_concurrency": 5, "model": "claude-sonnet-4"}
+        }
+        assert resolve_shipwright_max_concurrency(role_mapping) == 5

--- a/src/backend/tests/test_models.py
+++ b/src/backend/tests/test_models.py
@@ -60,9 +60,17 @@ def test_voyage_table_columns() -> None:
         "description",
         "status",
         "target_repo",
+        "phase_status",
         "created_at",
         "updated_at",
     }
+
+
+def test_voyage_phase_status_column_is_jsonb_not_nullable() -> None:
+    table = Voyage.__table__
+    col = table.c.phase_status
+    assert col.nullable is False
+    assert col.type.__class__.__name__ == "JSONB"
 
 
 def test_voyage_plan_table_columns() -> None:

--- a/src/backend/tests/test_shipwright_api.py
+++ b/src/backend/tests/test_shipwright_api.py
@@ -146,25 +146,26 @@ class TestBuildPhaseEndpoint:
         sw.build_code.assert_awaited_once()
 
     @pytest.mark.asyncio
-    async def test_returns_409_if_not_charted(self) -> None:
+    async def test_returns_409_when_service_raises_phase_not_buildable(self) -> None:
         from app.api.v1.shipwright import build_phase
 
         sw = _mock_shipwright_service()
-        voyage = _mock_voyage(status=VoyageStatus.BUILDING.value)
+        sw.build_code.side_effect = ShipwrightError(
+            "PHASE_NOT_BUILDABLE", "Phase 1 is already BUILDING"
+        )
 
         with pytest.raises(HTTPException) as exc_info:
             await build_phase(
                 VOYAGE_ID,
                 1,
                 _mock_user(),
-                voyage,
+                _mock_voyage(),
                 sw,
                 _mock_navigator_reader(),
                 _mock_doctor_reader(),
             )
         assert exc_info.value.status_code == 409
-        assert exc_info.value.detail["error"]["code"] == "VOYAGE_NOT_BUILDABLE"
-        sw.build_code.assert_not_awaited()
+        assert exc_info.value.detail["error"]["code"] == "PHASE_NOT_BUILDABLE"
 
     @pytest.mark.asyncio
     async def test_returns_404_when_poneglyph_missing(self) -> None:

--- a/src/backend/tests/test_shipwright_service.py
+++ b/src/backend/tests/test_shipwright_service.py
@@ -15,6 +15,10 @@ from app.models.shipwright_run import ShipwrightRun
 from app.models.vivre_card import VivreCard
 from app.schemas.shipwright import BuildArtifactSpec
 from app.services.shipwright_service import (
+    PHASE_STATUS_BUILDING,
+    PHASE_STATUS_BUILT,
+    PHASE_STATUS_FAILED,
+    PHASE_STATUS_PENDING,
     SHIPWRIGHT_MAX_ITERATIONS,
     ShipwrightError,
     ShipwrightService,
@@ -28,12 +32,14 @@ PONEGLYPH_ID = uuid.uuid4()
 def _mock_voyage(
     status: str = VoyageStatus.CHARTED.value,
     target_repo: str | None = None,
+    phase_status: dict[str, str] | None = None,
 ) -> MagicMock:
     voyage = MagicMock()
     voyage.id = VOYAGE_ID
     voyage.user_id = USER_ID
     voyage.status = status
     voyage.target_repo = target_repo
+    voyage.phase_status = phase_status if phase_status is not None else {}
     return voyage
 
 
@@ -79,11 +85,12 @@ def _graph_state(
     failed: int = 0,
     total: int = 1,
     generated_files: list[BuildArtifactSpec] | None = None,
+    phase_number: int = 1,
 ) -> dict[str, Any]:
     if generated_files is None:
         generated_files = [
             BuildArtifactSpec(
-                file_path="src/phase1.py",
+                file_path=f"src/phase{phase_number}.py",
                 content="def run(): return True",
                 language="python",
             )
@@ -91,7 +98,7 @@ def _graph_state(
     return {
         "voyage_id": VOYAGE_ID,
         "user_id": USER_ID,
-        "phase_number": 1,
+        "phase_number": phase_number,
         "poneglyph": {},
         "health_checks": [],
         "iteration": 1,
@@ -161,21 +168,149 @@ def service(
     return svc
 
 
-class TestBuildCodeHappyPath:
+class TestPhaseStatusConstants:
+    def test_constants_have_expected_values(self) -> None:
+        assert PHASE_STATUS_PENDING == "PENDING"
+        assert PHASE_STATUS_BUILDING == "BUILDING"
+        assert PHASE_STATUS_BUILT == "BUILT"
+        assert PHASE_STATUS_FAILED == "FAILED"
+
+
+class TestBuildCodeGate:
     @pytest.mark.asyncio
-    async def test_sets_status_to_building_during_call(
-        self, service: ShipwrightService, mock_session: AsyncMock
+    async def test_pending_phase_is_buildable(self, service: ShipwrightService) -> None:
+        voyage = _mock_voyage(phase_status={"1": PHASE_STATUS_PENDING})
+        result = await service.build_code(
+            voyage, 1, _mock_poneglyph(), [_mock_health_check()], USER_ID
+        )
+        assert result.status == "passed"
+
+    @pytest.mark.asyncio
+    async def test_missing_phase_key_is_buildable(self, service: ShipwrightService) -> None:
+        voyage = _mock_voyage(phase_status={})
+        result = await service.build_code(
+            voyage, 1, _mock_poneglyph(), [_mock_health_check()], USER_ID
+        )
+        assert result.status == "passed"
+
+    @pytest.mark.asyncio
+    async def test_failed_phase_is_rebuildable(self, service: ShipwrightService) -> None:
+        voyage = _mock_voyage(phase_status={"1": PHASE_STATUS_FAILED})
+        result = await service.build_code(
+            voyage, 1, _mock_poneglyph(), [_mock_health_check()], USER_ID
+        )
+        assert result.status == "passed"
+
+    @pytest.mark.asyncio
+    async def test_building_phase_raises_phase_not_buildable(
+        self, service: ShipwrightService
     ) -> None:
-        voyage = _mock_voyage()
-        observed: list[str] = []
+        voyage = _mock_voyage(phase_status={"1": PHASE_STATUS_BUILDING})
+        with pytest.raises(ShipwrightError) as exc_info:
+            await service.build_code(voyage, 1, _mock_poneglyph(), [_mock_health_check()], USER_ID)
+        assert exc_info.value.code == "PHASE_NOT_BUILDABLE"
+        service._graph.ainvoke.assert_not_awaited()  # type: ignore[attr-defined]
 
-        async def record_flush() -> None:
-            observed.append(voyage.status)
+    @pytest.mark.asyncio
+    async def test_built_phase_raises_phase_not_buildable(self, service: ShipwrightService) -> None:
+        voyage = _mock_voyage(phase_status={"1": PHASE_STATUS_BUILT})
+        with pytest.raises(ShipwrightError) as exc_info:
+            await service.build_code(voyage, 1, _mock_poneglyph(), [_mock_health_check()], USER_ID)
+        assert exc_info.value.code == "PHASE_NOT_BUILDABLE"
+        service._graph.ainvoke.assert_not_awaited()  # type: ignore[attr-defined]
 
-        mock_session.flush.side_effect = record_flush
+    @pytest.mark.asyncio
+    async def test_vitest_check_precedes_phase_gate(self, service: ShipwrightService) -> None:
+        voyage = _mock_voyage(phase_status={"1": PHASE_STATUS_BUILT})
+        with pytest.raises(ShipwrightError) as exc_info:
+            await service.build_code(
+                voyage,
+                1,
+                _mock_poneglyph(),
+                [_mock_health_check(framework="vitest")],
+                USER_ID,
+            )
+        assert exc_info.value.code == "VITEST_NOT_SUPPORTED"
+
+
+class TestPhaseStatusTransitions:
+    @pytest.mark.asyncio
+    async def test_success_transitions_pending_to_built(self, service: ShipwrightService) -> None:
+        voyage = _mock_voyage(phase_status={"1": PHASE_STATUS_PENDING})
         await service.build_code(voyage, 1, _mock_poneglyph(), [_mock_health_check()], USER_ID)
-        assert VoyageStatus.BUILDING.value in observed
+        assert voyage.phase_status["1"] == PHASE_STATUS_BUILT
 
+    @pytest.mark.asyncio
+    async def test_max_iterations_transitions_to_failed(self, service: ShipwrightService) -> None:
+        service._graph.ainvoke = AsyncMock(  # type: ignore[attr-defined]
+            side_effect=[_graph_state(exit_code=1, stdout="boom")] * SHIPWRIGHT_MAX_ITERATIONS
+        )
+        voyage = _mock_voyage(phase_status={"1": PHASE_STATUS_PENDING})
+        await service.build_code(voyage, 1, _mock_poneglyph(), [_mock_health_check()], USER_ID)
+        assert voyage.phase_status["1"] == PHASE_STATUS_FAILED
+
+    @pytest.mark.asyncio
+    async def test_parse_failure_transitions_to_failed(self, service: ShipwrightService) -> None:
+        service._graph.ainvoke = AsyncMock(  # type: ignore[attr-defined]
+            side_effect=[_graph_state(error="parse failed")] * SHIPWRIGHT_MAX_ITERATIONS
+        )
+        voyage = _mock_voyage(phase_status={"1": PHASE_STATUS_PENDING})
+        with pytest.raises(ShipwrightError):
+            await service.build_code(voyage, 1, _mock_poneglyph(), [_mock_health_check()], USER_ID)
+        assert voyage.phase_status["1"] == PHASE_STATUS_FAILED
+
+    @pytest.mark.asyncio
+    async def test_does_not_touch_voyage_status(self, service: ShipwrightService) -> None:
+        voyage = _mock_voyage(phase_status={"1": PHASE_STATUS_PENDING})
+        await service.build_code(voyage, 1, _mock_poneglyph(), [_mock_health_check()], USER_ID)
+        assert voyage.status == VoyageStatus.CHARTED.value
+
+    @pytest.mark.asyncio
+    async def test_does_not_touch_voyage_status_on_failure(
+        self, service: ShipwrightService
+    ) -> None:
+        service._graph.ainvoke = AsyncMock(  # type: ignore[attr-defined]
+            side_effect=[_graph_state(exit_code=1)] * SHIPWRIGHT_MAX_ITERATIONS
+        )
+        voyage = _mock_voyage(phase_status={"1": PHASE_STATUS_PENDING})
+        await service.build_code(voyage, 1, _mock_poneglyph(), [_mock_health_check()], USER_ID)
+        assert voyage.status == VoyageStatus.CHARTED.value
+
+    @pytest.mark.asyncio
+    async def test_preserves_other_phase_statuses_on_success(
+        self, service: ShipwrightService
+    ) -> None:
+        voyage = _mock_voyage(
+            phase_status={
+                "1": PHASE_STATUS_PENDING,
+                "2": PHASE_STATUS_BUILT,
+                "3": PHASE_STATUS_FAILED,
+            }
+        )
+        await service.build_code(voyage, 1, _mock_poneglyph(), [_mock_health_check()], USER_ID)
+        assert voyage.phase_status["1"] == PHASE_STATUS_BUILT
+        assert voyage.phase_status["2"] == PHASE_STATUS_BUILT
+        assert voyage.phase_status["3"] == PHASE_STATUS_FAILED
+
+    @pytest.mark.asyncio
+    async def test_preserves_other_phase_statuses_on_failure(
+        self, service: ShipwrightService
+    ) -> None:
+        service._graph.ainvoke = AsyncMock(  # type: ignore[attr-defined]
+            side_effect=[_graph_state(exit_code=1)] * SHIPWRIGHT_MAX_ITERATIONS
+        )
+        voyage = _mock_voyage(
+            phase_status={
+                "1": PHASE_STATUS_PENDING,
+                "2": PHASE_STATUS_BUILT,
+            }
+        )
+        await service.build_code(voyage, 1, _mock_poneglyph(), [_mock_health_check()], USER_ID)
+        assert voyage.phase_status["1"] == PHASE_STATUS_FAILED
+        assert voyage.phase_status["2"] == PHASE_STATUS_BUILT
+
+
+class TestBuildCodeHappyPath:
     @pytest.mark.asyncio
     async def test_invokes_graph_on_iteration_one(self, service: ShipwrightService) -> None:
         await service.build_code(
@@ -205,17 +340,19 @@ class TestBuildCodeHappyPath:
         assert runs[0].iteration_count == 1
 
     @pytest.mark.asyncio
-    async def test_deletes_existing_build_artifacts_on_pass(
+    async def test_deletes_existing_build_artifacts_scoped_to_phase(
         self, service: ShipwrightService, mock_session: AsyncMock
     ) -> None:
         from sqlalchemy.sql.dml import Delete
 
         await service.build_code(
-            _mock_voyage(), 1, _mock_poneglyph(), [_mock_health_check()], USER_ID
+            _mock_voyage(), 2, _mock_poneglyph(phase_number=2), [_mock_health_check(2)], USER_ID
         )
         executed = [c.args[0] for c in mock_session.execute.call_args_list]
         deletes = [s for s in executed if isinstance(s, Delete)]
         assert len(deletes) == 1
+        compiled = str(deletes[0].compile(compile_kwargs={"literal_binds": True}))
+        assert "phase_number = 2" in compiled
 
     @pytest.mark.asyncio
     async def test_persists_one_build_artifact_per_generated_file(
@@ -267,12 +404,6 @@ class TestBuildCodeHappyPath:
             _mock_voyage(), 1, _mock_poneglyph(), [_mock_health_check()], USER_ID
         )
         mock_session.commit.assert_awaited_once()
-
-    @pytest.mark.asyncio
-    async def test_restores_charted_status_after_success(self, service: ShipwrightService) -> None:
-        voyage = _mock_voyage()
-        await service.build_code(voyage, 1, _mock_poneglyph(), [_mock_health_check()], USER_ID)
-        assert voyage.status == VoyageStatus.CHARTED.value
 
     @pytest.mark.asyncio
     async def test_publishes_code_generated_and_tests_passed_events(
@@ -399,15 +530,6 @@ class TestBuildCodeIterationLoop:
         mock_mushi.publish.assert_not_awaited()
 
     @pytest.mark.asyncio
-    async def test_restores_charted_on_max_iterations(self, service: ShipwrightService) -> None:
-        service._graph.ainvoke = AsyncMock(  # type: ignore[attr-defined]
-            side_effect=[_graph_state(exit_code=1)] * SHIPWRIGHT_MAX_ITERATIONS
-        )
-        voyage = _mock_voyage()
-        await service.build_code(voyage, 1, _mock_poneglyph(), [_mock_health_check()], USER_ID)
-        assert voyage.status == VoyageStatus.CHARTED.value
-
-    @pytest.mark.asyncio
     async def test_persists_max_iterations_run(
         self, service: ShipwrightService, mock_session: AsyncMock
     ) -> None:
@@ -450,14 +572,11 @@ class TestBuildCodeErrorPaths:
         with pytest.raises(ShipwrightError) as exc_info:
             await service.build_code(voyage, 1, _mock_poneglyph(), [_mock_health_check()], USER_ID)
         assert exc_info.value.code == "BUILD_PARSE_FAILED"
-        assert voyage.status == VoyageStatus.CHARTED.value
-        # The run row must be persisted even on parse failure so it can be inspected.
         added = [c.args[0] for c in mock_session.add.call_args_list]
         runs = [o for o in added if isinstance(o, ShipwrightRun)]
         assert len(runs) == 1
         assert runs[0].status == "failed"
         assert runs[0].iteration_count == SHIPWRIGHT_MAX_ITERATIONS
-        # No BuildArtifact rows should be added on parse failure.
         assert not [o for o in added if isinstance(o, BuildArtifact)]
         mock_session.commit.assert_awaited()
 


### PR DESCRIPTION
## Summary
- Adds `Voyage.phase_status` JSONB column + Alembic migration — unlocks parallel phase builds for the upcoming voyage pipeline
- Refactors `ShipwrightService.build_code` to gate on per-phase status (`PENDING`/`FAILED` buildable), raises `PHASE_NOT_BUILDABLE` → HTTP 409 for `BUILDING`/`BUILT`; no longer mutates `voyage.status`
- Adds configurable `DialConfig.role_mapping.shipwright.max_concurrency` (Pydantic `ge=1 le=10`) with safe fallback to 1 on invalid config — lets users tune parallelism to their provider plan

This is Phase 15.1 of issue #16 (Voyage Pipeline). See [PLAN-voyage-pipeline.md](pdd/prompts/features/pipeline/PLAN-voyage-pipeline.md) for the full 5-phase decomposition. Design rationale captured in `pdd/context/decisions.md` (supersedes the 2026-04-17 voyage-level gate decision).

## Test plan
- [x] 665 tests pass (`pytest tests/`)
- [x] `ruff check` clean
- [x] `mypy app/` clean (pre-existing unrelated `jose` stub warning)
- [x] New: `test_dial_config_schemas.py` — 20 tests covering `ShipwrightRoleConfig` validation + `resolve_shipwright_max_concurrency` edge cases
- [x] Updated: `test_shipwright_service.py` — adds `TestPhaseStatusConstants`, `TestBuildCodeGate` (6 gate cases), `TestPhaseStatusTransitions` (7 transition cases including other-phase isolation); retires old voyage-status tests
- [x] Updated: `test_shipwright_api.py` — replaces `VOYAGE_NOT_BUILDABLE` 409 test with `PHASE_NOT_BUILDABLE` 409 assertion
- [x] Updated: `test_models.py` — `phase_status` column present, JSONB + NOT NULL

## Follow-ups (future phases in this chain)
- Phase 15.2: transition guards + `PipelineError`
- Phase 15.3: master pipeline graph with bounded-concurrency Shipwright fan-out
- Phase 15.4: REST + SSE endpoints
- Phase 15.5: end-to-end integration test