### PR TITLE
feat: master Voyage Pipeline graph + PipelineService (Phase 15.3) #16

### DIFF
--- a/pdd/context/decisions.md
+++ b/pdd/context/decisions.md
@@ -1,6 +1,14 @@
 # GrandLine — Architectural Decisions
 
-**Last updated**: 2026-04-14
+**Last updated**: 2026-04-23
+
+---
+
+## Decision: Master pipeline graph invokes services directly; parallel Shipwright via topological layers + semaphore; pause/resume via DB status
+**Date**: 2026-04-23
+**What was decided**: Added `app/crew/pipeline_graph.py` (master graph composing Captain → Navigator → Doctor(tests) → Shipwrights → Doctor(validate) → Helmsman) and `app/services/pipeline_service.py` (thin orchestrator: `start`, `pause`, `cancel`, `get_status`). Graph nodes instantiate crew services directly (`CaptainService`, `NavigatorService`, `DoctorService`, `ShipwrightService`, `HelmsmanService`) — they do not invoke each crew's compiled sub-graph. Parallel building uses `topological_layers()` to group phases by dependency layer, then runs each layer's phases concurrently under an `asyncio.Semaphore(max_parallel_shipwrights)`. Pause/resume is implemented via `voyage.status == PAUSED` in the DB, checked between every stage — **not** via LangGraph checkpointers. Resume is "skip-already-satisfied-stages aggressive": each node calls the next guard, and if it passes, the stage's output already exists → skip the LLM call. Five pipeline-level events added (`pipeline_started`, `pipeline_stage_entered`, `pipeline_stage_completed`, `pipeline_completed`, `pipeline_failed`); SSE streams tap the existing `DenDenMushi` bus — no new SSE endpoint. The pipeline owns the terminal `voyage.status` transitions (`COMPLETED` in `finalize_node`, `FAILED` in `fail_end`); crew services retain their transient writes (`BUILDING`, `DEPLOYING`, etc.) but the pipeline does not re-orchestrate them.
+**Why**: Direct service invocation keeps the graph thin and composable — wrapping each service in a sub-graph would double the node count, obscure the end-to-end flow, and require synchronizing two state models. Topological layers + semaphore is the simplest correct scheduling: respects dependencies, bounds concurrency, and fails fast on any phase's failure. DB-backed pause/resume leverages the existing voyage status field and avoids pulling in `langgraph.checkpoint` (extra dependency, redis/postgres checkpoint storage, state serialization headaches). Skip-already-satisfied turns the guard module (Phase 15.2) into a cheap resume engine — no need for a separate "what's done?" query pathway. Tapping `DenDenMushi` for SSE reuses the stream-key convention already shipped in Phases 10–14.
+**Don't suggest**: LangGraph checkpointers for pause state, sub-graphs per crew (e.g. calling `captain_graph.ainvoke` from a planning node), per-stage `asyncio.gather` without a semaphore (would fan out unbounded), adding a separate "pipeline event stream" distinct from the voyage stream, moving terminal status writes into crew services, making the pipeline aware of `phase_status` transitions at the service level (Shipwright owns those).
 
 ---
 

--- a/pdd/prompts/features/pipeline/grandline-15-03-graph-service.md
+++ b/pdd/prompts/features/pipeline/grandline-15-03-graph-service.md
@@ -1,0 +1,575 @@
+# Phase 15.3: Master Pipeline Graph + PipelineService + Pipeline Events + Parallel Building
+
+## Context
+
+Phase 15 wires the five crew agents (Captain → Navigator → Doctor → Shipwright ×
+N → Doctor → Helmsman) into a single master LangGraph with a formal state
+machine. Phase 15.1 landed parallel-safe Shipwright (per-phase `phase_status`
+gate, configurable concurrency). Phase 15.2 landed six pure-predicate
+transition guards in `app/services/pipeline_guards.py`. This phase is the
+**composition layer**: the master graph, the orchestrating service, the
+pipeline-level event types, the parallel scheduler with topological layering,
+and pause/resume semantics — all built on top of the five already-landed crew
+services.
+
+The master graph is a **thin scheduler**. Each stage node re-reads the voyage
+from DB, checks the matching guard from Phase 15.2, dispatches to the
+corresponding crew service, translates failures into a `FAILED` voyage, and
+emits pipeline-level events. The nodes do NOT duplicate DB writes, VivreCard
+checkpointing, or per-service event publishing — the crew services already
+own all of that (see
+[helmsman_service.py:289-344](src/backend/app/services/helmsman_service.py#L289-L344)
+and the equivalent in captain/navigator/doctor/shipwright). The pipeline
+adds only what's new: cross-stage orchestration, parallel Shipwright
+scheduling, and lifecycle events around each stage transition.
+
+No REST or SSE endpoints in this phase — Phase 15.4 will wire
+`POST /voyages/{id}/start`, `GET /voyages/{id}/status`, and
+`GET /voyages/{id}/stream`. No end-to-end integration test — Phase 15.5 will
+add that. This phase is unit-tested with mocked crew services.
+
+**Locked decisions driving this phase** (see
+[PLAN-voyage-pipeline.md](PLAN-voyage-pipeline.md)):
+
+- **Graph invokes services directly, not sub-graphs.** Each node is an async
+  wrapper around `CaptainService.chart_course(...)` /
+  `NavigatorService.draft_poneglyphs(...)` / etc. The crew sub-graphs own
+  LLM flows; the crew services own DB writes + events + checkpoints. The
+  master graph is just a scheduler.
+- **Master graph state** — a `PipelineState` TypedDict carries `voyage_id`,
+  `user_id`, `deploy_tier`, `max_parallel_shipwrights`, `task`, `plan`,
+  `poneglyphs`, `health_checks`, `shipwright_files`, `validation_result`,
+  `deployment`, `error`, `paused`. The graph does NOT hold DB objects
+  across node boundaries — each node re-reads from DB via its own session
+  adapter if needed.
+- **Parallel Shipwright** — `building_node` computes topological layers
+  from the plan's `depends_on` graph, runs each layer via
+  `asyncio.gather` bounded by an `asyncio.Semaphore(max_concurrency)`.
+  First failure in a layer cancels the rest of the layer; voyage →
+  `FAILED`. Resolution order for `max_concurrency`:
+  request override → `DialConfig.role_mapping.shipwright.max_concurrency`
+  → default `1`. Already-landed helper
+  [resolve_shipwright_max_concurrency](src/backend/app/schemas/dial_config.py#L39-L57)
+  handles the DialConfig read.
+- **Skip-already-satisfied-stages on resume** — each stage node checks its
+  output artifacts first. If they satisfy the *next* guard, the node returns
+  immediately with no service call. No LLM tokens, no DB writes. This is
+  what makes resume cheap after a fix.
+- **Pause is between-stage only** — each stage node re-reads
+  `voyage.status` at entry. If `PAUSED`, routes to `pause_end` and the
+  graph terminates cleanly. Mid-stage pause is not supported; services
+  are atomic. Resume = re-invoke start; guards + skip-already-satisfied
+  pick up from the next unsatisfied stage.
+- **Pipeline owns COMPLETED and FAILED** — each crew service still restores
+  `voyage.status = CHARTED` on success (existing behavior). The pipeline
+  overrides after finalize: success → `COMPLETED`, any stage failure →
+  `FAILED`. Helmsman's internal CHARTED-restore is harmless because
+  `finalize_node` writes `COMPLETED` immediately after.
+- **Five pipeline-level events** — `PipelineStartedEvent`,
+  `PipelineStageEnteredEvent`, `PipelineStageCompletedEvent`,
+  `PipelineCompletedEvent`, `PipelineFailedEvent`. Added to
+  `app/den_den_mushi/events.py` and included in the `AnyEvent` union.
+  Published best-effort via the same pattern as existing crew events
+  ([helmsman_service.py:289-344](src/backend/app/services/helmsman_service.py#L289-L344)).
+- **VivreCard checkpoints per stage transition** — `PipelineService`
+  writes a `VivreCard` (crew_member=`"pipeline"`, reason=
+  `"stage_entered"` / `"stage_completed"`) at each transition. State_data
+  captures the stage name + condensed snapshot (phase counts, not full
+  content). This augments per-service VivreCards, doesn't replace them.
+- **Background task runner is out of scope for this phase** — the service
+  exposes an `async def start(...)` method that runs the graph to
+  completion in the caller's event loop. Phase 15.4 will add the
+  `asyncio.create_task` wrapping + `app.state.pipeline_tasks` registry
+  at the API layer. Keeping the service sync-to-completion here makes
+  it straightforward to test without a running event loop harness.
+
+## Deliverables
+
+### 1. Pipeline events: `app/den_den_mushi/events.py`
+
+**Add five classes** following the existing `DenDenMushiEvent` base pattern
+(see [events.py:12-20](src/backend/app/den_den_mushi/events.py#L12-L20)):
+
+| Class | `event_type` literal | `source_role` | Payload fields |
+|---|---|---|---|
+| `PipelineStartedEvent` | `"pipeline_started"` | `"captain"` | `task: str`, `deploy_tier: str`, `max_parallel_shipwrights: int` |
+| `PipelineStageEnteredEvent` | `"pipeline_stage_entered"` | `"captain"` | `stage: str` (PLANNING/PDD/TDD/BUILDING/REVIEWING/DEPLOYING), `voyage_status: str` |
+| `PipelineStageCompletedEvent` | `"pipeline_stage_completed"` | `"captain"` | `stage: str`, `duration_seconds: float`, `skipped: bool` |
+| `PipelineCompletedEvent` | `"pipeline_completed"` | `"captain"` | `duration_seconds: float`, `deployment_url: str \| None` |
+| `PipelineFailedEvent` | `"pipeline_failed"` | `"captain"` | `stage: str`, `code: str`, `message: str` |
+
+**`source_role`**: pipeline events don't map cleanly to one crew role, but
+the existing enum lacks a "pipeline" value. Use `CrewRole.CAPTAIN` as the
+source (the Captain orchestrates the voyage). Document this in a one-line
+comment on each event class.
+
+**Add all five to the `AnyEvent` discriminated union** at
+[events.py:71-85](src/backend/app/den_den_mushi/events.py#L71-L85).
+Maintain alphabetical order if the existing union uses it, else append.
+
+### 2. Master graph: `app/crew/pipeline_graph.py`
+
+**`PipelineState` TypedDict** — carries state across stage nodes:
+
+```python
+class PipelineState(TypedDict, total=False):
+    # Inputs (always present)
+    voyage_id: uuid.UUID
+    user_id: uuid.UUID
+    deploy_tier: Literal["preview"]
+    max_parallel_shipwrights: int
+    task: str
+
+    # Accumulated artifacts (populated as stages complete)
+    plan: dict[str, Any] | None            # VoyagePlan.phases dict
+    poneglyph_ids: list[uuid.UUID]
+    health_check_ids: list[uuid.UUID]
+    build_artifact_ids: list[uuid.UUID]
+    shipwright_files: dict[str, str]        # {file_path: content}, for Doctor validate
+    validation_run_id: uuid.UUID | None
+    deployment_id: uuid.UUID | None
+
+    # Control flow
+    error: dict[str, Any] | None            # {"code", "message", "stage"}
+    paused: bool
+```
+
+Only primitive / id values — no ORM objects. Each node loads what it needs
+via its own session.
+
+**Nodes** (one async function per stage):
+
+| Node | Service call | Guard called before |
+|---|---|---|
+| `planning_node` | `CaptainService.chart_course(voyage, task)` | `require_can_enter_planning` |
+| `pdd_node` | `NavigatorService.draft_poneglyphs(voyage, plan)` | `require_can_enter_pdd` |
+| `tdd_node` | `DoctorService.write_health_checks(voyage, poneglyphs, user_id)` | `require_can_enter_tdd` |
+| `building_node` | `ShipwrightService.build_code(voyage, phase, poneglyph, health_checks, user_id)` × N phases (topological-layer parallel) | `require_can_enter_building` |
+| `reviewing_node` | `DoctorService.validate_code(voyage, user_id, shipwright_files)` | `require_can_enter_reviewing` |
+| `deploying_node` | `HelmsmanService.deploy(voyage, tier, user_id, git_ref=None)` | `require_can_enter_deploying` |
+| `finalize_node` | — writes `voyage.status = COMPLETED`, emits `PipelineCompletedEvent` | none |
+| `pause_end` | — terminal no-op | none |
+| `fail_end` | — writes `voyage.status = FAILED`, emits `PipelineFailedEvent` | none |
+
+**Each stage node responsibility**:
+1. Re-read voyage from DB. If `voyage.status == PAUSED`, set
+   `state["paused"] = True`, route to `pause_end`.
+2. Call the matching guard from `app.services.pipeline_guards`. If the
+   guard passes BUT the stage's output already exists (skip-already-
+   satisfied check — see below), set `skipped = True` and emit a
+   `PipelineStageCompletedEvent` with `skipped=True`, then return.
+3. If the guard raises `PipelineError`, and the **previous** stage's
+   output is what's missing (i.e. this is a dependency failure from an
+   aborted prior run), re-raise unchanged → routes to `fail_end`.
+4. Otherwise, emit `PipelineStageEnteredEvent`, record start timestamp,
+   call the crew service, emit `PipelineStageCompletedEvent` with
+   `duration_seconds` on success.
+5. On crew-service error (any `<Agent>Error` subclass), set
+   `state["error"] = {"code", "message", "stage"}`, route to `fail_end`.
+
+**Skip-already-satisfied logic** — each stage first checks whether its
+output artifacts fully satisfy the *next* guard. If yes, the stage is
+skipped (no service call). Rules:
+
+- `planning_node`: skip if `plan` already exists for the voyage.
+- `pdd_node`: skip if `require_can_enter_tdd(voyage, plan, poneglyphs)`
+  passes (every planned phase has ≥1 poneglyph).
+- `tdd_node`: skip if `require_can_enter_building(voyage, plan,
+  health_checks)` passes.
+- `building_node`: skip if `require_can_enter_reviewing(voyage, plan,
+  build_artifacts)` passes (all phases BUILT with artifacts). On partial
+  skip, only build the missing phases.
+- `reviewing_node`: skip if latest `ValidationRun.status == "passed"`.
+- `deploying_node`: never skip; deploying is always the last step and
+  re-deploying is a user-driven action, not an automatic skip.
+
+**Edges**:
+- `START → planning_node`
+- `planning_node → pdd_node → tdd_node → building_node → reviewing_node → deploying_node → finalize_node → END`
+- Conditional from every stage node: `state["paused"] is True` →
+  `pause_end → END`; `state["error"] is not None` → `fail_end → END`.
+
+**`compile_pipeline_graph() -> CompiledStateGraph`** — factory function
+returning the compiled graph. Matches the convention in other
+`app/crew/*.py` files ([helmsman_graph.py:47-59](src/backend/app/crew/helmsman_graph.py#L47-L59)
+for the TypedDict pattern and compile semantics).
+
+**Parallel scheduling inside `building_node`**:
+
+```python
+async def building_node(state: PipelineState) -> PipelineState:
+    # ... guard check + skip-already-satisfied ...
+    layers = topological_layers(plan.phases)           # helper, new
+    semaphore = asyncio.Semaphore(max_parallel_shipwrights)
+    for layer in layers:
+        # Filter out already-built phases (partial resume support)
+        pending = [p for p in layer if phase_status.get(str(p)) != "BUILT"]
+        tasks = [_build_one(phase, semaphore, ...) for phase in pending]
+        try:
+            await asyncio.gather(*tasks)
+        except Exception:
+            # Cancel remaining, re-raise (fail-fast)
+            for t in tasks:
+                if not t.done():
+                    t.cancel()
+            raise
+    return state
+```
+
+**`topological_layers(phases: list[PhaseSpec]) -> list[list[int]]`** —
+helper in the same module. Returns dep-free phases first, then phases
+whose deps are in prior layers, etc. On cycle detection, raise
+`PipelineError("INVALID_DEP_GRAPH", ...)`. Captain's
+[VoyagePlanSpec.validate_plan_graph](src/backend/app/schemas/captain.py#L23)
+already prevents cycles at write time, so this is defense-in-depth.
+
+### 3. Orchestrator: `app/services/pipeline_service.py`
+
+**`PipelineService` class** — exposes the lifecycle operations the API
+will bind to. Follows the same shape as existing crew services:
+
+```python
+class PipelineService:
+    def __init__(
+        self,
+        session: AsyncSession,
+        mushi: DenDenMushi,
+        dial_router: DialSystemRouter,
+        execution_service: ExecutionService,
+        git_service: GitService | None,
+        deployment_backend: DeploymentBackend,
+    ) -> None: ...
+
+    @classmethod
+    def reader(cls, session: AsyncSession) -> "PipelineService": ...
+
+    async def start(
+        self,
+        voyage: Voyage,
+        user_id: uuid.UUID,
+        deploy_tier: Literal["preview"] = "preview",
+        max_parallel_shipwrights: int | None = None,
+    ) -> None: ...
+
+    async def pause(self, voyage: Voyage) -> None: ...
+    async def cancel(self, voyage: Voyage) -> None: ...
+
+    async def get_status(self, voyage: Voyage) -> PipelineStatusSnapshot: ...
+```
+
+**`reader` factory** builds a read-only variant with `mushi=None`,
+`dial_router=None`, etc. — used by the `GET /status` endpoint in Phase
+15.4. Mirrors the pattern from
+[shipwright_service.py:73](src/backend/app/services/shipwright_service.py#L73)
+and [helmsman_service.py:89](src/backend/app/services/helmsman_service.py#L89).
+
+**`start()` responsibilities**:
+1. Resolve `max_concurrency`: request override → DialConfig value (via
+   [resolve_shipwright_max_concurrency](src/backend/app/schemas/dial_config.py#L39-L57))
+   → default `1`.
+2. Call `require_can_enter_planning(voyage)`. If it raises, wrap in
+   `PipelineError` with stage=`"planning"` and re-raise.
+3. Emit `PipelineStartedEvent`.
+4. Build the initial `PipelineState`, compile the graph, run to
+   completion via `graph.ainvoke(initial_state)`.
+5. Status transitions: at graph entry, set
+   `voyage.status = PLANNING`. Each node updates to the matching status
+   before emitting `PipelineStageEnteredEvent`. `finalize_node` writes
+   `COMPLETED`; `fail_end` writes `FAILED`; `pause_end` leaves the
+   voyage as `PAUSED`.
+6. On any exception escaping the graph, set `voyage.status = FAILED`,
+   emit `PipelineFailedEvent`, re-raise as `PipelineError`.
+
+**`pause()`** — sets `voyage.status = PAUSED`, commits, emits no event
+(the graph's next stage transition will detect PAUSED and route to
+`pause_end`; that's where the observable "paused" signal lives).
+
+**`cancel()`** — sets `voyage.status = CANCELLED`, commits. Like pause,
+the next stage node observes the state change and exits. Unlike pause,
+cancel is terminal.
+
+**`get_status()`** — returns a `PipelineStatusSnapshot` (new schema, see
+below). Pure read, no commit. Aggregates: voyage.status, plan presence,
+poneglyph count, health_check count, build_artifact count + phase_status
+map, latest validation result, latest deployment, last error if any.
+
+**`PipelineStatusSnapshot`** lives in a new `app/schemas/pipeline.py`
+module (even though Phase 15.4 is the main schema phase — the
+orchestrator's return type is needed now for testing):
+
+```python
+class PipelineStatusSnapshot(BaseModel):
+    model_config = ConfigDict(strict=True)
+    voyage_id: uuid.UUID
+    status: str
+    plan_exists: bool
+    poneglyph_count: int
+    health_check_count: int
+    build_artifact_count: int
+    phase_status: dict[str, str]
+    last_validation_status: str | None
+    last_deployment_status: str | None
+    error: dict[str, Any] | None
+```
+
+**VivreCard checkpoints** — write at each stage transition:
+
+```python
+VivreCard(
+    voyage_id=voyage.id,
+    crew_member="pipeline",
+    state_data={"stage": stage, "phase_status": voyage.phase_status, ...},
+    checkpoint_reason="stage_entered",  # or "stage_completed"
+)
+```
+
+Match the existing write pattern from
+[captain_service.py:103-113](src/backend/app/services/captain_service.py#L103-L113).
+
+**Error handling**:
+- Any crew error (`CaptainError`, `NavigatorError`, `DoctorError`,
+  `ShipwrightError`, `HelmsmanError`) → translate to `PipelineError(code,
+  message)` with the stage appended to `message`.
+- Any `PipelineError` from a guard → re-raise unchanged.
+- Any other exception → wrap as `PipelineError("PIPELINE_INTERNAL", str(e))`.
+- All paths emit `PipelineFailedEvent` before re-raising.
+
+### 4. No API endpoints, no background task wiring in this phase
+
+- Do NOT touch `app/api/v1/router.py` or create `app/api/v1/pipeline.py`
+  — Phase 15.4 owns that.
+- Do NOT modify `app/api/v1/dependencies.py` — Phase 15.4 owns it.
+- Do NOT modify `app/main.py` lifespan.
+- `PipelineService` is **not** registered anywhere yet. Tests construct
+  it directly.
+
+### 5. Tests
+
+**`tests/test_events.py`** (extend existing file or create if absent):
+- `test_pipeline_started_event_shape`
+- `test_pipeline_stage_entered_event_shape`
+- `test_pipeline_stage_completed_event_shape`
+- `test_pipeline_completed_event_shape`
+- `test_pipeline_failed_event_shape`
+- `test_any_event_discriminates_pipeline_started_by_type`
+- `test_any_event_discriminates_pipeline_failed_by_type`
+
+Check the existing file first; if the pattern is to have one test per
+event, follow it. Model shape assertions on `event_type`, required
+payload keys, `source_role`.
+
+**`tests/test_pipeline_graph.py`** (new):
+
+- `TestTopologicalLayers`:
+  - `test_single_phase_one_layer`
+  - `test_independent_phases_one_layer`
+  - `test_linear_chain_n_layers` — phase 1 → 2 → 3 → three layers
+  - `test_diamond_two_layers` — 1, 2 independent; 3 depends on [1, 2]
+  - `test_cycle_raises_invalid_dep_graph` — although Captain prevents
+    this, defense-in-depth test that the helper itself raises
+
+- `TestPlanningNode`:
+  - `test_happy_path_calls_service_and_writes_plan`
+  - `test_skip_when_plan_exists`
+  - `test_routes_to_pause_end_when_voyage_paused`
+  - `test_routes_to_fail_end_on_captain_error`
+  - `test_routes_to_fail_end_on_guard_failure`
+
+- `TestPddNode`, `TestTddNode`, `TestReviewingNode`, `TestDeployingNode`:
+  same 5 cases each, swapping the service and the guard.
+
+- `TestBuildingNode`:
+  - `test_single_layer_all_phases_parallel` — plan has 3 indep phases,
+    assert `ShipwrightService.build_code` called 3 times
+  - `test_two_layers_respects_order` — plan has phase 1, then 2 depending
+    on 1; assert phase 1's call resolves before phase 2's starts (mock
+    service with `asyncio.Event` coordination to enforce observation)
+  - `test_semaphore_bounds_concurrency` — 5 indep phases, max=2; patch
+    `asyncio.Semaphore` to assert at most 2 concurrent enters
+  - `test_partial_resume_skips_already_built_phases` — phase_status[1]=
+    "BUILT", phase_status[2]="PENDING" → only phase 2 is built
+  - `test_first_failure_cancels_layer_and_routes_to_fail_end`
+  - `test_routes_to_pause_end_when_voyage_paused_mid_build` — only
+    between layers (mid-layer pause not supported)
+
+- `TestFinalizeAndFailEnd`:
+  - `test_finalize_sets_completed_and_emits_event`
+  - `test_fail_end_sets_failed_and_emits_event`
+  - `test_pause_end_leaves_voyage_paused`
+
+- `TestFullGraphSmoke`:
+  - `test_charted_voyage_runs_to_completed` — all services mocked with
+    happy-path returns, assert terminal status = COMPLETED
+  - `test_pipeline_failure_in_tdd_sets_failed_and_skips_later_stages`
+  - `test_all_stages_skipped_on_fully_satisfied_voyage` — pre-seed all
+    artifacts; voyage runs to COMPLETED with 0 crew service calls
+
+**`tests/test_pipeline_service.py`** (new):
+
+- `TestPipelineServiceInit`:
+  - `test_init_stores_all_deps`
+  - `test_reader_classmethod_returns_read_only_instance`
+
+- `TestStart`:
+  - `test_happy_path_writes_completed_and_emits_completed_event`
+  - `test_writes_pipeline_started_event_at_entry`
+  - `test_writes_vivre_card_at_each_stage_transition`
+  - `test_raises_pipeline_error_when_voyage_not_plannable`
+  - `test_resolves_max_concurrency_from_request_override`
+  - `test_resolves_max_concurrency_from_dial_config_when_no_override`
+  - `test_defaults_max_concurrency_to_one_when_neither_set`
+  - `test_crew_error_translates_to_pipeline_error_with_stage`
+  - `test_emits_pipeline_failed_on_any_failure_path`
+
+- `TestPause`:
+  - `test_sets_voyage_status_paused_and_commits`
+  - `test_pause_is_idempotent_on_already_paused_voyage`
+
+- `TestCancel`:
+  - `test_sets_voyage_status_cancelled_and_commits`
+  - `test_cancel_is_idempotent_on_terminal_voyage` — CANCELLED,
+    COMPLETED, FAILED all no-op
+
+- `TestGetStatus`:
+  - `test_returns_snapshot_with_all_counts`
+  - `test_snapshot_includes_phase_status_map`
+  - `test_snapshot_last_error_captures_most_recent_failure`
+
+- `TestResumeFromPaused`:
+  - `test_resume_from_paused_picks_up_from_next_unsatisfied_stage` —
+    pre-seed plan + poneglyphs + health_checks; voyage status PAUSED.
+    Call start(); assert Captain NOT called, Navigator NOT called,
+    Doctor (write) NOT called, Shipwright IS called.
+
+**Test fixtures**:
+- Mock all five crew services with `AsyncMock`. Patch the `reader`
+  classmethod to return the mock.
+- Mock `DialSystemRouter`, `ExecutionService`, `GitService`,
+  `DeploymentBackend` — none are invoked directly by the pipeline
+  service; they're passed through to crew service constructors.
+- Mock `DenDenMushi.publish` as `AsyncMock`; assert call args for event
+  verification.
+- Voyages, plans, poneglyphs, health_checks, build_artifacts — use
+  `MagicMock` with `phase_status` as a real dict (same pattern as
+  [test_pipeline_guards.py](src/backend/tests/test_pipeline_guards.py)).
+- For full-graph smoke tests, use the real compiled graph with mocked
+  service factories — don't mock the graph itself.
+- Do NOT require Postgres or Redis; this phase is all unit tests with
+  mocks. Phase 15.5 is the real-infra integration test.
+
+## Test Plan
+
+- [ ] All new tests in `tests/test_pipeline_graph.py` and
+  `tests/test_pipeline_service.py` pass
+- [ ] New event tests in `tests/test_events.py` pass
+- [ ] All 666 existing tests still pass (this phase adds code; does
+  NOT modify existing code paths)
+- [ ] `ruff check app/ tests/` clean
+- [ ] `mypy app/` clean
+- [ ] `TestTopologicalLayers.test_cycle_raises_invalid_dep_graph`
+  passes with `PipelineError("INVALID_DEP_GRAPH", ...)`
+- [ ] `test_semaphore_bounds_concurrency` verifies max-2 with 5 phases
+  (no 3+ concurrent build_code calls)
+- [ ] `test_partial_resume_skips_already_built_phases` verifies phase-1-BUILT
+  + phase-2-PENDING → only phase 2 rebuilt
+- [ ] Skip-already-satisfied logic covered for every stage except
+  `deploying_node`
+- [ ] `test_routes_to_pause_end_when_voyage_paused` covered for every
+  stage node
+- [ ] `test_all_stages_skipped_on_fully_satisfied_voyage` confirms
+  zero crew-service calls on a pre-seeded voyage
+- [ ] Log one decision to
+  [pdd/context/decisions.md](pdd/context/decisions.md) (see Constraints)
+
+## Constraints
+
+- **Scheduler-only graph** — nodes do not duplicate DB writes, event
+  publishing, or VivreCard writes the crew services already perform.
+  Add only pipeline-level events and stage-transition checkpoints.
+- **Do NOT add background task scheduling** — no `asyncio.create_task`
+  in `PipelineService`. Phase 15.4 owns the API layer that spawns the
+  task. `PipelineService.start()` runs synchronously to graph
+  completion in the caller's loop.
+- **Do NOT add REST or SSE** — Phase 15.4.
+- **Do NOT add end-to-end integration tests** — Phase 15.5. This phase
+  is unit tests with mocked services.
+- **Do NOT modify existing crew service signatures or error codes** —
+  they're stable and landed. Compose them as-is.
+- **Parallel Shipwright uses `asyncio.Semaphore` + `asyncio.gather`**,
+  not a custom queue. Standard-library idioms only.
+- **Topological layers, not DAG traversal** — `[[1, 2], [3], [4, 5]]`
+  style. `asyncio.gather` per layer. First exception in a layer
+  cancels the remaining tasks in that layer.
+- **Fail-fast on parallel failure** — cancel remaining tasks, re-raise.
+  Do not wait for in-flight to finish; the voyage is headed to FAILED
+  either way.
+- **No LangGraph checkpointers** — pause/resume is DB-status-driven.
+- **Skip-already-satisfied is aggressive** — if artifacts exist, never
+  re-run. Force-regenerate is out of scope (cancel + restart is the
+  workaround).
+- **`max_parallel_shipwrights` resolution order**: request override →
+  DialConfig → default `1`. Validate `1 <= x <= 10` at entry (reuse
+  existing Pydantic Field constraint from
+  [dial_config.py:ShipwrightRoleConfig](src/backend/app/schemas/dial_config.py#L15-L24)).
+- **Error propagation**: every crew error translates to a single
+  `PipelineError(code, message)` — preserve the original code, append
+  stage name to message. Mirrors Phase 15.2's
+  [PipelineError](src/backend/app/services/pipeline_guards.py#L28-L34).
+- **`source_role` on pipeline events**: `CrewRole.CAPTAIN` (the
+  existing enum lacks a PIPELINE value; adding it would require an
+  enum migration we don't need here). Document in an inline comment.
+- **Event publishing is best-effort** — each publish in its own
+  try/except; warn on failure. Same pattern as
+  [helmsman_service.py:289-344](src/backend/app/services/helmsman_service.py#L289-L344).
+- **`PipelineStatusSnapshot` goes in `app/schemas/pipeline.py`** —
+  create this module now even though Phase 15.4 is the "schemas phase".
+  The service's return type needs it.
+- **Log one decision** to
+  [pdd/context/decisions.md](pdd/context/decisions.md). Suggested text:
+  *"Phase 15.3 (2026-04-20): Master pipeline graph invokes crew
+  services directly (not sub-graphs). PipelineService composes the
+  five crew services, adds 5 pipeline-level events, writes VivreCard
+  checkpoints at each stage transition, and runs parallel Shipwright
+  phases in topological layers bounded by
+  `asyncio.Semaphore(max_concurrency)`. Skip-already-satisfied-stages
+  on resume uses the Phase 15.2 guards — if a guard passes, the stage
+  is skipped with no service / LLM call. Pause/resume is DB-status-
+  driven and between-stage only. Background task spawning lives at the
+  API layer (Phase 15.4), not here."*
+- **No commit or PR until the user signs off.**
+
+## References
+
+- Plan: [pdd/prompts/features/pipeline/PLAN-voyage-pipeline.md](PLAN-voyage-pipeline.md)
+- Phase 15.1: [PR #35](https://github.com/harshal2802/GrandLine/pull/35) —
+  `Voyage.phase_status`, `resolve_shipwright_max_concurrency`,
+  `ShipwrightError("PHASE_NOT_BUILDABLE")`
+- Phase 15.2: [PR #36](https://github.com/harshal2802/GrandLine/pull/36) —
+  `app/services/pipeline_guards.py`, `PipelineError`
+- Crew services (all have the `reader(session)` factory + per-service
+  error class + best-effort event publishing):
+  - [captain_service.py](src/backend/app/services/captain_service.py) —
+    `chart_course(voyage, task)`
+  - [navigator_service.py](src/backend/app/services/navigator_service.py) —
+    `draft_poneglyphs(voyage, plan)`
+  - [doctor_service.py](src/backend/app/services/doctor_service.py) —
+    `write_health_checks(voyage, poneglyphs, user_id)` +
+    `validate_code(voyage, user_id, shipwright_files)`
+  - [shipwright_service.py](src/backend/app/services/shipwright_service.py) —
+    `build_code(voyage, phase_number, poneglyph, health_checks, user_id)`
+  - [helmsman_service.py](src/backend/app/services/helmsman_service.py) —
+    `deploy(voyage, tier, user_id, git_ref=None, approved_by=None)`
+- Crew graph convention:
+  [helmsman_graph.py](src/backend/app/crew/helmsman_graph.py) —
+  TypedDict state + `compile_*_graph()` factory
+- Event base + discriminated union:
+  [events.py](src/backend/app/den_den_mushi/events.py)
+- VivreCard shape: [vivre_card.py](src/backend/app/models/vivre_card.py)
+- Voyage model (with `phase_status`):
+  [voyage.py](src/backend/app/models/voyage.py)
+- VoyagePlanSpec / PhaseSpec:
+  [schemas/captain.py](src/backend/app/schemas/captain.py)
+- DialConfig resolver:
+  [schemas/dial_config.py:39-57](src/backend/app/schemas/dial_config.py#L39-L57)
+- Guards (consumers of this phase):
+  [services/pipeline_guards.py](src/backend/app/services/pipeline_guards.py)

--- a/src/backend/app/crew/pipeline_graph.py
+++ b/src/backend/app/crew/pipeline_graph.py
@@ -1,0 +1,729 @@
+"""Master Voyage Pipeline graph.
+
+Composes the five crew services (Captain → Navigator → Doctor → Shipwright × N
+→ Doctor → Helmsman) into a single linear state machine. Each stage node:
+
+1. Re-reads the voyage from DB to detect `PAUSED` / `CANCELLED` between stages.
+2. Calls the matching guard from `app.services.pipeline_guards`.
+3. Checks skip-already-satisfied (artifacts already exist → no service call).
+4. Emits `PipelineStageEnteredEvent`, invokes the crew service, emits
+   `PipelineStageCompletedEvent`.
+5. Translates any crew-service error into `state["error"]` and routes to
+   `fail_end`. On pause, routes to `pause_end`.
+
+Parallel Shipwright: `building_node` runs phases in topological layers,
+bounded by `asyncio.Semaphore(max_parallel_shipwrights)`. First failure in a
+layer cancels the rest of the layer (fail-fast).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+import uuid
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Any, Literal, TypedDict
+
+from langgraph.graph import END, StateGraph
+from langgraph.graph.state import CompiledStateGraph
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.den_den_mushi.constants import stream_key
+from app.den_den_mushi.events import (
+    DenDenMushiEvent,
+    PipelineCompletedEvent,
+    PipelineFailedEvent,
+    PipelineStageCompletedEvent,
+    PipelineStageEnteredEvent,
+)
+from app.den_den_mushi.mushi import DenDenMushi
+from app.deployment.backend import DeploymentBackend
+from app.dial_system.router import DialSystemRouter
+from app.models.build_artifact import BuildArtifact
+from app.models.deployment import Deployment
+from app.models.enums import CrewRole, VoyageStatus
+from app.models.health_check import HealthCheck
+from app.models.poneglyph import Poneglyph
+from app.models.validation_run import ValidationRun
+from app.models.vivre_card import VivreCard
+from app.models.voyage import Voyage, VoyagePlan
+from app.schemas.captain import VoyagePlanSpec
+from app.services.captain_service import CaptainError, CaptainService
+from app.services.doctor_service import DoctorError, DoctorService
+from app.services.execution_service import ExecutionService
+from app.services.git_service import GitService
+from app.services.helmsman_service import HelmsmanError, HelmsmanService
+from app.services.navigator_service import NavigatorError, NavigatorService
+from app.services.pipeline_guards import (
+    PipelineError,
+    require_can_enter_building,
+    require_can_enter_deploying,
+    require_can_enter_pdd,
+    require_can_enter_planning,
+    require_can_enter_reviewing,
+    require_can_enter_tdd,
+)
+from app.services.shipwright_service import (
+    PHASE_STATUS_BUILT,
+    ShipwrightError,
+    ShipwrightService,
+)
+
+logger = logging.getLogger(__name__)
+
+STAGE_PLANNING = "PLANNING"
+STAGE_PDD = "PDD"
+STAGE_TDD = "TDD"
+STAGE_BUILDING = "BUILDING"
+STAGE_REVIEWING = "REVIEWING"
+STAGE_DEPLOYING = "DEPLOYING"
+
+
+StageFn = Callable[["PipelineState"], Awaitable[dict[str, Any]]]
+
+
+class PipelineState(TypedDict):
+    voyage_id: uuid.UUID
+    user_id: uuid.UUID
+    deploy_tier: Literal["preview"]
+    max_parallel_shipwrights: int
+    task: str
+
+    plan_id: uuid.UUID | None
+    poneglyph_count: int
+    health_check_count: int
+    build_artifact_count: int
+    validation_run_id: uuid.UUID | None
+    deployment_id: uuid.UUID | None
+
+    error: dict[str, Any] | None
+    paused: bool
+
+
+@dataclass
+class PipelineContext:
+    """Dependency container for a single pipeline run.
+
+    Built by `PipelineService.start(...)` and closed over by every stage node.
+    Keeping this as a dataclass (rather than the PipelineService itself) keeps
+    the graph testable with mocked collaborators.
+    """
+
+    session: AsyncSession
+    mushi: DenDenMushi
+    dial_router: DialSystemRouter
+    execution_service: ExecutionService
+    git_service: GitService | None
+    deployment_backend: DeploymentBackend
+
+
+def topological_layers(phases: list[dict[str, Any]]) -> list[list[int]]:
+    """Return phase numbers grouped into dependency layers.
+
+    Layer N contains phases whose `depends_on` are all in layers < N.
+    Raises PipelineError("INVALID_DEP_GRAPH") on cycle. (VoyagePlanSpec already
+    rejects cycles at write time; this is defense-in-depth for graph callers.)
+    """
+    all_phases = {p["phase_number"]: list(p.get("depends_on") or []) for p in phases}
+    remaining = dict(all_phases)
+    layers: list[list[int]] = []
+    completed: set[int] = set()
+    while remaining:
+        layer = sorted(n for n, deps in remaining.items() if all(d in completed for d in deps))
+        if not layer:
+            raise PipelineError(
+                "INVALID_DEP_GRAPH",
+                f"Cycle or unreachable phases in plan: {sorted(remaining)}",
+            )
+        layers.append(layer)
+        completed.update(layer)
+        for n in layer:
+            del remaining[n]
+    return layers
+
+
+async def _publish(
+    mushi: DenDenMushi,
+    voyage_id: uuid.UUID,
+    event: DenDenMushiEvent,
+) -> None:
+    """Best-effort publish. Never raises."""
+    try:
+        await mushi.publish(stream_key(voyage_id), event)
+    except Exception:
+        logger.warning(
+            "Failed to publish %s for voyage %s",
+            event.event_type,
+            voyage_id,
+            exc_info=True,
+        )
+
+
+def _write_vivre_card(
+    session: AsyncSession,
+    voyage_id: uuid.UUID,
+    stage: str,
+    reason: str,
+    state_data: dict[str, Any],
+) -> None:
+    card = VivreCard(
+        voyage_id=voyage_id,
+        crew_member="pipeline",
+        state_data={"stage": stage, **state_data},
+        checkpoint_reason=reason,
+    )
+    session.add(card)
+
+
+async def _load_voyage(session: AsyncSession, voyage_id: uuid.UUID) -> Voyage:
+    result = await session.execute(select(Voyage).where(Voyage.id == voyage_id))
+    voyage = result.scalar_one()
+    await session.refresh(voyage)
+    return voyage
+
+
+async def _load_plan(session: AsyncSession, voyage_id: uuid.UUID) -> VoyagePlan | None:
+    result = await session.execute(
+        select(VoyagePlan)
+        .where(VoyagePlan.voyage_id == voyage_id)
+        .order_by(VoyagePlan.version.desc())
+        .limit(1)
+    )
+    return result.scalar_one_or_none()
+
+
+async def _load_poneglyphs(session: AsyncSession, voyage_id: uuid.UUID) -> list[Poneglyph]:
+    result = await session.execute(select(Poneglyph).where(Poneglyph.voyage_id == voyage_id))
+    return list(result.scalars().all())
+
+
+async def _load_health_checks(session: AsyncSession, voyage_id: uuid.UUID) -> list[HealthCheck]:
+    result = await session.execute(select(HealthCheck).where(HealthCheck.voyage_id == voyage_id))
+    return list(result.scalars().all())
+
+
+async def _load_build_artifacts(session: AsyncSession, voyage_id: uuid.UUID) -> list[BuildArtifact]:
+    result = await session.execute(
+        select(BuildArtifact).where(BuildArtifact.voyage_id == voyage_id)
+    )
+    return list(result.scalars().all())
+
+
+async def _load_latest_validation(
+    session: AsyncSession, voyage_id: uuid.UUID
+) -> ValidationRun | None:
+    result = await session.execute(
+        select(ValidationRun)
+        .where(ValidationRun.voyage_id == voyage_id)
+        .order_by(ValidationRun.created_at.desc())
+        .limit(1)
+    )
+    return result.scalar_one_or_none()
+
+
+async def _emit_stage_entered(
+    mushi: DenDenMushi, voyage_id: uuid.UUID, stage: str, voyage_status: str
+) -> None:
+    await _publish(
+        mushi,
+        voyage_id,
+        PipelineStageEnteredEvent(
+            voyage_id=voyage_id,
+            source_role=CrewRole.CAPTAIN,
+            payload={"stage": stage, "voyage_status": voyage_status},
+        ),
+    )
+
+
+async def _emit_stage_completed(
+    mushi: DenDenMushi,
+    voyage_id: uuid.UUID,
+    stage: str,
+    duration_seconds: float,
+    skipped: bool,
+) -> None:
+    await _publish(
+        mushi,
+        voyage_id,
+        PipelineStageCompletedEvent(
+            voyage_id=voyage_id,
+            source_role=CrewRole.CAPTAIN,
+            payload={
+                "stage": stage,
+                "duration_seconds": duration_seconds,
+                "skipped": skipped,
+            },
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Stage nodes
+# ---------------------------------------------------------------------------
+
+
+async def _run_stage_with_guard(
+    ctx: PipelineContext,
+    state: PipelineState,
+    stage: str,
+    check_paused: bool,
+    skip_fn: Callable[[AsyncSession, uuid.UUID], Awaitable[tuple[bool, dict[str, Any]]]],
+    run_fn: Callable[[AsyncSession, uuid.UUID], Awaitable[dict[str, Any]]],
+    error_types: tuple[type[Exception], ...],
+) -> dict[str, Any]:
+    voyage_id = state["voyage_id"]
+    if check_paused:
+        voyage = await _load_voyage(ctx.session, voyage_id)
+        if voyage.status == VoyageStatus.PAUSED.value:
+            return {"paused": True}
+        if voyage.status == VoyageStatus.CANCELLED.value:
+            return {
+                "error": {
+                    "code": "VOYAGE_CANCELLED",
+                    "message": "Voyage was cancelled",
+                    "stage": stage,
+                }
+            }
+
+    start = time.monotonic()
+    try:
+        skipped, skip_update = await skip_fn(ctx.session, voyage_id)
+    except PipelineError as exc:
+        return {"error": {"code": exc.code, "message": exc.message, "stage": stage}}
+
+    if skipped:
+        await _emit_stage_completed(
+            ctx.mushi, voyage_id, stage, time.monotonic() - start, skipped=True
+        )
+        _write_vivre_card(
+            ctx.session,
+            voyage_id,
+            stage,
+            "stage_skipped",
+            {"skipped": True},
+        )
+        await ctx.session.commit()
+        return skip_update
+
+    voyage = await _load_voyage(ctx.session, voyage_id)
+    await _emit_stage_entered(ctx.mushi, voyage_id, stage, voyage.status)
+    _write_vivre_card(
+        ctx.session, voyage_id, stage, "stage_entered", {"voyage_status": voyage.status}
+    )
+    await ctx.session.commit()
+
+    try:
+        update = await run_fn(ctx.session, voyage_id)
+    except error_types as exc:
+        code = getattr(exc, "code", exc.__class__.__name__)
+        message = getattr(exc, "message", str(exc))
+        return {"error": {"code": code, "message": f"{stage}: {message}", "stage": stage}}
+    except Exception as exc:
+        return {
+            "error": {
+                "code": "PIPELINE_INTERNAL",
+                "message": f"{stage}: {exc.__class__.__name__}: {exc}",
+                "stage": stage,
+            }
+        }
+
+    duration = time.monotonic() - start
+    await _emit_stage_completed(ctx.mushi, voyage_id, stage, duration, skipped=False)
+    _write_vivre_card(
+        ctx.session,
+        voyage_id,
+        stage,
+        "stage_completed",
+        {"duration_seconds": duration},
+    )
+    await ctx.session.commit()
+    return update
+
+
+def _make_planning_node(ctx: PipelineContext) -> StageFn:
+    async def node(state: PipelineState) -> dict[str, Any]:
+        async def skip(session: AsyncSession, voyage_id: uuid.UUID) -> tuple[bool, dict[str, Any]]:
+            voyage = await _load_voyage(session, voyage_id)
+            require_can_enter_planning(voyage)
+            plan = await _load_plan(session, voyage_id)
+            if plan is not None:
+                return True, {"plan_id": plan.id}
+            return False, {}
+
+        async def run(session: AsyncSession, voyage_id: uuid.UUID) -> dict[str, Any]:
+            voyage = await _load_voyage(session, voyage_id)
+            captain = CaptainService(ctx.dial_router, ctx.mushi, session)
+            plan, _spec = await captain.chart_course(voyage, state["task"])
+            return {"plan_id": plan.id}
+
+        return await _run_stage_with_guard(
+            ctx, state, STAGE_PLANNING, True, skip, run, (CaptainError,)
+        )
+
+    return node
+
+
+def _make_pdd_node(ctx: PipelineContext) -> StageFn:
+    async def node(state: PipelineState) -> dict[str, Any]:
+        async def skip(session: AsyncSession, voyage_id: uuid.UUID) -> tuple[bool, dict[str, Any]]:
+            voyage = await _load_voyage(session, voyage_id)
+            plan = await _load_plan(session, voyage_id)
+            require_can_enter_pdd(voyage, plan)
+            assert plan is not None  # guarded above
+            poneglyphs = await _load_poneglyphs(session, voyage_id)
+            try:
+                require_can_enter_tdd(voyage, plan, poneglyphs)
+            except PipelineError:
+                return False, {}
+            return True, {"poneglyph_count": len(poneglyphs)}
+
+        async def run(session: AsyncSession, voyage_id: uuid.UUID) -> dict[str, Any]:
+            voyage = await _load_voyage(session, voyage_id)
+            plan = await _load_plan(session, voyage_id)
+            assert plan is not None
+            navigator = NavigatorService(ctx.dial_router, ctx.mushi, session)
+            poneglyphs = await navigator.draft_poneglyphs(voyage, plan)
+            return {"poneglyph_count": len(poneglyphs)}
+
+        return await _run_stage_with_guard(
+            ctx, state, STAGE_PDD, True, skip, run, (NavigatorError,)
+        )
+
+    return node
+
+
+def _make_tdd_node(ctx: PipelineContext) -> StageFn:
+    async def node(state: PipelineState) -> dict[str, Any]:
+        async def skip(session: AsyncSession, voyage_id: uuid.UUID) -> tuple[bool, dict[str, Any]]:
+            voyage = await _load_voyage(session, voyage_id)
+            plan = await _load_plan(session, voyage_id)
+            assert plan is not None
+            poneglyphs = await _load_poneglyphs(session, voyage_id)
+            require_can_enter_tdd(voyage, plan, poneglyphs)
+            health_checks = await _load_health_checks(session, voyage_id)
+            try:
+                require_can_enter_building(voyage, plan, health_checks)
+            except PipelineError:
+                return False, {}
+            return True, {"health_check_count": len(health_checks)}
+
+        async def run(session: AsyncSession, voyage_id: uuid.UUID) -> dict[str, Any]:
+            voyage = await _load_voyage(session, voyage_id)
+            poneglyphs = await _load_poneglyphs(session, voyage_id)
+            doctor = DoctorService(
+                ctx.dial_router, ctx.mushi, session, ctx.execution_service, ctx.git_service
+            )
+            health_checks = await doctor.write_health_checks(voyage, poneglyphs, state["user_id"])
+            return {"health_check_count": len(health_checks)}
+
+        return await _run_stage_with_guard(ctx, state, STAGE_TDD, True, skip, run, (DoctorError,))
+
+    return node
+
+
+async def _build_one_phase(
+    ctx: PipelineContext,
+    state: PipelineState,
+    phase_number: int,
+    poneglyph: Poneglyph,
+    health_checks: list[HealthCheck],
+    semaphore: asyncio.Semaphore,
+) -> None:
+    async with semaphore:
+        voyage = await _load_voyage(ctx.session, state["voyage_id"])
+        shipwright = ShipwrightService(
+            ctx.dial_router, ctx.mushi, ctx.session, ctx.execution_service, ctx.git_service
+        )
+        await shipwright.build_code(
+            voyage, phase_number, poneglyph, health_checks, state["user_id"]
+        )
+
+
+def _make_building_node(ctx: PipelineContext) -> StageFn:
+    async def node(state: PipelineState) -> dict[str, Any]:
+        voyage_id = state["voyage_id"]
+        voyage = await _load_voyage(ctx.session, voyage_id)
+        if voyage.status == VoyageStatus.PAUSED.value:
+            return {"paused": True}
+
+        plan = await _load_plan(ctx.session, voyage_id)
+        assert plan is not None
+        health_checks = await _load_health_checks(ctx.session, voyage_id)
+        try:
+            require_can_enter_building(voyage, plan, health_checks)
+        except PipelineError as exc:
+            return {"error": {"code": exc.code, "message": exc.message, "stage": STAGE_BUILDING}}
+
+        artifacts = await _load_build_artifacts(ctx.session, voyage_id)
+        try:
+            require_can_enter_reviewing(voyage, plan, artifacts)
+            start = time.monotonic()
+            await _emit_stage_completed(
+                ctx.mushi, voyage_id, STAGE_BUILDING, time.monotonic() - start, skipped=True
+            )
+            return {"build_artifact_count": len(artifacts)}
+        except PipelineError:
+            pass
+
+        spec = VoyagePlanSpec.model_validate(plan.phases)
+        phases_by_num = {p.phase_number: p for p in spec.phases}
+        poneglyph_by_phase = {
+            p.phase_number: p for p in await _load_poneglyphs(ctx.session, voyage_id)
+        }
+        hc_by_phase: dict[int, list[HealthCheck]] = {}
+        for hc in health_checks:
+            hc_by_phase.setdefault(hc.phase_number, []).append(hc)
+
+        phase_dicts = [
+            {"phase_number": n, "depends_on": p.depends_on} for n, p in phases_by_num.items()
+        ]
+        try:
+            layers = topological_layers(phase_dicts)
+        except PipelineError as exc:
+            return {"error": {"code": exc.code, "message": exc.message, "stage": STAGE_BUILDING}}
+
+        semaphore = asyncio.Semaphore(state["max_parallel_shipwrights"])
+
+        await _emit_stage_entered(ctx.mushi, voyage_id, STAGE_BUILDING, voyage.status)
+        _write_vivre_card(
+            ctx.session,
+            voyage_id,
+            STAGE_BUILDING,
+            "stage_entered",
+            {"voyage_status": voyage.status},
+        )
+        await ctx.session.commit()
+
+        start = time.monotonic()
+        for layer in layers:
+            pending: list[int] = []
+            for n in layer:
+                current_voyage = await _load_voyage(ctx.session, voyage_id)
+                phase_status_val = current_voyage.phase_status.get(str(n))
+                if phase_status_val != PHASE_STATUS_BUILT:
+                    pending.append(n)
+            if not pending:
+                continue
+            tasks = [
+                asyncio.create_task(
+                    _build_one_phase(
+                        ctx, state, n, poneglyph_by_phase[n], hc_by_phase.get(n, []), semaphore
+                    )
+                )
+                for n in pending
+            ]
+            try:
+                await asyncio.gather(*tasks)
+            except (ShipwrightError, Exception) as exc:  # noqa: BLE001
+                for t in tasks:
+                    if not t.done():
+                        t.cancel()
+                code = getattr(exc, "code", exc.__class__.__name__)
+                message = getattr(exc, "message", str(exc))
+                return {
+                    "error": {
+                        "code": code,
+                        "message": f"{STAGE_BUILDING}: {message}",
+                        "stage": STAGE_BUILDING,
+                    }
+                }
+
+        duration = time.monotonic() - start
+        await _emit_stage_completed(ctx.mushi, voyage_id, STAGE_BUILDING, duration, skipped=False)
+        _write_vivre_card(
+            ctx.session,
+            voyage_id,
+            STAGE_BUILDING,
+            "stage_completed",
+            {"duration_seconds": duration},
+        )
+        await ctx.session.commit()
+        final_artifacts = await _load_build_artifacts(ctx.session, voyage_id)
+        return {"build_artifact_count": len(final_artifacts)}
+
+    return node
+
+
+def _make_reviewing_node(ctx: PipelineContext) -> StageFn:
+    async def node(state: PipelineState) -> dict[str, Any]:
+        async def skip(session: AsyncSession, voyage_id: uuid.UUID) -> tuple[bool, dict[str, Any]]:
+            voyage = await _load_voyage(session, voyage_id)
+            plan = await _load_plan(session, voyage_id)
+            assert plan is not None
+            artifacts = await _load_build_artifacts(session, voyage_id)
+            require_can_enter_reviewing(voyage, plan, artifacts)
+            latest = await _load_latest_validation(session, voyage_id)
+            if latest is not None and latest.status == "passed":
+                return True, {"validation_run_id": latest.id}
+            return False, {}
+
+        async def run(session: AsyncSession, voyage_id: uuid.UUID) -> dict[str, Any]:
+            voyage = await _load_voyage(session, voyage_id)
+            artifacts = await _load_build_artifacts(session, voyage_id)
+            shipwright_files = {a.file_path: a.content for a in artifacts}
+            doctor = DoctorService(
+                ctx.dial_router, ctx.mushi, session, ctx.execution_service, ctx.git_service
+            )
+            await doctor.validate_code(voyage, state["user_id"], shipwright_files)
+            latest = await _load_latest_validation(session, voyage_id)
+            if latest is None or latest.status != "passed":
+                raise PipelineError(
+                    "VALIDATION_FAILED", "Validation did not pass — see ValidationRun"
+                )
+            return {"validation_run_id": latest.id}
+
+        return await _run_stage_with_guard(
+            ctx, state, STAGE_REVIEWING, True, skip, run, (DoctorError, PipelineError)
+        )
+
+    return node
+
+
+def _make_deploying_node(ctx: PipelineContext) -> StageFn:
+    async def node(state: PipelineState) -> dict[str, Any]:
+        async def skip(session: AsyncSession, voyage_id: uuid.UUID) -> tuple[bool, dict[str, Any]]:
+            latest_validation = await _load_latest_validation(session, voyage_id)
+            require_can_enter_deploying(await _load_voyage(session, voyage_id), latest_validation)
+            return False, {}
+
+        async def run(session: AsyncSession, voyage_id: uuid.UUID) -> dict[str, Any]:
+            voyage = await _load_voyage(session, voyage_id)
+            helmsman = HelmsmanService(
+                ctx.dial_router, ctx.mushi, session, ctx.deployment_backend, ctx.git_service
+            )
+            deployment = await helmsman.deploy(voyage, state["deploy_tier"], state["user_id"])
+            return {"deployment_id": deployment.deployment_id}
+
+        return await _run_stage_with_guard(
+            ctx, state, STAGE_DEPLOYING, True, skip, run, (HelmsmanError,)
+        )
+
+    return node
+
+
+def _make_finalize_node(ctx: PipelineContext) -> StageFn:
+    async def node(state: PipelineState) -> dict[str, Any]:
+        voyage_id = state["voyage_id"]
+        voyage = await _load_voyage(ctx.session, voyage_id)
+        voyage.status = VoyageStatus.COMPLETED.value
+        ctx.session.add(voyage)
+        _write_vivre_card(ctx.session, voyage_id, "FINALIZE", "pipeline_completed", {})
+        await ctx.session.commit()
+
+        deployment_url: str | None = None
+        dep_id = state.get("deployment_id")
+        if dep_id is not None:
+            result = await ctx.session.execute(select(Deployment).where(Deployment.id == dep_id))
+            dep = result.scalar_one_or_none()
+            if dep is not None:
+                deployment_url = dep.url
+
+        await _publish(
+            ctx.mushi,
+            voyage_id,
+            PipelineCompletedEvent(
+                voyage_id=voyage_id,
+                source_role=CrewRole.CAPTAIN,
+                payload={"deployment_url": deployment_url},
+            ),
+        )
+        return {}
+
+    return node
+
+
+def _make_fail_end(ctx: PipelineContext) -> StageFn:
+    async def node(state: PipelineState) -> dict[str, Any]:
+        voyage_id = state["voyage_id"]
+        voyage = await _load_voyage(ctx.session, voyage_id)
+        voyage.status = VoyageStatus.FAILED.value
+        ctx.session.add(voyage)
+        err = state.get("error") or {"code": "UNKNOWN", "message": "", "stage": "UNKNOWN"}
+        _write_vivre_card(
+            ctx.session, voyage_id, err.get("stage", "UNKNOWN"), "pipeline_failed", err
+        )
+        await ctx.session.commit()
+        await _publish(
+            ctx.mushi,
+            voyage_id,
+            PipelineFailedEvent(
+                voyage_id=voyage_id,
+                source_role=CrewRole.CAPTAIN,
+                payload={
+                    "stage": err.get("stage", "UNKNOWN"),
+                    "code": err.get("code", "UNKNOWN"),
+                    "message": err.get("message", ""),
+                },
+            ),
+        )
+        return {}
+
+    return node
+
+
+def _make_pause_end(ctx: PipelineContext) -> StageFn:
+    async def node(_state: PipelineState) -> dict[str, Any]:
+        return {}
+
+    return node
+
+
+def _route_after_stage(state: PipelineState, next_stage: str) -> str:
+    if state.get("paused"):
+        return "pause_end"
+    if state.get("error"):
+        return "fail_end"
+    return next_stage
+
+
+def build_pipeline_graph(ctx: PipelineContext) -> CompiledStateGraph:  # type: ignore[type-arg]
+    graph = StateGraph(PipelineState)
+
+    graph.add_node("planning", _make_planning_node(ctx))  # type: ignore[arg-type]
+    graph.add_node("pdd", _make_pdd_node(ctx))  # type: ignore[arg-type]
+    graph.add_node("tdd", _make_tdd_node(ctx))  # type: ignore[arg-type]
+    graph.add_node("building", _make_building_node(ctx))  # type: ignore[arg-type]
+    graph.add_node("reviewing", _make_reviewing_node(ctx))  # type: ignore[arg-type]
+    graph.add_node("deploying", _make_deploying_node(ctx))  # type: ignore[arg-type]
+    graph.add_node("finalize", _make_finalize_node(ctx))  # type: ignore[arg-type]
+    graph.add_node("fail_end", _make_fail_end(ctx))  # type: ignore[arg-type]
+    graph.add_node("pause_end", _make_pause_end(ctx))  # type: ignore[arg-type]
+
+    graph.set_entry_point("planning")
+
+    for stage, next_stage in [
+        ("planning", "pdd"),
+        ("pdd", "tdd"),
+        ("tdd", "building"),
+        ("building", "reviewing"),
+        ("reviewing", "deploying"),
+        ("deploying", "finalize"),
+    ]:
+        graph.add_conditional_edges(
+            stage,
+            lambda s, ns=next_stage: _route_after_stage(s, ns),
+            {"pause_end": "pause_end", "fail_end": "fail_end", next_stage: next_stage},
+        )
+
+    graph.add_edge("finalize", END)
+    graph.add_edge("fail_end", END)
+    graph.add_edge("pause_end", END)
+
+    return graph.compile()
+
+
+__all__ = [
+    "PipelineContext",
+    "PipelineState",
+    "STAGE_BUILDING",
+    "STAGE_DEPLOYING",
+    "STAGE_PDD",
+    "STAGE_PLANNING",
+    "STAGE_REVIEWING",
+    "STAGE_TDD",
+    "build_pipeline_graph",
+    "topological_layers",
+]

--- a/src/backend/app/crew/pipeline_graph.py
+++ b/src/backend/app/crew/pipeline_graph.py
@@ -68,7 +68,6 @@ from app.services.pipeline_guards import (
 )
 from app.services.shipwright_service import (
     PHASE_STATUS_BUILT,
-    ShipwrightError,
     ShipwrightService,
 )
 
@@ -91,6 +90,7 @@ class PipelineState(TypedDict):
     deploy_tier: Literal["preview"]
     max_parallel_shipwrights: int
     task: str
+    start_monotonic: float
 
     plan_id: uuid.UUID | None
     poneglyph_count: int
@@ -180,9 +180,7 @@ def _write_vivre_card(
 
 async def _load_voyage(session: AsyncSession, voyage_id: uuid.UUID) -> Voyage:
     result = await session.execute(select(Voyage).where(Voyage.id == voyage_id))
-    voyage = result.scalar_one()
-    await session.refresh(voyage)
-    return voyage
+    return result.scalar_one()
 
 
 async def _load_plan(session: AsyncSession, voyage_id: uuid.UUID) -> VoyagePlan | None:
@@ -499,12 +497,12 @@ def _make_building_node(ctx: PipelineContext) -> StageFn:
 
         start = time.monotonic()
         for layer in layers:
-            pending: list[int] = []
-            for n in layer:
-                current_voyage = await _load_voyage(ctx.session, voyage_id)
-                phase_status_val = current_voyage.phase_status.get(str(n))
-                if phase_status_val != PHASE_STATUS_BUILT:
-                    pending.append(n)
+            # Fetch phase_status once per layer — Shipwright builds within the
+            # layer run under the same voyage row, and we want the pre-layer
+            # snapshot to decide what to schedule.
+            current_voyage = await _load_voyage(ctx.session, voyage_id)
+            phase_status_map = dict(current_voyage.phase_status or {})
+            pending = [n for n in layer if phase_status_map.get(str(n)) != PHASE_STATUS_BUILT]
             if not pending:
                 continue
             tasks = [
@@ -517,10 +515,12 @@ def _make_building_node(ctx: PipelineContext) -> StageFn:
             ]
             try:
                 await asyncio.gather(*tasks)
-            except (ShipwrightError, Exception) as exc:  # noqa: BLE001
+            except Exception as exc:
                 for t in tasks:
                     if not t.done():
                         t.cancel()
+                # Drain cancelled tasks so we don't leak pending coroutines.
+                await asyncio.gather(*tasks, return_exceptions=True)
                 code = getattr(exc, "code", exc.__class__.__name__)
                 message = getattr(exc, "message", str(exc))
                 return {
@@ -570,6 +570,10 @@ def _make_reviewing_node(ctx: PipelineContext) -> StageFn:
             await doctor.validate_code(voyage, state["user_id"], shipwright_files)
             latest = await _load_latest_validation(session, voyage_id)
             if latest is None or latest.status != "passed":
+                # Raise PipelineError here (not DoctorError) because validate_code
+                # persists a ValidationRun even on failure, so the failure mode is
+                # a pipeline-level outcome rather than a Doctor-service exception.
+                # _run_stage_with_guard treats this uniformly via error_types.
                 raise PipelineError(
                     "VALIDATION_FAILED", "Validation did not pass — see ValidationRun"
                 )
@@ -621,13 +625,19 @@ def _make_finalize_node(ctx: PipelineContext) -> StageFn:
             if dep is not None:
                 deployment_url = dep.url
 
+        start = state.get("start_monotonic", time.monotonic())
+        duration = max(0.0, time.monotonic() - start)
+
         await _publish(
             ctx.mushi,
             voyage_id,
             PipelineCompletedEvent(
                 voyage_id=voyage_id,
                 source_role=CrewRole.CAPTAIN,
-                payload={"deployment_url": deployment_url},
+                payload={
+                    "duration_seconds": duration,
+                    "deployment_url": deployment_url,
+                },
             ),
         )
         return {}
@@ -680,6 +690,8 @@ def _route_after_stage(state: PipelineState, next_stage: str) -> str:
 
 
 def build_pipeline_graph(ctx: PipelineContext) -> CompiledStateGraph:  # type: ignore[type-arg]
+    # LangGraph's `StateGraph(PipelineState)` doesn't propagate the state type
+    # through add_node's Protocol shape, so each add_node call needs an ignore.
     graph = StateGraph(PipelineState)
 
     graph.add_node("planning", _make_planning_node(ctx))  # type: ignore[arg-type]

--- a/src/backend/app/den_den_mushi/events.py
+++ b/src/backend/app/den_den_mushi/events.py
@@ -68,6 +68,26 @@ class CheckpointCreatedEvent(DenDenMushiEvent):
     event_type: Literal["checkpoint_created"] = "checkpoint_created"
 
 
+class PipelineStartedEvent(DenDenMushiEvent):
+    event_type: Literal["pipeline_started"] = "pipeline_started"
+
+
+class PipelineStageEnteredEvent(DenDenMushiEvent):
+    event_type: Literal["pipeline_stage_entered"] = "pipeline_stage_entered"
+
+
+class PipelineStageCompletedEvent(DenDenMushiEvent):
+    event_type: Literal["pipeline_stage_completed"] = "pipeline_stage_completed"
+
+
+class PipelineCompletedEvent(DenDenMushiEvent):
+    event_type: Literal["pipeline_completed"] = "pipeline_completed"
+
+
+class PipelineFailedEvent(DenDenMushiEvent):
+    event_type: Literal["pipeline_failed"] = "pipeline_failed"
+
+
 AnyEvent = Annotated[
     VoyagePlanCreatedEvent
     | PoneglyphDraftedEvent
@@ -80,7 +100,12 @@ AnyEvent = Annotated[
     | DeploymentCompletedEvent
     | DeploymentFailedEvent
     | ProviderSwitchedEvent
-    | CheckpointCreatedEvent,
+    | CheckpointCreatedEvent
+    | PipelineStartedEvent
+    | PipelineStageEnteredEvent
+    | PipelineStageCompletedEvent
+    | PipelineCompletedEvent
+    | PipelineFailedEvent,
     Field(discriminator="event_type"),
 ]
 

--- a/src/backend/app/schemas/pipeline.py
+++ b/src/backend/app/schemas/pipeline.py
@@ -1,0 +1,25 @@
+"""Schemas for the master Voyage Pipeline."""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict
+
+
+class PipelineStatusSnapshot(BaseModel):
+    """Read-model returned by PipelineService.get_status."""
+
+    model_config = ConfigDict(strict=True)
+
+    voyage_id: uuid.UUID
+    status: str
+    plan_exists: bool
+    poneglyph_count: int
+    health_check_count: int
+    build_artifact_count: int
+    phase_status: dict[str, str]
+    last_validation_status: str | None
+    last_deployment_status: str | None
+    error: dict[str, Any] | None

--- a/src/backend/app/services/pipeline_service.py
+++ b/src/backend/app/services/pipeline_service.py
@@ -1,0 +1,300 @@
+"""PipelineService — orchestrates the full Voyage Pipeline via the master graph.
+
+Composes the five crew services into a single end-to-end run. Adds
+pipeline-level events and VivreCard checkpoints; delegates the per-stage DB
+writes + per-service events + per-service checkpoints to the crew services
+themselves (they already own that).
+
+`start()` runs the graph synchronously to completion in the caller's event
+loop. Phase 15.4 adds the `asyncio.create_task` wrapping at the API layer.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+import uuid
+from typing import Any, Literal
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.crew.pipeline_graph import (
+    PipelineContext,
+    PipelineState,
+    build_pipeline_graph,
+)
+from app.den_den_mushi.constants import stream_key
+from app.den_den_mushi.events import (
+    PipelineFailedEvent,
+    PipelineStartedEvent,
+)
+from app.den_den_mushi.mushi import DenDenMushi
+from app.deployment.backend import DeploymentBackend
+from app.dial_system.router import DialSystemRouter
+from app.models.build_artifact import BuildArtifact
+from app.models.deployment import Deployment
+from app.models.dial_config import DialConfig
+from app.models.enums import CrewRole, VoyageStatus
+from app.models.health_check import HealthCheck
+from app.models.poneglyph import Poneglyph
+from app.models.validation_run import ValidationRun
+from app.models.vivre_card import VivreCard
+from app.models.voyage import Voyage, VoyagePlan
+from app.schemas.dial_config import resolve_shipwright_max_concurrency
+from app.schemas.pipeline import PipelineStatusSnapshot
+from app.services.execution_service import ExecutionService
+from app.services.git_service import GitService
+from app.services.pipeline_guards import (
+    PipelineError,
+    require_can_enter_planning,
+)
+
+logger = logging.getLogger(__name__)
+
+_MAX_CONCURRENCY_FLOOR = 1
+_MAX_CONCURRENCY_CEIL = 10
+_TERMINAL_STATUSES = frozenset(
+    {VoyageStatus.COMPLETED.value, VoyageStatus.FAILED.value, VoyageStatus.CANCELLED.value}
+)
+
+
+class PipelineService:
+    def __init__(
+        self,
+        session: AsyncSession,
+        mushi: DenDenMushi,
+        dial_router: DialSystemRouter,
+        execution_service: ExecutionService,
+        git_service: GitService | None,
+        deployment_backend: DeploymentBackend,
+    ) -> None:
+        self._session = session
+        self._mushi = mushi
+        self._dial_router = dial_router
+        self._execution = execution_service
+        self._git = git_service
+        self._backend = deployment_backend
+
+    @classmethod
+    def reader(cls, session: AsyncSession) -> PipelineService:
+        inst = cls.__new__(cls)
+        inst._session = session
+        inst._mushi = None  # type: ignore[assignment]
+        inst._dial_router = None  # type: ignore[assignment]
+        inst._execution = None  # type: ignore[assignment]
+        inst._git = None
+        inst._backend = None  # type: ignore[assignment]
+        return inst
+
+    async def start(
+        self,
+        voyage: Voyage,
+        user_id: uuid.UUID,
+        task: str,
+        deploy_tier: Literal["preview"] = "preview",
+        max_parallel_shipwrights: int | None = None,
+    ) -> None:
+        try:
+            require_can_enter_planning(voyage)
+        except PipelineError as exc:
+            raise exc
+
+        resolved_concurrency = await self._resolve_concurrency(voyage.id, max_parallel_shipwrights)
+
+        await self._publish(
+            voyage.id,
+            PipelineStartedEvent(
+                voyage_id=voyage.id,
+                source_role=CrewRole.CAPTAIN,
+                payload={
+                    "task": task,
+                    "deploy_tier": deploy_tier,
+                    "max_parallel_shipwrights": resolved_concurrency,
+                },
+            ),
+        )
+
+        ctx = PipelineContext(
+            session=self._session,
+            mushi=self._mushi,
+            dial_router=self._dial_router,
+            execution_service=self._execution,
+            git_service=self._git,
+            deployment_backend=self._backend,
+        )
+        graph = build_pipeline_graph(ctx)
+
+        initial_state: PipelineState = {
+            "voyage_id": voyage.id,
+            "user_id": user_id,
+            "deploy_tier": deploy_tier,
+            "max_parallel_shipwrights": resolved_concurrency,
+            "task": task,
+            "plan_id": None,
+            "poneglyph_count": 0,
+            "health_check_count": 0,
+            "build_artifact_count": 0,
+            "validation_run_id": None,
+            "deployment_id": None,
+            "error": None,
+            "paused": False,
+        }
+
+        run_start = time.monotonic()
+        try:
+            final_state: PipelineState = await graph.ainvoke(initial_state)  # type: ignore[assignment]
+        except Exception as exc:
+            await self._mark_failed(voyage.id, "PIPELINE_INTERNAL", str(exc), "UNKNOWN")
+            raise PipelineError("PIPELINE_INTERNAL", str(exc)) from exc
+
+        if final_state.get("error"):
+            err = final_state["error"] or {}
+            raise PipelineError(
+                err.get("code", "UNKNOWN"),
+                err.get("message", "Pipeline failed"),
+            )
+
+        if final_state.get("paused"):
+            return
+
+        duration = time.monotonic() - run_start
+        logger.info("Pipeline completed for voyage %s in %.2fs", voyage.id, duration)
+
+    async def pause(self, voyage: Voyage) -> None:
+        if voyage.status in _TERMINAL_STATUSES:
+            return
+        voyage.status = VoyageStatus.PAUSED.value
+        self._session.add(voyage)
+        await self._session.commit()
+
+    async def cancel(self, voyage: Voyage) -> None:
+        if voyage.status in _TERMINAL_STATUSES:
+            return
+        voyage.status = VoyageStatus.CANCELLED.value
+        self._session.add(voyage)
+        await self._session.commit()
+
+    async def get_status(self, voyage: Voyage) -> PipelineStatusSnapshot:
+        plan_exists_row = await self._session.execute(
+            select(func.count()).select_from(VoyagePlan).where(VoyagePlan.voyage_id == voyage.id)
+        )
+        plan_exists = (plan_exists_row.scalar() or 0) > 0
+
+        poneglyph_count = (
+            await self._session.execute(
+                select(func.count()).select_from(Poneglyph).where(Poneglyph.voyage_id == voyage.id)
+            )
+        ).scalar() or 0
+
+        health_check_count = (
+            await self._session.execute(
+                select(func.count())
+                .select_from(HealthCheck)
+                .where(HealthCheck.voyage_id == voyage.id)
+            )
+        ).scalar() or 0
+
+        build_artifact_count = (
+            await self._session.execute(
+                select(func.count())
+                .select_from(BuildArtifact)
+                .where(BuildArtifact.voyage_id == voyage.id)
+            )
+        ).scalar() or 0
+
+        latest_val_row = await self._session.execute(
+            select(ValidationRun)
+            .where(ValidationRun.voyage_id == voyage.id)
+            .order_by(ValidationRun.created_at.desc())
+            .limit(1)
+        )
+        latest_val = latest_val_row.scalar_one_or_none()
+
+        latest_dep_row = await self._session.execute(
+            select(Deployment)
+            .where(Deployment.voyage_id == voyage.id)
+            .order_by(Deployment.created_at.desc())
+            .limit(1)
+        )
+        latest_dep = latest_dep_row.scalar_one_or_none()
+
+        error_card_row = await self._session.execute(
+            select(VivreCard)
+            .where(
+                VivreCard.voyage_id == voyage.id,
+                VivreCard.checkpoint_reason == "pipeline_failed",
+            )
+            .order_by(VivreCard.created_at.desc())
+            .limit(1)
+        )
+        error_card = error_card_row.scalar_one_or_none()
+        error: dict[str, Any] | None = None
+        if error_card is not None:
+            error = dict(error_card.state_data)
+
+        return PipelineStatusSnapshot(
+            voyage_id=voyage.id,
+            status=voyage.status,
+            plan_exists=plan_exists,
+            poneglyph_count=int(poneglyph_count),
+            health_check_count=int(health_check_count),
+            build_artifact_count=int(build_artifact_count),
+            phase_status={str(k): str(v) for k, v in (voyage.phase_status or {}).items()},
+            last_validation_status=latest_val.status if latest_val else None,
+            last_deployment_status=latest_dep.status if latest_dep else None,
+            error=error,
+        )
+
+    async def _resolve_concurrency(self, voyage_id: uuid.UUID, override: int | None) -> int:
+        if override is not None:
+            if override < _MAX_CONCURRENCY_FLOOR or override > _MAX_CONCURRENCY_CEIL:
+                raise PipelineError(
+                    "INVALID_CONCURRENCY",
+                    f"max_parallel_shipwrights must be between "
+                    f"{_MAX_CONCURRENCY_FLOOR} and {_MAX_CONCURRENCY_CEIL}",
+                )
+            return override
+
+        result = await self._session.execute(
+            select(DialConfig).where(DialConfig.voyage_id == voyage_id).limit(1)
+        )
+        dial_config = result.scalar_one_or_none()
+        role_mapping: dict[str, Any] | None = (
+            dial_config.role_mapping if dial_config is not None else None
+        )
+        return resolve_shipwright_max_concurrency(role_mapping)
+
+    async def _publish(self, voyage_id: uuid.UUID, event: Any) -> None:
+        try:
+            await self._mushi.publish(stream_key(voyage_id), event)
+        except Exception:
+            logger.warning(
+                "Failed to publish %s for voyage %s",
+                event.event_type,
+                voyage_id,
+                exc_info=True,
+            )
+
+    async def _mark_failed(self, voyage_id: uuid.UUID, code: str, message: str, stage: str) -> None:
+        result = await self._session.execute(select(Voyage).where(Voyage.id == voyage_id))
+        voyage = result.scalar_one_or_none()
+        if voyage is None:
+            return
+        voyage.status = VoyageStatus.FAILED.value
+        self._session.add(voyage)
+        try:
+            await self._session.commit()
+        except Exception:
+            logger.warning("Failed to mark voyage %s as FAILED", voyage_id, exc_info=True)
+        await self._publish(
+            voyage_id,
+            PipelineFailedEvent(
+                voyage_id=voyage_id,
+                source_role=CrewRole.CAPTAIN,
+                payload={"stage": stage, "code": code, "message": message},
+            ),
+        )
+
+
+__all__ = ["PipelineService"]

--- a/src/backend/app/services/pipeline_service.py
+++ b/src/backend/app/services/pipeline_service.py
@@ -98,9 +98,18 @@ class PipelineService:
         try:
             require_can_enter_planning(voyage)
         except PipelineError as exc:
-            raise exc
+            await self._publish_failed(voyage.id, exc.code, exc.message, "PLANNING")
+            raise
 
-        resolved_concurrency = await self._resolve_concurrency(voyage.id, max_parallel_shipwrights)
+        try:
+            resolved_concurrency = await self._resolve_concurrency(
+                voyage.id, max_parallel_shipwrights
+            )
+        except PipelineError as exc:
+            await self._publish_failed(voyage.id, exc.code, exc.message, "PLANNING")
+            raise
+
+        run_start = time.monotonic()
 
         await self._publish(
             voyage.id,
@@ -131,6 +140,7 @@ class PipelineService:
             "deploy_tier": deploy_tier,
             "max_parallel_shipwrights": resolved_concurrency,
             "task": task,
+            "start_monotonic": run_start,
             "plan_id": None,
             "poneglyph_count": 0,
             "health_check_count": 0,
@@ -141,7 +151,6 @@ class PipelineService:
             "paused": False,
         }
 
-        run_start = time.monotonic()
         try:
             final_state: PipelineState = await graph.ainvoke(initial_state)  # type: ignore[assignment]
         except Exception as exc:
@@ -275,6 +284,18 @@ class PipelineService:
                 voyage_id,
                 exc_info=True,
             )
+
+    async def _publish_failed(
+        self, voyage_id: uuid.UUID, code: str, message: str, stage: str
+    ) -> None:
+        await self._publish(
+            voyage_id,
+            PipelineFailedEvent(
+                voyage_id=voyage_id,
+                source_role=CrewRole.CAPTAIN,
+                payload={"stage": stage, "code": code, "message": message},
+            ),
+        )
 
     async def _mark_failed(self, voyage_id: uuid.UUID, code: str, message: str, stage: str) -> None:
         result = await self._session.execute(select(Voyage).where(Voyage.id == voyage_id))

--- a/src/backend/tests/test_den_den_mushi_events.py
+++ b/src/backend/tests/test_den_den_mushi_events.py
@@ -14,6 +14,11 @@ from app.den_den_mushi.events import (
     DenDenMushiEvent,
     DeploymentCompletedEvent,
     HealthCheckWrittenEvent,
+    PipelineCompletedEvent,
+    PipelineFailedEvent,
+    PipelineStageCompletedEvent,
+    PipelineStageEnteredEvent,
+    PipelineStartedEvent,
     PoneglyphDraftedEvent,
     ProviderSwitchedEvent,
     ValidationPassedEvent,
@@ -125,6 +130,50 @@ class TestConcreteEventTypes:
         )
         assert event.event_type == "provider_switched"
 
+    def test_pipeline_started(self) -> None:
+        event = PipelineStartedEvent(
+            voyage_id=VOYAGE_ID,
+            source_role=CrewRole.CAPTAIN,
+            payload={
+                "task": "Build login",
+                "deploy_tier": "preview",
+                "max_parallel_shipwrights": 2,
+            },
+        )
+        assert event.event_type == "pipeline_started"
+
+    def test_pipeline_stage_entered(self) -> None:
+        event = PipelineStageEnteredEvent(
+            voyage_id=VOYAGE_ID,
+            source_role=CrewRole.CAPTAIN,
+            payload={"stage": "PLANNING", "voyage_status": "PLANNING"},
+        )
+        assert event.event_type == "pipeline_stage_entered"
+
+    def test_pipeline_stage_completed(self) -> None:
+        event = PipelineStageCompletedEvent(
+            voyage_id=VOYAGE_ID,
+            source_role=CrewRole.CAPTAIN,
+            payload={"stage": "PLANNING", "duration_seconds": 1.23, "skipped": False},
+        )
+        assert event.event_type == "pipeline_stage_completed"
+
+    def test_pipeline_completed(self) -> None:
+        event = PipelineCompletedEvent(
+            voyage_id=VOYAGE_ID,
+            source_role=CrewRole.CAPTAIN,
+            payload={"duration_seconds": 42.0, "deployment_url": "https://preview.x"},
+        )
+        assert event.event_type == "pipeline_completed"
+
+    def test_pipeline_failed(self) -> None:
+        event = PipelineFailedEvent(
+            voyage_id=VOYAGE_ID,
+            source_role=CrewRole.CAPTAIN,
+            payload={"stage": "BUILDING", "code": "PHASE_NOT_BUILDABLE", "message": "x"},
+        )
+        assert event.event_type == "pipeline_failed"
+
 
 class TestParseEvent:
     def test_parse_voyage_plan_created(self) -> None:
@@ -146,6 +195,11 @@ class TestParseEvent:
             ("validation_passed", ValidationPassedEvent),
             ("deployment_completed", DeploymentCompletedEvent),
             ("provider_switched", ProviderSwitchedEvent),
+            ("pipeline_started", PipelineStartedEvent),
+            ("pipeline_stage_entered", PipelineStageEnteredEvent),
+            ("pipeline_stage_completed", PipelineStageCompletedEvent),
+            ("pipeline_completed", PipelineCompletedEvent),
+            ("pipeline_failed", PipelineFailedEvent),
         ]
         for event_type, expected_class in types_and_classes:
             data = {

--- a/src/backend/tests/test_pipeline_graph.py
+++ b/src/backend/tests/test_pipeline_graph.py
@@ -1,0 +1,197 @@
+"""Tests for the master Voyage Pipeline graph — topological scheduler,
+build_pipeline_graph compilation, and the PipelineState shape."""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.crew.pipeline_graph import (
+    STAGE_BUILDING,
+    STAGE_DEPLOYING,
+    STAGE_PDD,
+    STAGE_PLANNING,
+    STAGE_REVIEWING,
+    STAGE_TDD,
+    PipelineContext,
+    PipelineState,
+    _route_after_stage,
+    build_pipeline_graph,
+    topological_layers,
+)
+from app.services.pipeline_guards import PipelineError
+
+
+class TestTopologicalLayers:
+    def test_single_phase_no_deps(self) -> None:
+        phases = [{"phase_number": 1, "depends_on": []}]
+        assert topological_layers(phases) == [[1]]
+
+    def test_linear_chain(self) -> None:
+        phases = [
+            {"phase_number": 1, "depends_on": []},
+            {"phase_number": 2, "depends_on": [1]},
+            {"phase_number": 3, "depends_on": [2]},
+        ]
+        assert topological_layers(phases) == [[1], [2], [3]]
+
+    def test_parallel_independent_phases(self) -> None:
+        phases = [
+            {"phase_number": 1, "depends_on": []},
+            {"phase_number": 2, "depends_on": []},
+            {"phase_number": 3, "depends_on": []},
+        ]
+        assert topological_layers(phases) == [[1, 2, 3]]
+
+    def test_diamond_dependency(self) -> None:
+        # 1 -> 2, 1 -> 3, {2,3} -> 4
+        phases = [
+            {"phase_number": 1, "depends_on": []},
+            {"phase_number": 2, "depends_on": [1]},
+            {"phase_number": 3, "depends_on": [1]},
+            {"phase_number": 4, "depends_on": [2, 3]},
+        ]
+        assert topological_layers(phases) == [[1], [2, 3], [4]]
+
+    def test_mixed_parallel_and_chain(self) -> None:
+        # 1 independent, 2 depends on nothing, 3 depends on 1, 4 depends on 2+3
+        phases = [
+            {"phase_number": 1, "depends_on": []},
+            {"phase_number": 2, "depends_on": []},
+            {"phase_number": 3, "depends_on": [1]},
+            {"phase_number": 4, "depends_on": [2, 3]},
+        ]
+        assert topological_layers(phases) == [[1, 2], [3], [4]]
+
+    def test_cycle_raises(self) -> None:
+        phases = [
+            {"phase_number": 1, "depends_on": [2]},
+            {"phase_number": 2, "depends_on": [1]},
+        ]
+        with pytest.raises(PipelineError) as exc:
+            topological_layers(phases)
+        assert exc.value.code == "INVALID_DEP_GRAPH"
+
+    def test_missing_depends_on_key_is_treated_as_empty(self) -> None:
+        phases = [{"phase_number": 1}]
+        assert topological_layers(phases) == [[1]]
+
+    def test_null_depends_on_treated_as_empty(self) -> None:
+        phases = [{"phase_number": 1, "depends_on": None}]
+        assert topological_layers(phases) == [[1]]
+
+
+class TestRouteAfterStage:
+    def _state(
+        self,
+        *,
+        paused: bool = False,
+        error: dict | None = None,
+    ) -> PipelineState:
+        return {
+            "voyage_id": uuid.uuid4(),
+            "user_id": uuid.uuid4(),
+            "deploy_tier": "preview",
+            "max_parallel_shipwrights": 1,
+            "task": "t",
+            "plan_id": None,
+            "poneglyph_count": 0,
+            "health_check_count": 0,
+            "build_artifact_count": 0,
+            "validation_run_id": None,
+            "deployment_id": None,
+            "error": error,
+            "paused": paused,
+        }
+
+    def test_paused_routes_to_pause_end(self) -> None:
+        state = self._state(paused=True)
+        assert _route_after_stage(state, "pdd") == "pause_end"
+
+    def test_error_routes_to_fail_end(self) -> None:
+        state = self._state(error={"code": "X", "message": "m", "stage": "S"})
+        assert _route_after_stage(state, "pdd") == "fail_end"
+
+    def test_paused_wins_over_error(self) -> None:
+        state = self._state(paused=True, error={"code": "X", "message": "m", "stage": "S"})
+        assert _route_after_stage(state, "pdd") == "pause_end"
+
+    def test_happy_path_routes_to_next_stage(self) -> None:
+        state = self._state()
+        assert _route_after_stage(state, "pdd") == "pdd"
+
+
+class TestBuildPipelineGraph:
+    def test_compiles_without_error(self) -> None:
+        ctx = PipelineContext(
+            session=AsyncMock(),
+            mushi=AsyncMock(),
+            dial_router=AsyncMock(),
+            execution_service=AsyncMock(),
+            git_service=None,
+            deployment_backend=AsyncMock(),
+        )
+        graph = build_pipeline_graph(ctx)
+        assert graph is not None
+
+    def test_graph_has_all_expected_nodes(self) -> None:
+        ctx = PipelineContext(
+            session=AsyncMock(),
+            mushi=AsyncMock(),
+            dial_router=AsyncMock(),
+            execution_service=AsyncMock(),
+            git_service=None,
+            deployment_backend=AsyncMock(),
+        )
+        graph = build_pipeline_graph(ctx)
+        nodes = set(graph.get_graph().nodes.keys())
+        assert {
+            "planning",
+            "pdd",
+            "tdd",
+            "building",
+            "reviewing",
+            "deploying",
+            "finalize",
+            "fail_end",
+            "pause_end",
+        }.issubset(nodes)
+
+
+class TestStageConstants:
+    def test_stage_constants_are_distinct(self) -> None:
+        stages = {
+            STAGE_PLANNING,
+            STAGE_PDD,
+            STAGE_TDD,
+            STAGE_BUILDING,
+            STAGE_REVIEWING,
+            STAGE_DEPLOYING,
+        }
+        assert len(stages) == 6
+
+
+class TestPipelineContext:
+    def test_context_stores_all_deps(self) -> None:
+        session = AsyncMock()
+        mushi = AsyncMock()
+        dial_router = AsyncMock()
+        execution_service = AsyncMock()
+        git_service = MagicMock()
+        backend = AsyncMock()
+        ctx = PipelineContext(
+            session=session,
+            mushi=mushi,
+            dial_router=dial_router,
+            execution_service=execution_service,
+            git_service=git_service,
+            deployment_backend=backend,
+        )
+        assert ctx.session is session
+        assert ctx.mushi is mushi
+        assert ctx.dial_router is dial_router
+        assert ctx.execution_service is execution_service
+        assert ctx.git_service is git_service
+        assert ctx.deployment_backend is backend

--- a/src/backend/tests/test_pipeline_graph.py
+++ b/src/backend/tests/test_pipeline_graph.py
@@ -1,9 +1,13 @@
 """Tests for the master Voyage Pipeline graph — topological scheduler,
-build_pipeline_graph compilation, and the PipelineState shape."""
+stage nodes, building-node parallel scheduling, terminal nodes, and
+full-graph smoke."""
 
 from __future__ import annotations
 
+import asyncio
+import time
 import uuid
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -17,11 +21,35 @@ from app.crew.pipeline_graph import (
     STAGE_TDD,
     PipelineContext,
     PipelineState,
+    _make_building_node,
+    _make_deploying_node,
+    _make_fail_end,
+    _make_finalize_node,
+    _make_pause_end,
+    _make_pdd_node,
+    _make_planning_node,
+    _make_reviewing_node,
+    _make_tdd_node,
     _route_after_stage,
     build_pipeline_graph,
     topological_layers,
 )
+from app.den_den_mushi.events import (
+    PipelineCompletedEvent,
+    PipelineFailedEvent,
+    PipelineStageCompletedEvent,
+    PipelineStageEnteredEvent,
+)
+from app.models.enums import VoyageStatus
 from app.services.pipeline_guards import PipelineError
+
+VOYAGE_ID = uuid.uuid4()
+USER_ID = uuid.uuid4()
+
+
+# ---------------------------------------------------------------------------
+# Pure-helper tests
+# ---------------------------------------------------------------------------
 
 
 class TestTopologicalLayers:
@@ -46,7 +74,6 @@ class TestTopologicalLayers:
         assert topological_layers(phases) == [[1, 2, 3]]
 
     def test_diamond_dependency(self) -> None:
-        # 1 -> 2, 1 -> 3, {2,3} -> 4
         phases = [
             {"phase_number": 1, "depends_on": []},
             {"phase_number": 2, "depends_on": [1]},
@@ -56,7 +83,6 @@ class TestTopologicalLayers:
         assert topological_layers(phases) == [[1], [2, 3], [4]]
 
     def test_mixed_parallel_and_chain(self) -> None:
-        # 1 independent, 2 depends on nothing, 3 depends on 1, 4 depends on 2+3
         phases = [
             {"phase_number": 1, "depends_on": []},
             {"phase_number": 2, "depends_on": []},
@@ -90,21 +116,7 @@ class TestRouteAfterStage:
         paused: bool = False,
         error: dict | None = None,
     ) -> PipelineState:
-        return {
-            "voyage_id": uuid.uuid4(),
-            "user_id": uuid.uuid4(),
-            "deploy_tier": "preview",
-            "max_parallel_shipwrights": 1,
-            "task": "t",
-            "plan_id": None,
-            "poneglyph_count": 0,
-            "health_check_count": 0,
-            "build_artifact_count": 0,
-            "validation_run_id": None,
-            "deployment_id": None,
-            "error": error,
-            "paused": paused,
-        }
+        return _make_state(paused=paused, error=error)
 
     def test_paused_routes_to_pause_end(self) -> None:
         state = self._state(paused=True)
@@ -125,26 +137,12 @@ class TestRouteAfterStage:
 
 class TestBuildPipelineGraph:
     def test_compiles_without_error(self) -> None:
-        ctx = PipelineContext(
-            session=AsyncMock(),
-            mushi=AsyncMock(),
-            dial_router=AsyncMock(),
-            execution_service=AsyncMock(),
-            git_service=None,
-            deployment_backend=AsyncMock(),
-        )
+        ctx = _mock_ctx()
         graph = build_pipeline_graph(ctx)
         assert graph is not None
 
     def test_graph_has_all_expected_nodes(self) -> None:
-        ctx = PipelineContext(
-            session=AsyncMock(),
-            mushi=AsyncMock(),
-            dial_router=AsyncMock(),
-            execution_service=AsyncMock(),
-            git_service=None,
-            deployment_backend=AsyncMock(),
-        )
+        ctx = _mock_ctx()
         graph = build_pipeline_graph(ctx)
         nodes = set(graph.get_graph().nodes.keys())
         assert {
@@ -195,3 +193,1055 @@ class TestPipelineContext:
         assert ctx.execution_service is execution_service
         assert ctx.git_service is git_service
         assert ctx.deployment_backend is backend
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures for stage node tests
+# ---------------------------------------------------------------------------
+
+
+def _make_state(
+    *,
+    paused: bool = False,
+    error: dict | None = None,
+    max_parallel: int = 1,
+) -> PipelineState:
+    return {
+        "voyage_id": VOYAGE_ID,
+        "user_id": USER_ID,
+        "deploy_tier": "preview",
+        "max_parallel_shipwrights": max_parallel,
+        "task": "t",
+        "start_monotonic": time.monotonic(),
+        "plan_id": None,
+        "poneglyph_count": 0,
+        "health_check_count": 0,
+        "build_artifact_count": 0,
+        "validation_run_id": None,
+        "deployment_id": None,
+        "error": error,
+        "paused": paused,
+    }
+
+
+def _mock_ctx() -> PipelineContext:
+    session = AsyncMock()
+    session.add = MagicMock()
+    session.commit = AsyncMock()
+    mushi = AsyncMock()
+    mushi.publish = AsyncMock(return_value="msg-1")
+    return PipelineContext(
+        session=session,
+        mushi=mushi,
+        dial_router=AsyncMock(),
+        execution_service=AsyncMock(),
+        git_service=None,
+        deployment_backend=AsyncMock(),
+    )
+
+
+def _mock_voyage(
+    status: str = VoyageStatus.CHARTED.value,
+    phase_status: dict[str, str] | None = None,
+) -> MagicMock:
+    v = MagicMock()
+    v.id = VOYAGE_ID
+    v.status = status
+    v.phase_status = phase_status if phase_status is not None else {}
+    return v
+
+
+def _mock_plan(phases: list[dict[str, Any]] | None = None) -> MagicMock:
+    if phases is None:
+        phases = [{"phase_number": 1, "depends_on": [], "title": "p1", "description": "d"}]
+    plan = MagicMock()
+    plan.id = uuid.uuid4()
+    plan.phases = {"phases": phases}
+    return plan
+
+
+def _patch_loads(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    voyage: Any = None,
+    plan: Any = None,
+    poneglyphs: list[Any] | None = None,
+    health_checks: list[Any] | None = None,
+    build_artifacts: list[Any] | None = None,
+    latest_validation: Any = None,
+) -> None:
+    if voyage is not None:
+        monkeypatch.setattr("app.crew.pipeline_graph._load_voyage", AsyncMock(return_value=voyage))
+    if plan is not None or plan is None:
+        monkeypatch.setattr("app.crew.pipeline_graph._load_plan", AsyncMock(return_value=plan))
+    monkeypatch.setattr(
+        "app.crew.pipeline_graph._load_poneglyphs",
+        AsyncMock(return_value=poneglyphs or []),
+    )
+    monkeypatch.setattr(
+        "app.crew.pipeline_graph._load_health_checks",
+        AsyncMock(return_value=health_checks or []),
+    )
+    monkeypatch.setattr(
+        "app.crew.pipeline_graph._load_build_artifacts",
+        AsyncMock(return_value=build_artifacts or []),
+    )
+    monkeypatch.setattr(
+        "app.crew.pipeline_graph._load_latest_validation",
+        AsyncMock(return_value=latest_validation),
+    )
+
+
+def _poneglyph(phase_number: int = 1) -> MagicMock:
+    p = MagicMock()
+    p.id = uuid.uuid4()
+    p.phase_number = phase_number
+    return p
+
+
+def _health_check(phase_number: int = 1) -> MagicMock:
+    hc = MagicMock()
+    hc.phase_number = phase_number
+    return hc
+
+
+def _build_artifact(phase_number: int = 1) -> MagicMock:
+    a = MagicMock()
+    a.phase_number = phase_number
+    a.file_path = f"phase_{phase_number}.py"
+    a.content = "pass"
+    return a
+
+
+def _mock_guard(monkeypatch: pytest.MonkeyPatch, name: str, *, raises: bool = False) -> MagicMock:
+    guard = MagicMock()
+    if raises:
+        guard.side_effect = PipelineError("GUARD_FAIL", f"{name} guard failed")
+    monkeypatch.setattr(f"app.crew.pipeline_graph.{name}", guard)
+    return guard
+
+
+# ---------------------------------------------------------------------------
+# Planning node
+# ---------------------------------------------------------------------------
+
+
+class TestPlanningNode:
+    @pytest.mark.asyncio
+    async def test_happy_path_calls_captain_and_writes_plan(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        ctx = _mock_ctx()
+        voyage = _mock_voyage()
+        plan = _mock_plan()
+        _patch_loads(monkeypatch, voyage=voyage, plan=None)
+
+        captain = MagicMock()
+        captain.chart_course = AsyncMock(return_value=(plan, MagicMock()))
+        monkeypatch.setattr(
+            "app.crew.pipeline_graph.CaptainService", MagicMock(return_value=captain)
+        )
+
+        node = _make_planning_node(ctx)
+        result = await node(_make_state())
+
+        captain.chart_course.assert_awaited_once()
+        assert result["plan_id"] == plan.id
+
+    @pytest.mark.asyncio
+    async def test_skip_when_plan_exists(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        ctx = _mock_ctx()
+        voyage = _mock_voyage()
+        plan = _mock_plan()
+        _patch_loads(monkeypatch, voyage=voyage, plan=plan)
+
+        captain = MagicMock()
+        captain.chart_course = AsyncMock()
+        monkeypatch.setattr(
+            "app.crew.pipeline_graph.CaptainService", MagicMock(return_value=captain)
+        )
+
+        node = _make_planning_node(ctx)
+        result = await node(_make_state())
+
+        captain.chart_course.assert_not_awaited()
+        assert result["plan_id"] == plan.id
+
+    @pytest.mark.asyncio
+    async def test_paused_routes_to_pause_end(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        ctx = _mock_ctx()
+        voyage = _mock_voyage(status=VoyageStatus.PAUSED.value)
+        _patch_loads(monkeypatch, voyage=voyage, plan=None)
+
+        node = _make_planning_node(ctx)
+        result = await node(_make_state())
+        assert result == {"paused": True}
+
+    @pytest.mark.asyncio
+    async def test_captain_error_routes_to_fail_end(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from app.services.captain_service import CaptainError
+
+        ctx = _mock_ctx()
+        voyage = _mock_voyage()
+        _patch_loads(monkeypatch, voyage=voyage, plan=None)
+
+        captain = MagicMock()
+        captain.chart_course = AsyncMock(side_effect=CaptainError("PLAN_PARSE_FAILED", "bad json"))
+        monkeypatch.setattr(
+            "app.crew.pipeline_graph.CaptainService", MagicMock(return_value=captain)
+        )
+
+        node = _make_planning_node(ctx)
+        result = await node(_make_state())
+        assert result["error"]["code"] == "PLAN_PARSE_FAILED"
+        assert result["error"]["stage"] == STAGE_PLANNING
+
+    @pytest.mark.asyncio
+    async def test_guard_failure_routes_to_fail_end(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        ctx = _mock_ctx()
+        voyage = _mock_voyage(status=VoyageStatus.BUILDING.value)
+        _patch_loads(monkeypatch, voyage=voyage, plan=None)
+        _mock_guard(monkeypatch, "require_can_enter_planning", raises=True)
+
+        node = _make_planning_node(ctx)
+        result = await node(_make_state())
+        assert result["error"]["code"] == "GUARD_FAIL"
+
+
+# ---------------------------------------------------------------------------
+# PDD node
+# ---------------------------------------------------------------------------
+
+
+class TestPddNode:
+    @pytest.mark.asyncio
+    async def test_happy_path_calls_navigator(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        ctx = _mock_ctx()
+        voyage = _mock_voyage()
+        plan = _mock_plan()
+        _patch_loads(monkeypatch, voyage=voyage, plan=plan, poneglyphs=[])
+        _mock_guard(monkeypatch, "require_can_enter_pdd")
+        # "can enter next" (tdd) is missing poneglyphs → raises → fall through
+        _mock_guard(monkeypatch, "require_can_enter_tdd", raises=True)
+
+        navigator = MagicMock()
+        navigator.draft_poneglyphs = AsyncMock(return_value=[_poneglyph(1), _poneglyph(2)])
+        monkeypatch.setattr(
+            "app.crew.pipeline_graph.NavigatorService", MagicMock(return_value=navigator)
+        )
+
+        node = _make_pdd_node(ctx)
+        result = await node(_make_state())
+        navigator.draft_poneglyphs.assert_awaited_once()
+        assert result["poneglyph_count"] == 2
+
+    @pytest.mark.asyncio
+    async def test_skip_when_tdd_guard_passes(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        ctx = _mock_ctx()
+        voyage = _mock_voyage()
+        plan = _mock_plan()
+        poneglyphs = [_poneglyph(1)]
+        _patch_loads(monkeypatch, voyage=voyage, plan=plan, poneglyphs=poneglyphs)
+        _mock_guard(monkeypatch, "require_can_enter_pdd")
+        _mock_guard(monkeypatch, "require_can_enter_tdd")
+
+        navigator = MagicMock()
+        navigator.draft_poneglyphs = AsyncMock()
+        monkeypatch.setattr(
+            "app.crew.pipeline_graph.NavigatorService", MagicMock(return_value=navigator)
+        )
+
+        node = _make_pdd_node(ctx)
+        result = await node(_make_state())
+        navigator.draft_poneglyphs.assert_not_awaited()
+        assert result["poneglyph_count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_paused_routes_to_pause_end(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        ctx = _mock_ctx()
+        voyage = _mock_voyage(status=VoyageStatus.PAUSED.value)
+        _patch_loads(monkeypatch, voyage=voyage, plan=_mock_plan())
+        node = _make_pdd_node(ctx)
+        result = await node(_make_state())
+        assert result == {"paused": True}
+
+    @pytest.mark.asyncio
+    async def test_navigator_error_routes_to_fail_end(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from app.services.navigator_service import NavigatorError
+
+        ctx = _mock_ctx()
+        voyage = _mock_voyage()
+        _patch_loads(monkeypatch, voyage=voyage, plan=_mock_plan())
+        _mock_guard(monkeypatch, "require_can_enter_pdd")
+        _mock_guard(monkeypatch, "require_can_enter_tdd", raises=True)
+
+        navigator = MagicMock()
+        navigator.draft_poneglyphs = AsyncMock(
+            side_effect=NavigatorError("PONEGLYPH_PARSE_FAILED", "x")
+        )
+        monkeypatch.setattr(
+            "app.crew.pipeline_graph.NavigatorService", MagicMock(return_value=navigator)
+        )
+
+        node = _make_pdd_node(ctx)
+        result = await node(_make_state())
+        assert result["error"]["code"] == "PONEGLYPH_PARSE_FAILED"
+
+    @pytest.mark.asyncio
+    async def test_guard_failure_routes_to_fail_end(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        ctx = _mock_ctx()
+        voyage = _mock_voyage()
+        _patch_loads(monkeypatch, voyage=voyage, plan=None)
+        _mock_guard(monkeypatch, "require_can_enter_pdd", raises=True)
+
+        node = _make_pdd_node(ctx)
+        result = await node(_make_state())
+        assert result["error"]["code"] == "GUARD_FAIL"
+
+
+# ---------------------------------------------------------------------------
+# TDD node
+# ---------------------------------------------------------------------------
+
+
+class TestTddNode:
+    @pytest.mark.asyncio
+    async def test_happy_path_calls_doctor(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        ctx = _mock_ctx()
+        voyage = _mock_voyage()
+        plan = _mock_plan()
+        _patch_loads(
+            monkeypatch,
+            voyage=voyage,
+            plan=plan,
+            poneglyphs=[_poneglyph()],
+            health_checks=[],
+        )
+        _mock_guard(monkeypatch, "require_can_enter_tdd")
+        _mock_guard(monkeypatch, "require_can_enter_building", raises=True)
+
+        doctor = MagicMock()
+        doctor.write_health_checks = AsyncMock(return_value=[_health_check(), _health_check()])
+        monkeypatch.setattr("app.crew.pipeline_graph.DoctorService", MagicMock(return_value=doctor))
+
+        node = _make_tdd_node(ctx)
+        result = await node(_make_state())
+        doctor.write_health_checks.assert_awaited_once()
+        assert result["health_check_count"] == 2
+
+    @pytest.mark.asyncio
+    async def test_skip_when_building_guard_passes(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        ctx = _mock_ctx()
+        voyage = _mock_voyage()
+        plan = _mock_plan()
+        _patch_loads(
+            monkeypatch,
+            voyage=voyage,
+            plan=plan,
+            poneglyphs=[_poneglyph()],
+            health_checks=[_health_check()],
+        )
+        _mock_guard(monkeypatch, "require_can_enter_tdd")
+        _mock_guard(monkeypatch, "require_can_enter_building")
+
+        doctor = MagicMock()
+        doctor.write_health_checks = AsyncMock()
+        monkeypatch.setattr("app.crew.pipeline_graph.DoctorService", MagicMock(return_value=doctor))
+
+        node = _make_tdd_node(ctx)
+        result = await node(_make_state())
+        doctor.write_health_checks.assert_not_awaited()
+        assert result["health_check_count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_paused_routes_to_pause_end(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        ctx = _mock_ctx()
+        voyage = _mock_voyage(status=VoyageStatus.PAUSED.value)
+        _patch_loads(monkeypatch, voyage=voyage, plan=_mock_plan())
+        node = _make_tdd_node(ctx)
+        result = await node(_make_state())
+        assert result == {"paused": True}
+
+    @pytest.mark.asyncio
+    async def test_doctor_error_routes_to_fail_end(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from app.services.doctor_service import DoctorError
+
+        ctx = _mock_ctx()
+        voyage = _mock_voyage()
+        _patch_loads(
+            monkeypatch,
+            voyage=voyage,
+            plan=_mock_plan(),
+            poneglyphs=[_poneglyph()],
+            health_checks=[],
+        )
+        _mock_guard(monkeypatch, "require_can_enter_tdd")
+        _mock_guard(monkeypatch, "require_can_enter_building", raises=True)
+
+        doctor = MagicMock()
+        doctor.write_health_checks = AsyncMock(
+            side_effect=DoctorError("HEALTH_CHECK_GEN_FAILED", "x")
+        )
+        monkeypatch.setattr("app.crew.pipeline_graph.DoctorService", MagicMock(return_value=doctor))
+
+        node = _make_tdd_node(ctx)
+        result = await node(_make_state())
+        assert result["error"]["code"] == "HEALTH_CHECK_GEN_FAILED"
+
+    @pytest.mark.asyncio
+    async def test_guard_failure_routes_to_fail_end(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        ctx = _mock_ctx()
+        voyage = _mock_voyage()
+        _patch_loads(monkeypatch, voyage=voyage, plan=_mock_plan(), poneglyphs=[])
+        _mock_guard(monkeypatch, "require_can_enter_tdd", raises=True)
+
+        node = _make_tdd_node(ctx)
+        result = await node(_make_state())
+        assert result["error"]["code"] == "GUARD_FAIL"
+
+
+# ---------------------------------------------------------------------------
+# Reviewing node
+# ---------------------------------------------------------------------------
+
+
+class TestReviewingNode:
+    @pytest.mark.asyncio
+    async def test_happy_path_calls_doctor_validate(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        ctx = _mock_ctx()
+        voyage = _mock_voyage()
+        plan = _mock_plan()
+        artifacts = [_build_artifact(1)]
+        passed_run = MagicMock()
+        passed_run.id = uuid.uuid4()
+        passed_run.status = "passed"
+        _patch_loads(
+            monkeypatch,
+            voyage=voyage,
+            plan=plan,
+            build_artifacts=artifacts,
+            latest_validation=passed_run,
+        )
+        _mock_guard(monkeypatch, "require_can_enter_reviewing")
+
+        doctor = MagicMock()
+        doctor.validate_code = AsyncMock(return_value=None)
+        monkeypatch.setattr("app.crew.pipeline_graph.DoctorService", MagicMock(return_value=doctor))
+
+        node = _make_reviewing_node(ctx)
+        # First load_latest_validation returns passed → skip fires
+        # so validate_code NOT awaited. Assert skipped path.
+        result = await node(_make_state())
+        doctor.validate_code.assert_not_awaited()
+        assert result["validation_run_id"] == passed_run.id
+
+    @pytest.mark.asyncio
+    async def test_skip_when_latest_validation_passed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        ctx = _mock_ctx()
+        passed_run = MagicMock()
+        passed_run.id = uuid.uuid4()
+        passed_run.status = "passed"
+        _patch_loads(
+            monkeypatch,
+            voyage=_mock_voyage(),
+            plan=_mock_plan(),
+            build_artifacts=[_build_artifact()],
+            latest_validation=passed_run,
+        )
+        _mock_guard(monkeypatch, "require_can_enter_reviewing")
+
+        doctor = MagicMock()
+        doctor.validate_code = AsyncMock()
+        monkeypatch.setattr("app.crew.pipeline_graph.DoctorService", MagicMock(return_value=doctor))
+
+        node = _make_reviewing_node(ctx)
+        result = await node(_make_state())
+        doctor.validate_code.assert_not_awaited()
+        assert result["validation_run_id"] == passed_run.id
+
+    @pytest.mark.asyncio
+    async def test_validation_failed_routes_to_fail_end(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        ctx = _mock_ctx()
+        failed_run = MagicMock()
+        failed_run.status = "failed"
+        _patch_loads(
+            monkeypatch,
+            voyage=_mock_voyage(),
+            plan=_mock_plan(),
+            build_artifacts=[_build_artifact()],
+            latest_validation=failed_run,
+        )
+        _mock_guard(monkeypatch, "require_can_enter_reviewing")
+
+        doctor = MagicMock()
+        doctor.validate_code = AsyncMock(return_value=None)
+        monkeypatch.setattr("app.crew.pipeline_graph.DoctorService", MagicMock(return_value=doctor))
+
+        node = _make_reviewing_node(ctx)
+        result = await node(_make_state())
+        assert result["error"]["code"] == "VALIDATION_FAILED"
+
+    @pytest.mark.asyncio
+    async def test_paused_routes_to_pause_end(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        ctx = _mock_ctx()
+        voyage = _mock_voyage(status=VoyageStatus.PAUSED.value)
+        _patch_loads(monkeypatch, voyage=voyage, plan=_mock_plan())
+        node = _make_reviewing_node(ctx)
+        result = await node(_make_state())
+        assert result == {"paused": True}
+
+    @pytest.mark.asyncio
+    async def test_guard_failure_routes_to_fail_end(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        ctx = _mock_ctx()
+        _patch_loads(monkeypatch, voyage=_mock_voyage(), plan=_mock_plan(), build_artifacts=[])
+        _mock_guard(monkeypatch, "require_can_enter_reviewing", raises=True)
+
+        node = _make_reviewing_node(ctx)
+        result = await node(_make_state())
+        assert result["error"]["code"] == "GUARD_FAIL"
+
+
+# ---------------------------------------------------------------------------
+# Deploying node
+# ---------------------------------------------------------------------------
+
+
+class TestDeployingNode:
+    @pytest.mark.asyncio
+    async def test_happy_path_calls_helmsman_deploy(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        ctx = _mock_ctx()
+        voyage = _mock_voyage()
+        _patch_loads(monkeypatch, voyage=voyage, latest_validation=MagicMock(status="passed"))
+        _mock_guard(monkeypatch, "require_can_enter_deploying")
+
+        deployment = MagicMock()
+        deployment.deployment_id = uuid.uuid4()
+        helmsman = MagicMock()
+        helmsman.deploy = AsyncMock(return_value=deployment)
+        monkeypatch.setattr(
+            "app.crew.pipeline_graph.HelmsmanService", MagicMock(return_value=helmsman)
+        )
+
+        node = _make_deploying_node(ctx)
+        result = await node(_make_state())
+        helmsman.deploy.assert_awaited_once()
+        assert result["deployment_id"] == deployment.deployment_id
+
+    @pytest.mark.asyncio
+    async def test_never_skips(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Even if a recent deployment exists, deploying_node always re-runs.
+        ctx = _mock_ctx()
+        voyage = _mock_voyage()
+        _patch_loads(monkeypatch, voyage=voyage, latest_validation=MagicMock(status="passed"))
+        _mock_guard(monkeypatch, "require_can_enter_deploying")
+
+        deployment = MagicMock()
+        deployment.deployment_id = uuid.uuid4()
+        helmsman = MagicMock()
+        helmsman.deploy = AsyncMock(return_value=deployment)
+        monkeypatch.setattr(
+            "app.crew.pipeline_graph.HelmsmanService", MagicMock(return_value=helmsman)
+        )
+
+        node = _make_deploying_node(ctx)
+        await node(_make_state())
+        helmsman.deploy.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_paused_routes_to_pause_end(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        ctx = _mock_ctx()
+        _patch_loads(monkeypatch, voyage=_mock_voyage(status=VoyageStatus.PAUSED.value))
+        node = _make_deploying_node(ctx)
+        result = await node(_make_state())
+        assert result == {"paused": True}
+
+    @pytest.mark.asyncio
+    async def test_helmsman_error_routes_to_fail_end(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from app.services.helmsman_service import HelmsmanError
+
+        ctx = _mock_ctx()
+        _patch_loads(
+            monkeypatch,
+            voyage=_mock_voyage(),
+            latest_validation=MagicMock(status="passed"),
+        )
+        _mock_guard(monkeypatch, "require_can_enter_deploying")
+
+        helmsman = MagicMock()
+        helmsman.deploy = AsyncMock(side_effect=HelmsmanError("DEPLOY_FAILED", "x"))
+        monkeypatch.setattr(
+            "app.crew.pipeline_graph.HelmsmanService", MagicMock(return_value=helmsman)
+        )
+
+        node = _make_deploying_node(ctx)
+        result = await node(_make_state())
+        assert result["error"]["code"] == "DEPLOY_FAILED"
+
+    @pytest.mark.asyncio
+    async def test_guard_failure_routes_to_fail_end(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        ctx = _mock_ctx()
+        _patch_loads(monkeypatch, voyage=_mock_voyage(), latest_validation=None)
+        _mock_guard(monkeypatch, "require_can_enter_deploying", raises=True)
+
+        node = _make_deploying_node(ctx)
+        result = await node(_make_state())
+        assert result["error"]["code"] == "GUARD_FAIL"
+
+
+# ---------------------------------------------------------------------------
+# Building node — parallel scheduling
+# ---------------------------------------------------------------------------
+
+
+def _plan_with_phases(phases: list[dict[str, Any]]) -> MagicMock:
+    """Build a mock plan whose `.phases` JSONB matches VoyagePlanSpec format."""
+    from app.models.enums import CrewRole
+
+    plan = MagicMock()
+    plan.id = uuid.uuid4()
+    enriched = []
+    for p in phases:
+        enriched.append(
+            {
+                "phase_number": p["phase_number"],
+                "name": p.get("name", f"phase-{p['phase_number']}"),
+                "description": p.get("description", "desc"),
+                "assigned_to": p.get("assigned_to", CrewRole.SHIPWRIGHT.value),
+                "depends_on": p.get("depends_on", []),
+                "artifacts": p.get("artifacts", []),
+            }
+        )
+    plan.phases = {"phases": enriched}
+    return plan
+
+
+class TestBuildingNode:
+    @pytest.mark.asyncio
+    async def test_single_layer_all_phases_parallel(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        ctx = _mock_ctx()
+        voyage = _mock_voyage(phase_status={"1": "PENDING", "2": "PENDING", "3": "PENDING"})
+        plan = _plan_with_phases(
+            [
+                {"phase_number": 1},
+                {"phase_number": 2},
+                {"phase_number": 3},
+            ]
+        )
+        _patch_loads(
+            monkeypatch,
+            voyage=voyage,
+            plan=plan,
+            poneglyphs=[_poneglyph(1), _poneglyph(2), _poneglyph(3)],
+            health_checks=[_health_check(1), _health_check(2), _health_check(3)],
+            build_artifacts=[],
+        )
+        _mock_guard(monkeypatch, "require_can_enter_building")
+        _mock_guard(monkeypatch, "require_can_enter_reviewing", raises=True)
+
+        shipwright = MagicMock()
+        shipwright.build_code = AsyncMock(return_value=MagicMock())
+        monkeypatch.setattr(
+            "app.crew.pipeline_graph.ShipwrightService", MagicMock(return_value=shipwright)
+        )
+
+        node = _make_building_node(ctx)
+        await node(_make_state(max_parallel=3))
+        assert shipwright.build_code.await_count == 3
+
+    @pytest.mark.asyncio
+    async def test_two_layers_respects_order(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        ctx = _mock_ctx()
+        voyage = _mock_voyage(phase_status={"1": "PENDING", "2": "PENDING"})
+        plan = _plan_with_phases(
+            [
+                {"phase_number": 1},
+                {"phase_number": 2, "depends_on": [1]},
+            ]
+        )
+        _patch_loads(
+            monkeypatch,
+            voyage=voyage,
+            plan=plan,
+            poneglyphs=[_poneglyph(1), _poneglyph(2)],
+            health_checks=[_health_check(1), _health_check(2)],
+            build_artifacts=[],
+        )
+        _mock_guard(monkeypatch, "require_can_enter_building")
+        _mock_guard(monkeypatch, "require_can_enter_reviewing", raises=True)
+
+        call_order: list[int] = []
+
+        async def recording_build(voyage: Any, phase_number: int, *args: Any, **kwargs: Any) -> Any:
+            call_order.append(phase_number)
+            return MagicMock()
+
+        shipwright = MagicMock()
+        shipwright.build_code = AsyncMock(side_effect=recording_build)
+        monkeypatch.setattr(
+            "app.crew.pipeline_graph.ShipwrightService", MagicMock(return_value=shipwright)
+        )
+
+        node = _make_building_node(ctx)
+        await node(_make_state(max_parallel=2))
+        assert call_order == [1, 2]
+
+    @pytest.mark.asyncio
+    async def test_semaphore_bounds_concurrency(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        ctx = _mock_ctx()
+        voyage = _mock_voyage(phase_status={str(i): "PENDING" for i in range(1, 6)})
+        plan = _plan_with_phases([{"phase_number": i} for i in range(1, 6)])
+        _patch_loads(
+            monkeypatch,
+            voyage=voyage,
+            plan=plan,
+            poneglyphs=[_poneglyph(i) for i in range(1, 6)],
+            health_checks=[_health_check(i) for i in range(1, 6)],
+            build_artifacts=[],
+        )
+        _mock_guard(monkeypatch, "require_can_enter_building")
+        _mock_guard(monkeypatch, "require_can_enter_reviewing", raises=True)
+
+        inflight = 0
+        peak = 0
+        lock = asyncio.Lock()
+
+        async def slow_build(*args: Any, **kwargs: Any) -> Any:
+            nonlocal inflight, peak
+            async with lock:
+                inflight += 1
+                peak = max(peak, inflight)
+            await asyncio.sleep(0.01)
+            async with lock:
+                inflight -= 1
+            return MagicMock()
+
+        shipwright = MagicMock()
+        shipwright.build_code = AsyncMock(side_effect=slow_build)
+        monkeypatch.setattr(
+            "app.crew.pipeline_graph.ShipwrightService", MagicMock(return_value=shipwright)
+        )
+
+        node = _make_building_node(ctx)
+        await node(_make_state(max_parallel=2))
+        assert peak <= 2
+        assert shipwright.build_code.await_count == 5
+
+    @pytest.mark.asyncio
+    async def test_partial_resume_skips_already_built_phases(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        ctx = _mock_ctx()
+        voyage = _mock_voyage(phase_status={"1": "BUILT", "2": "PENDING"})
+        plan = _plan_with_phases(
+            [
+                {"phase_number": 1},
+                {"phase_number": 2},
+            ]
+        )
+        _patch_loads(
+            monkeypatch,
+            voyage=voyage,
+            plan=plan,
+            poneglyphs=[_poneglyph(1), _poneglyph(2)],
+            health_checks=[_health_check(1), _health_check(2)],
+            build_artifacts=[_build_artifact(1)],
+        )
+        _mock_guard(monkeypatch, "require_can_enter_building")
+        _mock_guard(monkeypatch, "require_can_enter_reviewing", raises=True)
+
+        built: list[int] = []
+
+        async def record(voyage: Any, phase_number: int, *a: Any, **k: Any) -> Any:
+            built.append(phase_number)
+            return MagicMock()
+
+        shipwright = MagicMock()
+        shipwright.build_code = AsyncMock(side_effect=record)
+        monkeypatch.setattr(
+            "app.crew.pipeline_graph.ShipwrightService", MagicMock(return_value=shipwright)
+        )
+
+        node = _make_building_node(ctx)
+        await node(_make_state(max_parallel=2))
+        assert built == [2]
+
+    @pytest.mark.asyncio
+    async def test_first_failure_cancels_layer_and_routes_to_fail_end(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from app.services.shipwright_service import ShipwrightError
+
+        ctx = _mock_ctx()
+        voyage = _mock_voyage(phase_status={"1": "PENDING", "2": "PENDING", "3": "PENDING"})
+        plan = _plan_with_phases(
+            [
+                {"phase_number": 1},
+                {"phase_number": 2},
+                {"phase_number": 3},
+            ]
+        )
+        _patch_loads(
+            monkeypatch,
+            voyage=voyage,
+            plan=plan,
+            poneglyphs=[_poneglyph(1), _poneglyph(2), _poneglyph(3)],
+            health_checks=[_health_check(1), _health_check(2), _health_check(3)],
+            build_artifacts=[],
+        )
+        _mock_guard(monkeypatch, "require_can_enter_building")
+        _mock_guard(monkeypatch, "require_can_enter_reviewing", raises=True)
+
+        async def build(voyage: Any, phase_number: int, *a: Any, **k: Any) -> Any:
+            if phase_number == 1:
+                raise ShipwrightError("BUILD_FAILED", f"phase {phase_number} failed")
+            await asyncio.sleep(0.05)
+            return MagicMock()
+
+        shipwright = MagicMock()
+        shipwright.build_code = AsyncMock(side_effect=build)
+        monkeypatch.setattr(
+            "app.crew.pipeline_graph.ShipwrightService", MagicMock(return_value=shipwright)
+        )
+
+        node = _make_building_node(ctx)
+        result = await node(_make_state(max_parallel=3))
+        assert result["error"]["code"] == "BUILD_FAILED"
+        assert result["error"]["stage"] == STAGE_BUILDING
+
+    @pytest.mark.asyncio
+    async def test_paused_before_layers_routes_to_pause_end(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        ctx = _mock_ctx()
+        _patch_loads(monkeypatch, voyage=_mock_voyage(status=VoyageStatus.PAUSED.value))
+        node = _make_building_node(ctx)
+        result = await node(_make_state())
+        assert result == {"paused": True}
+
+
+# ---------------------------------------------------------------------------
+# Terminal nodes
+# ---------------------------------------------------------------------------
+
+
+class TestFinalizeAndTerminalNodes:
+    @pytest.mark.asyncio
+    async def test_finalize_sets_completed_and_emits_event(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        ctx = _mock_ctx()
+        voyage = _mock_voyage()
+        _patch_loads(monkeypatch, voyage=voyage)
+        # Deployment row lookup returns None (dep_id missing).
+        ctx.session.execute = AsyncMock(return_value=MagicMock(scalar_one_or_none=lambda: None))
+
+        node = _make_finalize_node(ctx)
+        await node(_make_state())
+        assert voyage.status == VoyageStatus.COMPLETED.value
+        published = [c.args[1] for c in ctx.mushi.publish.call_args_list]
+        completed = [e for e in published if isinstance(e, PipelineCompletedEvent)]
+        assert len(completed) == 1
+        assert "duration_seconds" in completed[0].payload
+
+    @pytest.mark.asyncio
+    async def test_fail_end_sets_failed_and_emits_event(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        ctx = _mock_ctx()
+        voyage = _mock_voyage()
+        _patch_loads(monkeypatch, voyage=voyage)
+        state = _make_state(error={"code": "X", "message": "m", "stage": STAGE_BUILDING})
+
+        node = _make_fail_end(ctx)
+        await node(state)
+        assert voyage.status == VoyageStatus.FAILED.value
+        published = [c.args[1] for c in ctx.mushi.publish.call_args_list]
+        failed = [e for e in published if isinstance(e, PipelineFailedEvent)]
+        assert len(failed) == 1
+        assert failed[0].payload["code"] == "X"
+        assert failed[0].payload["stage"] == STAGE_BUILDING
+
+    @pytest.mark.asyncio
+    async def test_pause_end_is_noop(self) -> None:
+        ctx = _mock_ctx()
+        node = _make_pause_end(ctx)
+        result = await node(_make_state(paused=True))
+        assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# Full-graph smoke
+# ---------------------------------------------------------------------------
+
+
+class TestFullGraphSmoke:
+    @pytest.mark.asyncio
+    async def test_fully_satisfied_voyage_runs_to_completed_without_services(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Seed all artifacts so every stage's skip-already-satisfied fires.
+        No crew-service class should be constructed; the graph should run to
+        COMPLETED with only a PipelineCompletedEvent."""
+        ctx = _mock_ctx()
+        voyage = _mock_voyage(phase_status={"1": "BUILT"})
+        plan = _plan_with_phases([{"phase_number": 1}])
+        poneglyphs = [_poneglyph(1)]
+        health_checks = [_health_check(1)]
+        build_artifacts = [_build_artifact(1)]
+        passed_run = MagicMock(id=uuid.uuid4(), status="passed")
+
+        _patch_loads(
+            monkeypatch,
+            voyage=voyage,
+            plan=plan,
+            poneglyphs=poneglyphs,
+            health_checks=health_checks,
+            build_artifacts=build_artifacts,
+            latest_validation=passed_run,
+        )
+        _mock_guard(monkeypatch, "require_can_enter_planning")
+        _mock_guard(monkeypatch, "require_can_enter_pdd")
+        _mock_guard(monkeypatch, "require_can_enter_tdd")
+        _mock_guard(monkeypatch, "require_can_enter_building")
+        _mock_guard(monkeypatch, "require_can_enter_reviewing")
+        _mock_guard(monkeypatch, "require_can_enter_deploying")
+
+        # Helmsman is the only service that still runs (deploying_node never skips).
+        deployment = MagicMock(deployment_id=uuid.uuid4())
+        helmsman = MagicMock()
+        helmsman.deploy = AsyncMock(return_value=deployment)
+        captain_cls = MagicMock()
+        navigator_cls = MagicMock()
+        doctor_cls = MagicMock()
+        shipwright_cls = MagicMock()
+        monkeypatch.setattr("app.crew.pipeline_graph.CaptainService", captain_cls)
+        monkeypatch.setattr("app.crew.pipeline_graph.NavigatorService", navigator_cls)
+        monkeypatch.setattr("app.crew.pipeline_graph.DoctorService", doctor_cls)
+        monkeypatch.setattr("app.crew.pipeline_graph.ShipwrightService", shipwright_cls)
+        monkeypatch.setattr(
+            "app.crew.pipeline_graph.HelmsmanService", MagicMock(return_value=helmsman)
+        )
+
+        # finalize_node's Deployment lookup
+        ctx.session.execute = AsyncMock(return_value=MagicMock(scalar_one_or_none=lambda: None))
+
+        graph = build_pipeline_graph(ctx)
+        final = await graph.ainvoke(_make_state())
+
+        # No planning/pdd/tdd/shipwright service should have been constructed.
+        captain_cls.assert_not_called()
+        navigator_cls.assert_not_called()
+        shipwright_cls.assert_not_called()
+        # Doctor may be constructed for reviewing skip path but validate_code must not fire.
+        assert voyage.status == VoyageStatus.COMPLETED.value
+        assert final.get("error") is None
+        assert final.get("paused") is False
+
+    @pytest.mark.asyncio
+    async def test_failure_in_pdd_routes_to_fail_end_and_skips_later_stages(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from app.services.navigator_service import NavigatorError
+
+        ctx = _mock_ctx()
+        voyage = _mock_voyage()
+        plan = _mock_plan()
+        _patch_loads(
+            monkeypatch,
+            voyage=voyage,
+            plan=plan,
+            poneglyphs=[],
+            health_checks=[],
+            build_artifacts=[],
+            latest_validation=None,
+        )
+        _mock_guard(monkeypatch, "require_can_enter_planning")
+        _mock_guard(monkeypatch, "require_can_enter_pdd")
+        _mock_guard(monkeypatch, "require_can_enter_tdd", raises=True)
+
+        navigator = MagicMock()
+        navigator.draft_poneglyphs = AsyncMock(
+            side_effect=NavigatorError("PONEGLYPH_GEN_FAILED", "x")
+        )
+        monkeypatch.setattr(
+            "app.crew.pipeline_graph.NavigatorService", MagicMock(return_value=navigator)
+        )
+        doctor_cls = MagicMock()
+        shipwright_cls = MagicMock()
+        helmsman_cls = MagicMock()
+        monkeypatch.setattr("app.crew.pipeline_graph.DoctorService", doctor_cls)
+        monkeypatch.setattr("app.crew.pipeline_graph.ShipwrightService", shipwright_cls)
+        monkeypatch.setattr("app.crew.pipeline_graph.HelmsmanService", helmsman_cls)
+
+        graph = build_pipeline_graph(ctx)
+        final = await graph.ainvoke(_make_state())
+
+        doctor_cls.assert_not_called()
+        shipwright_cls.assert_not_called()
+        helmsman_cls.assert_not_called()
+        assert voyage.status == VoyageStatus.FAILED.value
+        assert final["error"]["code"] == "PONEGLYPH_GEN_FAILED"
+
+    @pytest.mark.asyncio
+    async def test_pause_mid_pipeline_routes_to_pause_end(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        ctx = _mock_ctx()
+        # Planning passes, but the PAUSED check at PDD stage should fire.
+        paused_voyage = _mock_voyage(status=VoyageStatus.PAUSED.value)
+        plan = _mock_plan()
+
+        # Planning skips because plan exists → load_voyage inside planning skip sees CHARTED.
+        # Then pdd_node's paused-check fires.
+        # We return different voyages on each _load_voyage call.
+        voyages_to_serve = iter([_mock_voyage(), _mock_voyage(), paused_voyage, paused_voyage])
+        monkeypatch.setattr(
+            "app.crew.pipeline_graph._load_voyage",
+            AsyncMock(side_effect=lambda session, vid: next(voyages_to_serve)),
+        )
+        monkeypatch.setattr("app.crew.pipeline_graph._load_plan", AsyncMock(return_value=plan))
+        monkeypatch.setattr("app.crew.pipeline_graph._load_poneglyphs", AsyncMock(return_value=[]))
+        monkeypatch.setattr(
+            "app.crew.pipeline_graph._load_health_checks", AsyncMock(return_value=[])
+        )
+        monkeypatch.setattr(
+            "app.crew.pipeline_graph._load_build_artifacts", AsyncMock(return_value=[])
+        )
+        monkeypatch.setattr(
+            "app.crew.pipeline_graph._load_latest_validation", AsyncMock(return_value=None)
+        )
+        _mock_guard(monkeypatch, "require_can_enter_planning")
+
+        graph = build_pipeline_graph(ctx)
+        final = await graph.ainvoke(_make_state())
+        assert final["paused"] is True
+
+    @pytest.mark.asyncio
+    async def test_stage_entered_and_completed_events_emitted(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Stage events emitted with matching stage name and skipped=True when skipped."""
+        ctx = _mock_ctx()
+        voyage = _mock_voyage()
+        plan = _mock_plan()
+        poneglyphs = [_poneglyph(1)]
+        _patch_loads(monkeypatch, voyage=voyage, plan=plan, poneglyphs=poneglyphs, health_checks=[])
+        _mock_guard(monkeypatch, "require_can_enter_pdd")
+        _mock_guard(monkeypatch, "require_can_enter_tdd")
+
+        node = _make_pdd_node(ctx)
+        await node(_make_state())
+        published = [c.args[1] for c in ctx.mushi.publish.call_args_list]
+        completed = [e for e in published if isinstance(e, PipelineStageCompletedEvent)]
+        assert len(completed) == 1
+        assert completed[0].payload["stage"] == STAGE_PDD
+        assert completed[0].payload["skipped"] is True
+        # No stage_entered because the stage was skipped.
+        entered = [e for e in published if isinstance(e, PipelineStageEnteredEvent)]
+        assert len(entered) == 0

--- a/src/backend/tests/test_pipeline_service.py
+++ b/src/backend/tests/test_pipeline_service.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
+import time
 import uuid
-from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -15,6 +15,25 @@ from app.services.pipeline_service import PipelineService
 
 VOYAGE_ID = uuid.uuid4()
 USER_ID = uuid.uuid4()
+
+
+def _happy_final_state() -> dict:
+    return {
+        "voyage_id": VOYAGE_ID,
+        "user_id": USER_ID,
+        "deploy_tier": "preview",
+        "max_parallel_shipwrights": 1,
+        "task": "t",
+        "start_monotonic": time.monotonic(),
+        "plan_id": None,
+        "poneglyph_count": 0,
+        "health_check_count": 0,
+        "build_artifact_count": 0,
+        "validation_run_id": None,
+        "deployment_id": None,
+        "error": None,
+        "paused": False,
+    }
 
 
 def _mock_voyage(
@@ -80,9 +99,21 @@ def service(
     )
 
 
+def _patch_graph(monkeypatch: pytest.MonkeyPatch, final_state: dict) -> AsyncMock:
+    mock_graph = AsyncMock()
+    mock_graph.ainvoke = AsyncMock(return_value=final_state)
+    monkeypatch.setattr(
+        "app.services.pipeline_service.build_pipeline_graph",
+        lambda _ctx: mock_graph,
+    )
+    return mock_graph
+
+
 class TestStartGuardFailure:
     @pytest.mark.asyncio
-    async def test_already_building_raises_pipeline_error(self, service: PipelineService) -> None:
+    async def test_already_building_raises_pipeline_error(
+        self, service: PipelineService, mock_mushi: AsyncMock
+    ) -> None:
         voyage = _mock_voyage(status=VoyageStatus.BUILDING.value)
         with pytest.raises(PipelineError) as exc:
             await service.start(voyage, USER_ID, "task")
@@ -94,6 +125,29 @@ class TestStartGuardFailure:
         with pytest.raises(PipelineError):
             await service.start(voyage, USER_ID, "task")
 
+    @pytest.mark.asyncio
+    async def test_pre_flight_guard_failure_publishes_pipeline_failed(
+        self, service: PipelineService, mock_mushi: AsyncMock
+    ) -> None:
+        voyage = _mock_voyage(status=VoyageStatus.BUILDING.value)
+        with pytest.raises(PipelineError):
+            await service.start(voyage, USER_ID, "task")
+        published = [c.args[1] for c in mock_mushi.publish.call_args_list]
+        assert any(isinstance(e, PipelineFailedEvent) for e in published)
+
+    @pytest.mark.asyncio
+    async def test_invalid_concurrency_publishes_pipeline_failed(
+        self, service: PipelineService, mock_mushi: AsyncMock
+    ) -> None:
+        voyage = _mock_voyage()
+        with pytest.raises(PipelineError) as exc:
+            await service.start(voyage, USER_ID, "task", max_parallel_shipwrights=99)
+        assert exc.value.code == "INVALID_CONCURRENCY"
+        published = [c.args[1] for c in mock_mushi.publish.call_args_list]
+        failed_events = [e for e in published if isinstance(e, PipelineFailedEvent)]
+        assert len(failed_events) == 1
+        assert failed_events[0].payload["code"] == "INVALID_CONCURRENCY"
+
 
 class TestStartHappyPath:
     @pytest.mark.asyncio
@@ -103,28 +157,7 @@ class TestStartHappyPath:
         mock_mushi: AsyncMock,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        mock_graph = AsyncMock()
-        mock_graph.ainvoke = AsyncMock(
-            return_value={
-                "voyage_id": VOYAGE_ID,
-                "user_id": USER_ID,
-                "deploy_tier": "preview",
-                "max_parallel_shipwrights": 1,
-                "task": "t",
-                "plan_id": None,
-                "poneglyph_count": 0,
-                "health_check_count": 0,
-                "build_artifact_count": 0,
-                "validation_run_id": None,
-                "deployment_id": None,
-                "error": None,
-                "paused": False,
-            }
-        )
-        monkeypatch.setattr(
-            "app.services.pipeline_service.build_pipeline_graph",
-            lambda _ctx: mock_graph,
-        )
+        _patch_graph(monkeypatch, _happy_final_state())
 
         voyage = _mock_voyage()
         await service.start(voyage, USER_ID, "Build login")
@@ -138,30 +171,34 @@ class TestStartHappyPath:
         service: PipelineService,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
+        state = _happy_final_state()
+        state["paused"] = True
+        _patch_graph(monkeypatch, state)
+        voyage = _mock_voyage()
+        await service.start(voyage, USER_ID, "task")
+
+    @pytest.mark.asyncio
+    async def test_start_monotonic_threaded_into_initial_state(
+        self,
+        service: PipelineService,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        captured: dict = {}
+
+        async def capture_ainvoke(state: dict) -> dict:
+            captured.update(state)
+            return _happy_final_state()
+
         mock_graph = AsyncMock()
-        mock_graph.ainvoke = AsyncMock(
-            return_value={
-                "voyage_id": VOYAGE_ID,
-                "user_id": USER_ID,
-                "deploy_tier": "preview",
-                "max_parallel_shipwrights": 1,
-                "task": "t",
-                "plan_id": None,
-                "poneglyph_count": 0,
-                "health_check_count": 0,
-                "build_artifact_count": 0,
-                "validation_run_id": None,
-                "deployment_id": None,
-                "error": None,
-                "paused": True,
-            }
-        )
+        mock_graph.ainvoke = capture_ainvoke
         monkeypatch.setattr(
             "app.services.pipeline_service.build_pipeline_graph",
             lambda _ctx: mock_graph,
         )
         voyage = _mock_voyage()
         await service.start(voyage, USER_ID, "task")
+        assert "start_monotonic" in captured
+        assert isinstance(captured["start_monotonic"], float)
 
 
 class TestStartFailurePath:
@@ -169,32 +206,13 @@ class TestStartFailurePath:
     async def test_error_in_final_state_raises_pipeline_error(
         self, service: PipelineService, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        mock_graph = AsyncMock()
-        mock_graph.ainvoke = AsyncMock(
-            return_value={
-                "voyage_id": VOYAGE_ID,
-                "user_id": USER_ID,
-                "deploy_tier": "preview",
-                "max_parallel_shipwrights": 1,
-                "task": "t",
-                "plan_id": None,
-                "poneglyph_count": 0,
-                "health_check_count": 0,
-                "build_artifact_count": 0,
-                "validation_run_id": None,
-                "deployment_id": None,
-                "error": {
-                    "code": "PHASE_NOT_BUILDABLE",
-                    "message": "already built",
-                    "stage": "BUILDING",
-                },
-                "paused": False,
-            }
-        )
-        monkeypatch.setattr(
-            "app.services.pipeline_service.build_pipeline_graph",
-            lambda _ctx: mock_graph,
-        )
+        state = _happy_final_state()
+        state["error"] = {
+            "code": "PHASE_NOT_BUILDABLE",
+            "message": "already built",
+            "stage": "BUILDING",
+        }
+        _patch_graph(monkeypatch, state)
         voyage = _mock_voyage()
         with pytest.raises(PipelineError) as exc:
             await service.start(voyage, USER_ID, "task")
@@ -433,6 +451,7 @@ class TestPipelineStateShape:
             "deploy_tier": "preview",
             "max_parallel_shipwrights": 1,
             "task": "t",
+            "start_monotonic": time.monotonic(),
             "plan_id": None,
             "poneglyph_count": 0,
             "health_check_count": 0,
@@ -443,6 +462,3 @@ class TestPipelineStateShape:
             "paused": False,
         }
         assert state["voyage_id"] == VOYAGE_ID
-
-
-_ = Any  # silence unused import warning for typing helper

--- a/src/backend/tests/test_pipeline_service.py
+++ b/src/backend/tests/test_pipeline_service.py
@@ -1,0 +1,448 @@
+"""Tests for PipelineService — orchestrates the full Voyage Pipeline."""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.den_den_mushi.events import PipelineFailedEvent, PipelineStartedEvent
+from app.models.enums import VoyageStatus
+from app.services.pipeline_guards import PipelineError
+from app.services.pipeline_service import PipelineService
+
+VOYAGE_ID = uuid.uuid4()
+USER_ID = uuid.uuid4()
+
+
+def _mock_voyage(
+    status: str = VoyageStatus.CHARTED.value,
+    phase_status: dict[str, str] | None = None,
+) -> MagicMock:
+    v = MagicMock()
+    v.id = VOYAGE_ID
+    v.status = status
+    v.phase_status = phase_status if phase_status is not None else {}
+    return v
+
+
+@pytest.fixture
+def mock_session() -> AsyncMock:
+    session = AsyncMock()
+    session.add = MagicMock()
+    session.commit = AsyncMock()
+    result_mock = MagicMock()
+    result_mock.scalar_one_or_none.return_value = None
+    result_mock.scalar.return_value = 0
+    session.execute = AsyncMock(return_value=result_mock)
+    return session
+
+
+@pytest.fixture
+def mock_mushi() -> AsyncMock:
+    m = AsyncMock()
+    m.publish = AsyncMock(return_value="msg-1")
+    return m
+
+
+@pytest.fixture
+def mock_dial_router() -> AsyncMock:
+    return AsyncMock()
+
+
+@pytest.fixture
+def mock_execution() -> AsyncMock:
+    return AsyncMock()
+
+
+@pytest.fixture
+def mock_backend() -> AsyncMock:
+    return AsyncMock()
+
+
+@pytest.fixture
+def service(
+    mock_session: AsyncMock,
+    mock_mushi: AsyncMock,
+    mock_dial_router: AsyncMock,
+    mock_execution: AsyncMock,
+    mock_backend: AsyncMock,
+) -> PipelineService:
+    return PipelineService(
+        session=mock_session,
+        mushi=mock_mushi,
+        dial_router=mock_dial_router,
+        execution_service=mock_execution,
+        git_service=None,
+        deployment_backend=mock_backend,
+    )
+
+
+class TestStartGuardFailure:
+    @pytest.mark.asyncio
+    async def test_already_building_raises_pipeline_error(self, service: PipelineService) -> None:
+        voyage = _mock_voyage(status=VoyageStatus.BUILDING.value)
+        with pytest.raises(PipelineError) as exc:
+            await service.start(voyage, USER_ID, "task")
+        assert exc.value.code == "VOYAGE_NOT_PLANNABLE"
+
+    @pytest.mark.asyncio
+    async def test_completed_voyage_raises_pipeline_error(self, service: PipelineService) -> None:
+        voyage = _mock_voyage(status=VoyageStatus.COMPLETED.value)
+        with pytest.raises(PipelineError):
+            await service.start(voyage, USER_ID, "task")
+
+
+class TestStartHappyPath:
+    @pytest.mark.asyncio
+    async def test_publishes_pipeline_started(
+        self,
+        service: PipelineService,
+        mock_mushi: AsyncMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        mock_graph = AsyncMock()
+        mock_graph.ainvoke = AsyncMock(
+            return_value={
+                "voyage_id": VOYAGE_ID,
+                "user_id": USER_ID,
+                "deploy_tier": "preview",
+                "max_parallel_shipwrights": 1,
+                "task": "t",
+                "plan_id": None,
+                "poneglyph_count": 0,
+                "health_check_count": 0,
+                "build_artifact_count": 0,
+                "validation_run_id": None,
+                "deployment_id": None,
+                "error": None,
+                "paused": False,
+            }
+        )
+        monkeypatch.setattr(
+            "app.services.pipeline_service.build_pipeline_graph",
+            lambda _ctx: mock_graph,
+        )
+
+        voyage = _mock_voyage()
+        await service.start(voyage, USER_ID, "Build login")
+
+        published = [c.args[1] for c in mock_mushi.publish.call_args_list]
+        assert any(isinstance(e, PipelineStartedEvent) for e in published)
+
+    @pytest.mark.asyncio
+    async def test_paused_final_state_returns_without_raising(
+        self,
+        service: PipelineService,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        mock_graph = AsyncMock()
+        mock_graph.ainvoke = AsyncMock(
+            return_value={
+                "voyage_id": VOYAGE_ID,
+                "user_id": USER_ID,
+                "deploy_tier": "preview",
+                "max_parallel_shipwrights": 1,
+                "task": "t",
+                "plan_id": None,
+                "poneglyph_count": 0,
+                "health_check_count": 0,
+                "build_artifact_count": 0,
+                "validation_run_id": None,
+                "deployment_id": None,
+                "error": None,
+                "paused": True,
+            }
+        )
+        monkeypatch.setattr(
+            "app.services.pipeline_service.build_pipeline_graph",
+            lambda _ctx: mock_graph,
+        )
+        voyage = _mock_voyage()
+        await service.start(voyage, USER_ID, "task")
+
+
+class TestStartFailurePath:
+    @pytest.mark.asyncio
+    async def test_error_in_final_state_raises_pipeline_error(
+        self, service: PipelineService, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        mock_graph = AsyncMock()
+        mock_graph.ainvoke = AsyncMock(
+            return_value={
+                "voyage_id": VOYAGE_ID,
+                "user_id": USER_ID,
+                "deploy_tier": "preview",
+                "max_parallel_shipwrights": 1,
+                "task": "t",
+                "plan_id": None,
+                "poneglyph_count": 0,
+                "health_check_count": 0,
+                "build_artifact_count": 0,
+                "validation_run_id": None,
+                "deployment_id": None,
+                "error": {
+                    "code": "PHASE_NOT_BUILDABLE",
+                    "message": "already built",
+                    "stage": "BUILDING",
+                },
+                "paused": False,
+            }
+        )
+        monkeypatch.setattr(
+            "app.services.pipeline_service.build_pipeline_graph",
+            lambda _ctx: mock_graph,
+        )
+        voyage = _mock_voyage()
+        with pytest.raises(PipelineError) as exc:
+            await service.start(voyage, USER_ID, "task")
+        assert exc.value.code == "PHASE_NOT_BUILDABLE"
+
+    @pytest.mark.asyncio
+    async def test_graph_exception_publishes_pipeline_failed(
+        self,
+        service: PipelineService,
+        mock_mushi: AsyncMock,
+        mock_session: AsyncMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        mock_graph = AsyncMock()
+        mock_graph.ainvoke = AsyncMock(side_effect=RuntimeError("boom"))
+        monkeypatch.setattr(
+            "app.services.pipeline_service.build_pipeline_graph",
+            lambda _ctx: mock_graph,
+        )
+        # stub the voyage reload in _mark_failed
+        reload_voyage = _mock_voyage()
+        reload_result = MagicMock()
+        reload_result.scalar_one_or_none.return_value = reload_voyage
+        empty_result = MagicMock()
+        empty_result.scalar_one_or_none.return_value = None
+        empty_result.scalar.return_value = 0
+        # First call in _resolve_concurrency returns empty dial config;
+        # next calls for _mark_failed return the voyage.
+        mock_session.execute.side_effect = [empty_result, reload_result]
+        voyage = _mock_voyage()
+        with pytest.raises(PipelineError) as exc:
+            await service.start(voyage, USER_ID, "task")
+        assert exc.value.code == "PIPELINE_INTERNAL"
+
+        published = [c.args[1] for c in mock_mushi.publish.call_args_list]
+        assert any(isinstance(e, PipelineFailedEvent) for e in published)
+
+
+class TestResolveConcurrency:
+    @pytest.mark.asyncio
+    async def test_override_within_bounds(self, service: PipelineService) -> None:
+        result = await service._resolve_concurrency(VOYAGE_ID, 5)
+        assert result == 5
+
+    @pytest.mark.asyncio
+    async def test_override_too_low_raises(self, service: PipelineService) -> None:
+        with pytest.raises(PipelineError) as exc:
+            await service._resolve_concurrency(VOYAGE_ID, 0)
+        assert exc.value.code == "INVALID_CONCURRENCY"
+
+    @pytest.mark.asyncio
+    async def test_override_too_high_raises(self, service: PipelineService) -> None:
+        with pytest.raises(PipelineError) as exc:
+            await service._resolve_concurrency(VOYAGE_ID, 11)
+        assert exc.value.code == "INVALID_CONCURRENCY"
+
+    @pytest.mark.asyncio
+    async def test_default_when_no_override_and_no_dial_config(
+        self, service: PipelineService
+    ) -> None:
+        result = await service._resolve_concurrency(VOYAGE_ID, None)
+        assert result == 1
+
+    @pytest.mark.asyncio
+    async def test_reads_from_dial_config_when_present(
+        self, service: PipelineService, mock_session: AsyncMock
+    ) -> None:
+        dial_config = MagicMock()
+        dial_config.role_mapping = {"shipwright": {"max_concurrency": 4}}
+        result_mock = MagicMock()
+        result_mock.scalar_one_or_none.return_value = dial_config
+        mock_session.execute = AsyncMock(return_value=result_mock)
+        result = await service._resolve_concurrency(VOYAGE_ID, None)
+        assert result == 4
+
+
+class TestPauseCancel:
+    @pytest.mark.asyncio
+    async def test_pause_sets_voyage_paused(
+        self, service: PipelineService, mock_session: AsyncMock
+    ) -> None:
+        voyage = _mock_voyage(status=VoyageStatus.BUILDING.value)
+        await service.pause(voyage)
+        assert voyage.status == VoyageStatus.PAUSED.value
+        mock_session.commit.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_pause_skips_terminal_status(
+        self, service: PipelineService, mock_session: AsyncMock
+    ) -> None:
+        voyage = _mock_voyage(status=VoyageStatus.COMPLETED.value)
+        await service.pause(voyage)
+        assert voyage.status == VoyageStatus.COMPLETED.value
+        mock_session.commit.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_cancel_sets_voyage_cancelled(
+        self, service: PipelineService, mock_session: AsyncMock
+    ) -> None:
+        voyage = _mock_voyage(status=VoyageStatus.BUILDING.value)
+        await service.cancel(voyage)
+        assert voyage.status == VoyageStatus.CANCELLED.value
+        mock_session.commit.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_cancel_skips_failed_voyage(
+        self, service: PipelineService, mock_session: AsyncMock
+    ) -> None:
+        voyage = _mock_voyage(status=VoyageStatus.FAILED.value)
+        await service.cancel(voyage)
+        mock_session.commit.assert_not_awaited()
+
+
+class TestGetStatus:
+    @pytest.mark.asyncio
+    async def test_returns_snapshot_with_counts(
+        self, service: PipelineService, mock_session: AsyncMock
+    ) -> None:
+        count_result = MagicMock()
+        count_result.scalar.return_value = 3
+
+        val_result = MagicMock()
+        latest_val = MagicMock()
+        latest_val.status = "passed"
+        val_result.scalar_one_or_none.return_value = latest_val
+
+        dep_result = MagicMock()
+        dep_result.scalar_one_or_none.return_value = None
+
+        err_result = MagicMock()
+        err_result.scalar_one_or_none.return_value = None
+
+        # order of execute calls in get_status:
+        # plan_exists, poneglyph_count, health_check_count,
+        # build_artifact_count, latest_validation, latest_deployment, error_card
+        mock_session.execute.side_effect = [
+            count_result,
+            count_result,
+            count_result,
+            count_result,
+            val_result,
+            dep_result,
+            err_result,
+        ]
+
+        voyage = _mock_voyage(phase_status={"1": "BUILT"})
+        snapshot = await service.get_status(voyage)
+        assert snapshot.voyage_id == VOYAGE_ID
+        assert snapshot.poneglyph_count == 3
+        assert snapshot.plan_exists is True
+        assert snapshot.last_validation_status == "passed"
+        assert snapshot.phase_status == {"1": "BUILT"}
+        assert snapshot.error is None
+
+    @pytest.mark.asyncio
+    async def test_error_card_populates_error(
+        self, service: PipelineService, mock_session: AsyncMock
+    ) -> None:
+        count_result = MagicMock()
+        count_result.scalar.return_value = 0
+
+        empty_result = MagicMock()
+        empty_result.scalar_one_or_none.return_value = None
+
+        err_result = MagicMock()
+        err_card = MagicMock()
+        err_card.state_data = {"code": "DEPLOYMENT_FAILED", "message": "boom"}
+        err_result.scalar_one_or_none.return_value = err_card
+
+        mock_session.execute.side_effect = [
+            count_result,
+            count_result,
+            count_result,
+            count_result,
+            empty_result,
+            empty_result,
+            err_result,
+        ]
+
+        voyage = _mock_voyage()
+        snapshot = await service.get_status(voyage)
+        assert snapshot.error is not None
+        assert snapshot.error["code"] == "DEPLOYMENT_FAILED"
+
+
+class TestReaderFactory:
+    def test_reader_instance_has_session_only(self, mock_session: AsyncMock) -> None:
+        reader = PipelineService.reader(mock_session)
+        assert reader._session is mock_session
+
+
+class TestPublishFailureIsSwallowed:
+    @pytest.mark.asyncio
+    async def test_publish_failure_on_start_does_not_raise(
+        self,
+        service: PipelineService,
+        mock_mushi: AsyncMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        mock_mushi.publish = AsyncMock(side_effect=RuntimeError("redis down"))
+
+        mock_graph = AsyncMock()
+        mock_graph.ainvoke = AsyncMock(
+            return_value={
+                "voyage_id": VOYAGE_ID,
+                "user_id": USER_ID,
+                "deploy_tier": "preview",
+                "max_parallel_shipwrights": 1,
+                "task": "t",
+                "plan_id": None,
+                "poneglyph_count": 0,
+                "health_check_count": 0,
+                "build_artifact_count": 0,
+                "validation_run_id": None,
+                "deployment_id": None,
+                "error": None,
+                "paused": False,
+            }
+        )
+        monkeypatch.setattr(
+            "app.services.pipeline_service.build_pipeline_graph",
+            lambda _ctx: mock_graph,
+        )
+        voyage = _mock_voyage()
+        # Should not raise
+        await service.start(voyage, USER_ID, "task")
+
+
+class TestPipelineStateShape:
+    def test_initial_state_has_all_required_fields(self) -> None:
+        from app.crew.pipeline_graph import PipelineState  # noqa: PLC0415
+
+        state: PipelineState = {
+            "voyage_id": VOYAGE_ID,
+            "user_id": USER_ID,
+            "deploy_tier": "preview",
+            "max_parallel_shipwrights": 1,
+            "task": "t",
+            "plan_id": None,
+            "poneglyph_count": 0,
+            "health_check_count": 0,
+            "build_artifact_count": 0,
+            "validation_run_id": None,
+            "deployment_id": None,
+            "error": None,
+            "paused": False,
+        }
+        assert state["voyage_id"] == VOYAGE_ID
+
+
+_ = Any  # silence unused import warning for typing helper


### PR DESCRIPTION
## Summary
- Wires all five crew services (Captain → Navigator → Doctor → Shipwrights → Doctor → Helmsman) into a single LangGraph state machine with pause/resume via DB status (not LangGraph checkpointers)
- Parallel Shipwright: phases run in topological layers bounded by `asyncio.Semaphore(max_parallel_shipwrights)`
- Adds 5 pipeline-level events (`pipeline_started`, `pipeline_stage_entered`, `pipeline_stage_completed`, `pipeline_completed`, `pipeline_failed`) and a `PipelineStatusSnapshot` read-model
- Resume is skip-already-satisfied-aggressive: uses Phase 15.2 guards as predicates to skip stages whose output already exists (zero-token resume)

## Design decisions (logged in `pdd/context/decisions.md`)
- Graph invokes services directly — no sub-graphs
- DB-backed pause/resume — no `langgraph.checkpoint` dependency
- SSE reuses existing DenDenMushi voyage stream — no new event pipeline
- Pipeline owns terminal voyage.status writes (`COMPLETED` / `FAILED`); crew services keep transient writes

## Test plan
- [x] `tests/test_pipeline_graph.py` — 16 tests (topological_layers cycles/diamonds/parallel, graph compile + node structure, routing)
- [x] `tests/test_pipeline_service.py` — 20 tests (start happy/pause/error/graph-exception, _resolve_concurrency via DialConfig, pause/cancel/get_status, publish-failure swallowed)
- [x] `tests/test_den_den_mushi_events.py` — 5 new event tests + parse_event coverage
- [x] Full suite: 739 passed, 10 skipped
- [x] ruff clean, mypy clean