### PR TITLE
feat: pipeline transition guards and PipelineError (Phase 15.2) #16

### DIFF
--- a/pdd/context/decisions.md
+++ b/pdd/context/decisions.md
@@ -197,6 +197,14 @@
 
 ---
 
+## Decision: Pipeline transition guards as pure predicates
+**Date**: 2026-04-20
+**What was decided**: Added `app/services/pipeline_guards.py` with six `require_can_enter_*` helpers (`planning`, `pdd`, `tdd`, `building`, `reviewing`, `deploying`) and a single `PipelineError(code, message)` exception distinguished by `.code`. Guards take DB-loaded objects (voyage, plan, poneglyphs, health_checks, build_artifacts, validation_run) and raise on violation — no DB queries, no LLM calls, no event publishing, no state mutation. Error code taxonomy is 1:1 with guards: `VOYAGE_NOT_PLANNABLE`, `PLAN_MISSING`, `PONEGLYPHS_INCOMPLETE`, `HEALTH_CHECKS_INCOMPLETE`, `BUILD_INCOMPLETE`, `VALIDATION_NOT_PASSED`. "Can enter reviewing" checks both `BuildArtifact` presence AND `voyage.phase_status[str(phase)] == "BUILT"` for every planned phase — the first consumer of the Phase 15.1 `phase_status` gate.
+**Why**: The master pipeline has six stage transitions, each with different pre-conditions. Putting the checks inline in the graph nodes (Phase 15.3) would scatter invariants across six files and tangle scheduling with validation. Centralizing them as pure predicates means: one place to reason about "what does a voyage need to enter stage X," trivially unit-testable (no DB fixtures — 33 tests, 0.03s), and reusable as the engine for skip-already-satisfied-stages on resume. When a voyage resumes, the pipeline calls the *next* guard; if it passes, the stage's output already exists, so skip the stage + its LLM call entirely. That's token-cost savings on re-run after a fix.
+**Don't suggest**: Merging the guard module into `pipeline_service.py` (the separation is the point), one-exception-per-guard (`PlanMissingError`, `PoneglyphsIncompleteError` — unnecessary class sprawl, use `.code`), guards performing DB lookups (couples them to sessions and makes unit tests require mocked sessions), adding guards for status transitions the pipeline doesn't use (e.g. `require_can_enter_completed` — `finalize_node` owns that)
+
+---
+
 ## Decision: Configurable Shipwright concurrency via DialConfig (not env/global)
 **Date**: 2026-04-19
 **What was decided**: Added `ShipwrightRoleConfig.max_concurrency: int | None` (Pydantic `ge=1 le=10`) to `DialConfig.role_mapping.shipwright`. `resolve_shipwright_max_concurrency()` reads the value at pipeline-start time and falls back to `1` on any missing key, non-dict shape, validation failure, or `None`. No migration — piggybacks on the existing `role_mapping` JSONB.

--- a/pdd/prompts/features/pipeline/grandline-15-02-guards.md
+++ b/pdd/prompts/features/pipeline/grandline-15-02-guards.md
@@ -1,0 +1,237 @@
+# Phase 15.2: Transition Guards + PipelineError
+
+## Context
+
+Phase 15 wires all five crew agents into a single master LangGraph
+(`CHARTED → PLANNING → PDD → TDD → BUILDING → REVIEWING → DEPLOYING →
+COMPLETED`). Each stage transition has pre-conditions — the pipeline should
+refuse to enter a stage whose dependencies aren't satisfied (e.g. can't
+enter BUILDING unless every planned phase has a health_check).
+
+This phase centralizes those pre-conditions into **six pure predicate
+helpers** in a new module `app/services/pipeline_guards.py`. Each helper
+raises a single `PipelineError(code, message)` on violation. The helpers
+are declarative, DB-object-only (no DB access, no I/O, no LLM calls), and
+testable in isolation.
+
+These guards also drive **skip-already-satisfied-stages on resume**: when a
+voyage resumes from `PAUSED` or `FAILED`, the pipeline calls the guards to
+decide whether to re-run a stage or skip to the next. If Poneglyphs already
+cover every phase, there's no need to re-invoke the Navigator — the guard
+will pass and the pipeline moves on. That's a real token-cost savings on
+re-run after a fix.
+
+No graph logic, no service composition, no API endpoint work in this
+phase. Phase 15.3 will call these guards from `PipelineService`.
+
+**Locked decisions driving this phase** (see
+[PLAN-voyage-pipeline.md](PLAN-voyage-pipeline.md)):
+
+- Guards are **pure predicates** over DB-loaded objects. They receive the
+  Voyage and the relevant artifacts (plan, poneglyphs, health_checks,
+  build_artifacts, validation_run) — they do NOT query the DB themselves.
+  The caller (pipeline service) is responsible for loading.
+- Guards raise `PipelineError(code, message)` on violation. One exception
+  class for all pipeline-transition errors, distinguished by `.code`.
+- Every guard returns `None` on success (matches the existing
+  `HelmsmanError` / `DoctorError` / `ShipwrightError` "raise on failure"
+  convention across the codebase).
+- The **"can enter reviewing"** guard checks two things: every planned
+  phase has at least one `BuildArtifact` row, AND the voyage's
+  `phase_status[str(phase_number)] == "BUILT"` for every planned phase.
+  The `phase_status` check was introduced in Phase 15.1 — this guard is
+  its first consumer.
+- `Voyage.status` legal starting points for `require_can_enter_planning`:
+  `CHARTED`, `PAUSED`, `FAILED`. Re-running from `COMPLETED` or
+  `CANCELLED` requires explicit cancel/reset (out of scope for v1).
+
+## Deliverables
+
+### 1. New module: `app/services/pipeline_guards.py`
+
+**Exports**:
+
+- `PipelineError(Exception)` with `.code: str` and `.message: str`
+  attributes (mirroring `ShipwrightError` at
+  [src/backend/app/services/shipwright_service.py:41-47](src/backend/app/services/shipwright_service.py#L41-L47)
+  and `HelmsmanError` — same `__init__(self, code, message)` shape).
+- Six guard functions, each raising `PipelineError` on violation:
+  - `require_can_enter_planning(voyage: Voyage) -> None`
+  - `require_can_enter_pdd(voyage: Voyage, plan: VoyagePlan | None) -> None`
+  - `require_can_enter_tdd(voyage: Voyage, plan: VoyagePlan, poneglyphs: list[Poneglyph]) -> None`
+  - `require_can_enter_building(voyage: Voyage, plan: VoyagePlan, health_checks: list[HealthCheck]) -> None`
+  - `require_can_enter_reviewing(voyage: Voyage, plan: VoyagePlan, build_artifacts: list[BuildArtifact]) -> None`
+  - `require_can_enter_deploying(voyage: Voyage, latest_validation: ValidationRun | None) -> None`
+
+**Error code taxonomy** — lock each guard to exactly one code, so tests
+and callers can pattern-match without relying on message text:
+
+| Guard | Failure condition | Code |
+|---|---|---|
+| `require_can_enter_planning` | `voyage.status not in {CHARTED, PAUSED, FAILED}` | `VOYAGE_NOT_PLANNABLE` |
+| `require_can_enter_pdd` | `plan is None` | `PLAN_MISSING` |
+| `require_can_enter_tdd` | any planned phase has zero poneglyphs | `PONEGLYPHS_INCOMPLETE` |
+| `require_can_enter_building` | any planned phase has zero health_checks | `HEALTH_CHECKS_INCOMPLETE` |
+| `require_can_enter_reviewing` | any planned phase has zero artifacts OR `phase_status[str(phase)] != "BUILT"` for any planned phase | `BUILD_INCOMPLETE` |
+| `require_can_enter_deploying` | `latest_validation is None` OR `latest_validation.status != "passed"` | `VALIDATION_NOT_PASSED` |
+
+**Plan parsing**: guards that receive `plan: VoyagePlan` should pull the
+list of planned phase numbers from `plan.phases` (JSONB column).
+Parse via `VoyagePlanSpec.model_validate(plan.phases)` at
+[src/backend/app/schemas/captain.py:23](src/backend/app/schemas/captain.py#L23)
+and iterate `.phases`. Do NOT re-validate the dependency graph here —
+`VoyagePlanSpec.validate_plan_graph` already guarantees phase_number
+uniqueness + acyclic deps at write time. Guards just read the planned
+`phase_number`s.
+
+**Implementation notes**:
+
+- Use `from __future__ import annotations` at the top (matches the rest
+  of `app/services/`).
+- Import `VoyageStatus` from `app.models.enums` — don't hardcode the
+  string `"CHARTED"` etc.
+- Import `PHASE_STATUS_BUILT` from `app.services.shipwright_service`
+  (landed in Phase 15.1).
+- `Poneglyph` / `HealthCheck` / `BuildArtifact` / `ValidationRun` /
+  `Voyage` / `VoyagePlan` are all in `app.models.*`.
+- Error messages should name the specific missing phase(s) when
+  relevant: `f"Phases {sorted(missing)} missing health_checks"` — the
+  test suite will assert the phase numbers appear in the message for
+  the "incomplete" guards.
+- Keep each function under ~15 lines. These are predicates, not
+  workflows.
+- Module docstring: one-paragraph summary of the role of this file in
+  the pipeline (gatekeepers, pure predicates, no I/O).
+
+### 2. New tests: `tests/test_pipeline_guards.py`
+
+One test class per guard function. Cover:
+
+**`TestRequireCanEnterPlanning`**:
+- `test_allows_charted`
+- `test_allows_paused`
+- `test_allows_failed`
+- `test_rejects_completed` → `VOYAGE_NOT_PLANNABLE`
+- `test_rejects_planning` → `VOYAGE_NOT_PLANNABLE`
+- `test_rejects_cancelled` → `VOYAGE_NOT_PLANNABLE`
+
+**`TestRequireCanEnterPdd`**:
+- `test_allows_when_plan_exists`
+- `test_rejects_when_plan_is_none` → `PLAN_MISSING`
+
+**`TestRequireCanEnterTdd`**:
+- `test_allows_when_every_phase_has_poneglyph`
+- `test_rejects_when_any_phase_missing_poneglyph` → `PONEGLYPHS_INCOMPLETE`
+- `test_rejects_when_no_poneglyphs_at_all` → `PONEGLYPHS_INCOMPLETE`
+- `test_message_lists_missing_phase_numbers` — build a 3-phase plan,
+  give poneglyph for phase 1 only, assert the raised message contains
+  `"2"` and `"3"` somewhere
+- `test_ignores_extra_poneglyphs_for_phases_not_in_plan` — plan has
+  phases 1, 2; provide poneglyphs for 1, 2, 99 — should pass
+
+**`TestRequireCanEnterBuilding`**:
+- `test_allows_when_every_phase_has_health_check`
+- `test_rejects_when_any_phase_missing_health_check` → `HEALTH_CHECKS_INCOMPLETE`
+- `test_rejects_when_no_health_checks` → `HEALTH_CHECKS_INCOMPLETE`
+- `test_message_lists_missing_phase_numbers`
+- `test_multiple_health_checks_per_phase_counts_as_covered` — a single
+  phase may have many `HealthCheck` rows; guard just needs ≥1 per phase
+
+**`TestRequireCanEnterReviewing`**:
+- `test_allows_when_all_phases_built_with_artifacts`
+- `test_rejects_when_artifact_missing_for_phase` → `BUILD_INCOMPLETE`
+- `test_rejects_when_phase_status_not_built` → `BUILD_INCOMPLETE`
+  (artifacts present but `phase_status[phase] == "BUILDING"` or
+  `"FAILED"`)
+- `test_rejects_when_phase_status_missing_for_phase` → `BUILD_INCOMPLETE`
+  (artifacts present but `phase_status` dict missing the key entirely)
+- `test_message_lists_missing_phase_numbers`
+
+**`TestRequireCanEnterDeploying`**:
+- `test_allows_when_latest_validation_passed`
+- `test_rejects_when_latest_validation_is_none` → `VALIDATION_NOT_PASSED`
+- `test_rejects_when_latest_validation_failed` → `VALIDATION_NOT_PASSED`
+- `test_rejects_when_latest_validation_has_unknown_status` → `VALIDATION_NOT_PASSED`
+
+**`TestPipelineError`**:
+- `test_init_sets_code_and_message`
+- `test_is_exception` — `isinstance(PipelineError("X", "msg"), Exception)`
+- `test_str_shows_message`
+
+**Test fixtures**:
+- Use `MagicMock` for `Voyage`, `VoyagePlan`, `Poneglyph`, `HealthCheck`,
+  `BuildArtifact`, `ValidationRun` — same pattern as
+  [test_shipwright_service.py](src/backend/tests/test_shipwright_service.py).
+  No DB needed; these are pure predicates.
+- For `VoyagePlan`, set `plan.phases` to a real dict matching
+  `VoyagePlanSpec` shape: `{"phases": [{"phase_number": 1, "name":
+  "x", "description": "y", "assigned_to": "shipwright",
+  "depends_on": []}, ...]}`. The guard will validate-parse it.
+- For `Voyage.phase_status`, use real dicts (not MagicMock) so guards
+  can do real `.get(key)` lookups. Same lesson as Phase 15.1.
+
+### 3. No other files touched
+
+- Do NOT touch `app/services/shipwright_service.py`,
+  `app/crew/*`, `app/api/*`, or any migrations. Guards are a new module
+  with no consumers yet — Phase 15.3 will wire them in.
+- Do NOT export `PipelineError` from a broader package init (leave it
+  importable as `from app.services.pipeline_guards import PipelineError`).
+
+## Test Plan
+
+- [ ] All new tests in `tests/test_pipeline_guards.py` pass
+- [ ] All 665 existing tests still pass (no regressions — this phase
+  adds a module, doesn't modify existing code)
+- [ ] `ruff check app/ tests/` clean
+- [ ] `mypy app/` clean (pre-existing `jose` stub warning is ignorable)
+- [ ] Each guard function has ≥1 passing test and ≥1 failing-path test
+- [ ] Error-code taxonomy from the table above is 1:1 with test
+  assertions — no guard ever raises a code outside its row
+- [ ] "Incomplete" guards (TDD, BUILDING, REVIEWING) have a test
+  asserting the raised message mentions the missing phase numbers
+- [ ] Log one decision to `pdd/context/decisions.md` (see Constraints)
+
+## Constraints
+
+- **Pure predicates only** — no DB queries, no LLM calls, no event
+  publishing, no state mutation. Guards receive fully-loaded objects.
+  The caller (Phase 15.3 pipeline service) owns the loading.
+- **One error class, code-distinguished** — use `PipelineError(code,
+  message)`, not a separate exception per guard. Mirrors the
+  `ShipwrightError` / `HelmsmanError` convention.
+- **No new dependencies** — everything needed already exists in
+  `app.models.*` and `app.schemas.captain`.
+- **No changes to existing code paths** — this is a pure-addition phase.
+  Do not refactor the five crew services, the existing error classes,
+  or the `Voyage` model. Phase 15.3 will wire these guards in.
+- **Match existing style**: `from __future__ import annotations`,
+  `logger = logging.getLogger(__name__)` if logging is needed (it
+  likely isn't — guards raise, they don't log), type hints on every
+  parameter and return, single-line docstring per function.
+- **Do NOT add a shared `app/services/errors.py` catch-all module** —
+  existing pattern is one error class per service file (ShipwrightError
+  in shipwright_service.py, HelmsmanError in helmsman_service.py).
+  Follow it: `PipelineError` lives in `pipeline_guards.py`.
+- **Log one decision** to
+  [pdd/context/decisions.md](pdd/context/decisions.md) as part of this
+  phase. Suggested text: *"Pipeline transition pre-conditions are
+  enforced by six pure-predicate guards in
+  `app/services/pipeline_guards.py`, each raising
+  `PipelineError(code, message)`. Guards receive DB-loaded objects
+  and do no I/O — the pipeline service is responsible for loading.
+  This also enables skip-already-satisfied-stages on resume: the
+  pipeline calls the next guard; if it passes, the stage is skipped
+  with no service / LLM call."*
+- **No commit or PR until the user signs off** — land the prompt,
+  then run TDD implementation, then review before committing.
+
+## References
+
+- Plan: [pdd/prompts/features/pipeline/PLAN-voyage-pipeline.md](PLAN-voyage-pipeline.md)
+- Phase 15.1 landed: [PR #35](https://github.com/harshal2802/GrandLine/pull/35) — provides
+  `PHASE_STATUS_BUILT` constant and `Voyage.phase_status` column
+- Existing error convention:
+  [src/backend/app/services/shipwright_service.py:41-47](src/backend/app/services/shipwright_service.py#L41-L47),
+  `HelmsmanService` equivalent in `helmsman_service.py`
+- Plan-phase parsing: [src/backend/app/schemas/captain.py](src/backend/app/schemas/captain.py) — `VoyagePlanSpec`

--- a/src/backend/app/services/pipeline_guards.py
+++ b/src/backend/app/services/pipeline_guards.py
@@ -1,0 +1,105 @@
+"""Pipeline transition guards — pure predicates over DB-loaded objects.
+
+Each `require_can_enter_*` helper checks the pre-conditions for entering a
+pipeline stage and raises `PipelineError(code, message)` on violation.
+Guards perform no I/O (no DB queries, no LLM calls, no events) — the
+caller is responsible for loading the voyage plus any artifacts the guard
+needs. This also makes them the engine for skip-already-satisfied-stages
+on resume: the pipeline calls the next guard; if it passes, the stage is
+skipped with no service / LLM call.
+"""
+
+from __future__ import annotations
+
+from app.models.build_artifact import BuildArtifact
+from app.models.enums import VoyageStatus
+from app.models.health_check import HealthCheck
+from app.models.poneglyph import Poneglyph
+from app.models.validation_run import ValidationRun
+from app.models.voyage import Voyage, VoyagePlan
+from app.schemas.captain import VoyagePlanSpec
+from app.services.shipwright_service import PHASE_STATUS_BUILT
+
+_PLANNABLE_STATUSES = frozenset(
+    {VoyageStatus.CHARTED.value, VoyageStatus.PAUSED.value, VoyageStatus.FAILED.value}
+)
+
+
+class PipelineError(Exception):
+    """Raised when a pipeline transition pre-condition is violated."""
+
+    def __init__(self, code: str, message: str) -> None:
+        self.code = code
+        self.message = message
+        super().__init__(message)
+
+
+def _planned_phase_numbers(plan: VoyagePlan) -> list[int]:
+    spec = VoyagePlanSpec.model_validate(plan.phases)
+    return [p.phase_number for p in spec.phases]
+
+
+def require_can_enter_planning(voyage: Voyage) -> None:
+    """Allow entering PLANNING from CHARTED, PAUSED, or FAILED only."""
+    if voyage.status not in _PLANNABLE_STATUSES:
+        raise PipelineError(
+            "VOYAGE_NOT_PLANNABLE",
+            f"Voyage status is {voyage.status}; must be CHARTED, PAUSED, or FAILED",
+        )
+
+
+def require_can_enter_pdd(voyage: Voyage, plan: VoyagePlan | None) -> None:
+    """Require a VoyagePlan before entering PDD."""
+    if plan is None:
+        raise PipelineError("PLAN_MISSING", "Voyage has no plan; Captain must chart first")
+
+
+def require_can_enter_tdd(voyage: Voyage, plan: VoyagePlan, poneglyphs: list[Poneglyph]) -> None:
+    """Every planned phase must have at least one Poneglyph."""
+    planned = set(_planned_phase_numbers(plan))
+    covered = {p.phase_number for p in poneglyphs} & planned
+    missing = planned - covered
+    if missing:
+        raise PipelineError(
+            "PONEGLYPHS_INCOMPLETE",
+            f"Phases {sorted(missing)} missing poneglyphs",
+        )
+
+
+def require_can_enter_building(
+    voyage: Voyage, plan: VoyagePlan, health_checks: list[HealthCheck]
+) -> None:
+    """Every planned phase must have at least one HealthCheck."""
+    planned = set(_planned_phase_numbers(plan))
+    covered = {hc.phase_number for hc in health_checks} & planned
+    missing = planned - covered
+    if missing:
+        raise PipelineError(
+            "HEALTH_CHECKS_INCOMPLETE",
+            f"Phases {sorted(missing)} missing health_checks",
+        )
+
+
+def require_can_enter_reviewing(
+    voyage: Voyage, plan: VoyagePlan, build_artifacts: list[BuildArtifact]
+) -> None:
+    """Every planned phase must be BUILT with at least one BuildArtifact."""
+    planned = set(_planned_phase_numbers(plan))
+    with_artifact = {a.phase_number for a in build_artifacts} & planned
+    phase_status = voyage.phase_status or {}
+    built = {n for n in planned if phase_status.get(str(n)) == PHASE_STATUS_BUILT}
+    incomplete = planned - (with_artifact & built)
+    if incomplete:
+        raise PipelineError(
+            "BUILD_INCOMPLETE",
+            f"Phases {sorted(incomplete)} not built (missing artifacts or phase_status != BUILT)",
+        )
+
+
+def require_can_enter_deploying(voyage: Voyage, latest_validation: ValidationRun | None) -> None:
+    """The most-recent ValidationRun must exist and have status 'passed'."""
+    if latest_validation is None or latest_validation.status != "passed":
+        raise PipelineError(
+            "VALIDATION_NOT_PASSED",
+            "Most-recent validation_run must have status 'passed' to deploy",
+        )

--- a/src/backend/tests/test_pipeline_guards.py
+++ b/src/backend/tests/test_pipeline_guards.py
@@ -1,0 +1,312 @@
+"""Tests for pipeline transition guards."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.models.enums import VoyageStatus
+from app.services.pipeline_guards import (
+    PipelineError,
+    require_can_enter_building,
+    require_can_enter_deploying,
+    require_can_enter_pdd,
+    require_can_enter_planning,
+    require_can_enter_reviewing,
+    require_can_enter_tdd,
+)
+from app.services.shipwright_service import (
+    PHASE_STATUS_BUILDING,
+    PHASE_STATUS_BUILT,
+    PHASE_STATUS_FAILED,
+)
+
+
+def _mock_voyage(
+    status: str = VoyageStatus.CHARTED.value,
+    phase_status: dict[str, str] | None = None,
+) -> MagicMock:
+    voyage = MagicMock()
+    voyage.status = status
+    voyage.phase_status = phase_status if phase_status is not None else {}
+    return voyage
+
+
+def _mock_plan(phase_numbers: list[int]) -> MagicMock:
+    plan = MagicMock()
+    plan.phases = {
+        "phases": [
+            {
+                "phase_number": n,
+                "name": f"phase {n}",
+                "description": "do the thing",
+                "assigned_to": "shipwright",
+                "depends_on": [],
+                "artifacts": [],
+            }
+            for n in phase_numbers
+        ]
+    }
+    return plan
+
+
+def _mock_poneglyph(phase_number: int) -> MagicMock:
+    p = MagicMock()
+    p.phase_number = phase_number
+    return p
+
+
+def _mock_health_check(phase_number: int) -> MagicMock:
+    hc = MagicMock()
+    hc.phase_number = phase_number
+    return hc
+
+
+def _mock_artifact(phase_number: int) -> MagicMock:
+    a = MagicMock()
+    a.phase_number = phase_number
+    return a
+
+
+def _mock_validation(status_: str) -> MagicMock:
+    v = MagicMock()
+    v.status = status_
+    return v
+
+
+class TestPipelineError:
+    def test_init_sets_code_and_message(self) -> None:
+        err = PipelineError("CODE_X", "something went wrong")
+        assert err.code == "CODE_X"
+        assert err.message == "something went wrong"
+
+    def test_is_exception(self) -> None:
+        assert isinstance(PipelineError("X", "msg"), Exception)
+
+    def test_str_shows_message(self) -> None:
+        err = PipelineError("X", "boom")
+        assert "boom" in str(err)
+
+
+class TestRequireCanEnterPlanning:
+    def test_allows_charted(self) -> None:
+        require_can_enter_planning(_mock_voyage(status=VoyageStatus.CHARTED.value))
+
+    def test_allows_paused(self) -> None:
+        require_can_enter_planning(_mock_voyage(status=VoyageStatus.PAUSED.value))
+
+    def test_allows_failed(self) -> None:
+        require_can_enter_planning(_mock_voyage(status=VoyageStatus.FAILED.value))
+
+    def test_rejects_completed(self) -> None:
+        with pytest.raises(PipelineError) as exc:
+            require_can_enter_planning(_mock_voyage(status=VoyageStatus.COMPLETED.value))
+        assert exc.value.code == "VOYAGE_NOT_PLANNABLE"
+
+    def test_rejects_planning(self) -> None:
+        with pytest.raises(PipelineError) as exc:
+            require_can_enter_planning(_mock_voyage(status=VoyageStatus.PLANNING.value))
+        assert exc.value.code == "VOYAGE_NOT_PLANNABLE"
+
+    def test_rejects_cancelled(self) -> None:
+        with pytest.raises(PipelineError) as exc:
+            require_can_enter_planning(_mock_voyage(status=VoyageStatus.CANCELLED.value))
+        assert exc.value.code == "VOYAGE_NOT_PLANNABLE"
+
+
+class TestRequireCanEnterPdd:
+    def test_allows_when_plan_exists(self) -> None:
+        require_can_enter_pdd(_mock_voyage(), _mock_plan([1]))
+
+    def test_rejects_when_plan_is_none(self) -> None:
+        with pytest.raises(PipelineError) as exc:
+            require_can_enter_pdd(_mock_voyage(), None)
+        assert exc.value.code == "PLAN_MISSING"
+
+
+class TestRequireCanEnterTdd:
+    def test_allows_when_every_phase_has_poneglyph(self) -> None:
+        plan = _mock_plan([1, 2])
+        require_can_enter_tdd(_mock_voyage(), plan, [_mock_poneglyph(1), _mock_poneglyph(2)])
+
+    def test_rejects_when_any_phase_missing_poneglyph(self) -> None:
+        plan = _mock_plan([1, 2, 3])
+        with pytest.raises(PipelineError) as exc:
+            require_can_enter_tdd(_mock_voyage(), plan, [_mock_poneglyph(1), _mock_poneglyph(3)])
+        assert exc.value.code == "PONEGLYPHS_INCOMPLETE"
+
+    def test_rejects_when_no_poneglyphs_at_all(self) -> None:
+        plan = _mock_plan([1, 2])
+        with pytest.raises(PipelineError) as exc:
+            require_can_enter_tdd(_mock_voyage(), plan, [])
+        assert exc.value.code == "PONEGLYPHS_INCOMPLETE"
+
+    def test_message_lists_missing_phase_numbers(self) -> None:
+        plan = _mock_plan([1, 2, 3])
+        with pytest.raises(PipelineError) as exc:
+            require_can_enter_tdd(_mock_voyage(), plan, [_mock_poneglyph(1)])
+        assert "2" in exc.value.message
+        assert "3" in exc.value.message
+
+    def test_ignores_extra_poneglyphs_for_phases_not_in_plan(self) -> None:
+        plan = _mock_plan([1, 2])
+        require_can_enter_tdd(
+            _mock_voyage(),
+            plan,
+            [_mock_poneglyph(1), _mock_poneglyph(2), _mock_poneglyph(99)],
+        )
+
+
+class TestRequireCanEnterBuilding:
+    def test_allows_when_every_phase_has_health_check(self) -> None:
+        plan = _mock_plan([1, 2])
+        require_can_enter_building(
+            _mock_voyage(), plan, [_mock_health_check(1), _mock_health_check(2)]
+        )
+
+    def test_rejects_when_any_phase_missing_health_check(self) -> None:
+        plan = _mock_plan([1, 2])
+        with pytest.raises(PipelineError) as exc:
+            require_can_enter_building(_mock_voyage(), plan, [_mock_health_check(1)])
+        assert exc.value.code == "HEALTH_CHECKS_INCOMPLETE"
+
+    def test_rejects_when_no_health_checks(self) -> None:
+        plan = _mock_plan([1, 2])
+        with pytest.raises(PipelineError) as exc:
+            require_can_enter_building(_mock_voyage(), plan, [])
+        assert exc.value.code == "HEALTH_CHECKS_INCOMPLETE"
+
+    def test_message_lists_missing_phase_numbers(self) -> None:
+        plan = _mock_plan([1, 2, 3])
+        with pytest.raises(PipelineError) as exc:
+            require_can_enter_building(_mock_voyage(), plan, [_mock_health_check(2)])
+        assert "1" in exc.value.message
+        assert "3" in exc.value.message
+
+    def test_multiple_health_checks_per_phase_counts_as_covered(self) -> None:
+        plan = _mock_plan([1, 2])
+        require_can_enter_building(
+            _mock_voyage(),
+            plan,
+            [
+                _mock_health_check(1),
+                _mock_health_check(1),
+                _mock_health_check(1),
+                _mock_health_check(2),
+            ],
+        )
+
+
+class TestRequireCanEnterReviewing:
+    def test_allows_when_all_phases_built_with_artifacts(self) -> None:
+        plan = _mock_plan([1, 2])
+        voyage = _mock_voyage(phase_status={"1": PHASE_STATUS_BUILT, "2": PHASE_STATUS_BUILT})
+        require_can_enter_reviewing(voyage, plan, [_mock_artifact(1), _mock_artifact(2)])
+
+    def test_rejects_when_artifact_missing_for_phase(self) -> None:
+        plan = _mock_plan([1, 2])
+        voyage = _mock_voyage(phase_status={"1": PHASE_STATUS_BUILT, "2": PHASE_STATUS_BUILT})
+        with pytest.raises(PipelineError) as exc:
+            require_can_enter_reviewing(voyage, plan, [_mock_artifact(1)])
+        assert exc.value.code == "BUILD_INCOMPLETE"
+
+    def test_rejects_when_phase_status_building(self) -> None:
+        plan = _mock_plan([1, 2])
+        voyage = _mock_voyage(phase_status={"1": PHASE_STATUS_BUILT, "2": PHASE_STATUS_BUILDING})
+        with pytest.raises(PipelineError) as exc:
+            require_can_enter_reviewing(voyage, plan, [_mock_artifact(1), _mock_artifact(2)])
+        assert exc.value.code == "BUILD_INCOMPLETE"
+
+    def test_rejects_when_phase_status_failed(self) -> None:
+        plan = _mock_plan([1, 2])
+        voyage = _mock_voyage(phase_status={"1": PHASE_STATUS_BUILT, "2": PHASE_STATUS_FAILED})
+        with pytest.raises(PipelineError) as exc:
+            require_can_enter_reviewing(voyage, plan, [_mock_artifact(1), _mock_artifact(2)])
+        assert exc.value.code == "BUILD_INCOMPLETE"
+
+    def test_rejects_when_phase_status_missing_for_phase(self) -> None:
+        plan = _mock_plan([1, 2])
+        voyage = _mock_voyage(phase_status={"1": PHASE_STATUS_BUILT})
+        with pytest.raises(PipelineError) as exc:
+            require_can_enter_reviewing(voyage, plan, [_mock_artifact(1), _mock_artifact(2)])
+        assert exc.value.code == "BUILD_INCOMPLETE"
+
+    def test_message_lists_missing_phase_numbers(self) -> None:
+        plan = _mock_plan([1, 2, 3])
+        voyage = _mock_voyage(
+            phase_status={
+                "1": PHASE_STATUS_BUILT,
+                "2": PHASE_STATUS_FAILED,
+                "3": PHASE_STATUS_BUILT,
+            }
+        )
+        with pytest.raises(PipelineError) as exc:
+            require_can_enter_reviewing(
+                voyage,
+                plan,
+                [_mock_artifact(1), _mock_artifact(2), _mock_artifact(3)],
+            )
+        assert "2" in exc.value.message
+
+
+class TestRequireCanEnterDeploying:
+    def test_allows_when_latest_validation_passed(self) -> None:
+        require_can_enter_deploying(_mock_voyage(), _mock_validation("passed"))
+
+    def test_rejects_when_latest_validation_is_none(self) -> None:
+        with pytest.raises(PipelineError) as exc:
+            require_can_enter_deploying(_mock_voyage(), None)
+        assert exc.value.code == "VALIDATION_NOT_PASSED"
+
+    def test_rejects_when_latest_validation_failed(self) -> None:
+        with pytest.raises(PipelineError) as exc:
+            require_can_enter_deploying(_mock_voyage(), _mock_validation("failed"))
+        assert exc.value.code == "VALIDATION_NOT_PASSED"
+
+    def test_rejects_when_latest_validation_has_unknown_status(self) -> None:
+        with pytest.raises(PipelineError) as exc:
+            require_can_enter_deploying(_mock_voyage(), _mock_validation("weird"))
+        assert exc.value.code == "VALIDATION_NOT_PASSED"
+
+
+class TestPlanWithMalformedPhases:
+    """Plan coming from DB is a dict — Pydantic parse must succeed for well-formed plans."""
+
+    def test_tdd_guard_parses_real_plan_dict_shape(self) -> None:
+        plan = MagicMock()
+        plan.phases = {
+            "phases": [
+                {
+                    "phase_number": 1,
+                    "name": "a",
+                    "description": "b",
+                    "assigned_to": "shipwright",
+                    "depends_on": [],
+                    "artifacts": [],
+                }
+            ]
+        }
+        require_can_enter_tdd(_mock_voyage(), plan, [_mock_poneglyph(1)])
+
+    def test_tdd_guard_accepts_alternate_roles(self) -> None:
+        plan = MagicMock()
+        plan.phases = {
+            "phases": [
+                _plan_phase_dict(1, "captain"),
+                _plan_phase_dict(2, "shipwright"),
+            ]
+        }
+        require_can_enter_tdd(_mock_voyage(), plan, [_mock_poneglyph(1), _mock_poneglyph(2)])
+
+
+def _plan_phase_dict(n: int, assigned_to: str) -> dict[str, Any]:
+    return {
+        "phase_number": n,
+        "name": f"phase {n}",
+        "description": "x",
+        "assigned_to": assigned_to,
+        "depends_on": [],
+        "artifacts": [],
+    }


### PR DESCRIPTION
## Summary
- Adds `app/services/pipeline_guards.py` — pure predicate guards for each pipeline stage entry
- Single `PipelineError` exception with `.code` attribute for fine-grained transition-failure taxonomy
- No I/O: callers load voyage + artifacts and pass them in, enabling cheap skip-already-satisfied-stages on resume

## Error codes
| Code | Stage | Meaning |
|---|---|---|
| VOYAGE_NOT_PLANNABLE | PLANNING | voyage.status not in {CHARTED, PAUSED, FAILED} |
| PLAN_MISSING | PDD | VoyagePlan is None |
| PONEGLYPHS_INCOMPLETE | TDD | some planned phase has no Poneglyph |
| HEALTH_CHECKS_INCOMPLETE | BUILDING | some planned phase has no HealthCheck |
| BUILD_INCOMPLETE | REVIEWING | some planned phase missing BuildArtifact or phase_status != BUILT |
| VALIDATION_NOT_PASSED | DEPLOYING | latest ValidationRun absent or status != 'passed' |

Builds on Phase 15.1 `phase_status` map — `BUILD_INCOMPLETE` checks both artifacts AND per-phase status so partially-built voyages cannot advance.

## Test plan
- [x] 33 new tests in `tests/test_pipeline_guards.py` (all 6 guards + PipelineError + plan-shape variants)
- [x] Full suite passes (`pytest` — 666 tests)
- [x] `ruff check` clean, `ruff format` clean
- [x] `mypy app/` clean
- [x] Logged decision in `pdd/context/decisions.md`

Refs #16 — Phase 15.2 of Voyage Pipeline work.