### PR TITLE
feat: pipeline REST + SSE API endpoints (Phase 15.4) #16

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,150 @@
+.DEFAULT_GOAL := help
+SHELL := /bin/bash
+
+# ── Config ────────────────────────────────────────────────────────────────────
+COMPOSE_FILE := src/infra/docker/docker-compose.yml
+BACKEND := src/backend
+FRONTEND := src/frontend
+VENV := $(BACKEND)/venv
+PY := $(VENV)/bin/python3
+PIP := $(VENV)/bin/pip
+
+# Container runtime selection: prefer `docker compose` (Docker Desktop),
+# fall back to `podman compose`. Override with COMPOSE=... if needed.
+COMPOSE ?= $(shell \
+	if docker compose version >/dev/null 2>&1; then echo "docker compose"; \
+	elif command -v podman >/dev/null 2>&1 && podman compose version >/dev/null 2>&1; then echo "podman compose"; \
+	else echo "docker compose"; fi) -f $(COMPOSE_FILE)
+
+# ── Help ──────────────────────────────────────────────────────────────────────
+.PHONY: help
+help: ## Show this help
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z0-9_.-]+:.*?## / {printf "  \033[36m%-22s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+
+# ── Environment ──────────────────────────────────────────────────────────────
+.PHONY: podman-start
+podman-start: ## Start the Podman VM if not running (macOS)
+	@podman machine list --format '{{.LastUp}}' 2>/dev/null | head -1 | grep -q 'ago\|Currently running' \
+		|| podman machine start
+
+.PHONY: venv
+venv: ## Create backend venv and install requirements
+	@test -d $(VENV) || python3 -m venv $(VENV)
+	$(PIP) install -U pip
+	$(PIP) install -r $(BACKEND)/requirements.txt
+
+# ── Infra (Postgres + Redis) ─────────────────────────────────────────────────
+.PHONY: up
+up: podman-start ## Start Postgres + Redis containers
+	$(COMPOSE) up -d db redis
+
+.PHONY: up-api
+up-api: podman-start ## Start Postgres + Redis + API (all in containers)
+	$(COMPOSE) up -d db redis api
+
+.PHONY: down
+down: ## Stop all containers (preserves volumes)
+	$(COMPOSE) down
+
+.PHONY: nuke
+nuke: ## Stop containers AND delete volumes (full reset)
+	$(COMPOSE) down -v
+
+.PHONY: ps
+ps: ## List running containers
+	$(COMPOSE) ps
+
+.PHONY: logs
+logs: ## Tail logs for all services
+	$(COMPOSE) logs -f --tail=200
+
+.PHONY: logs-db
+logs-db: ## Tail Postgres logs
+	$(COMPOSE) logs -f --tail=200 db
+
+.PHONY: logs-api
+logs-api: ## Tail API container logs
+	$(COMPOSE) logs -f --tail=200 api
+
+.PHONY: psql
+psql: ## Open psql shell inside the db container
+	$(COMPOSE) exec db psql -U grandline -d grandline
+
+.PHONY: redis-cli
+redis-cli: ## Open redis-cli inside the redis container
+	$(COMPOSE) exec redis redis-cli
+
+# ── Migrations ───────────────────────────────────────────────────────────────
+.PHONY: migrate
+migrate: ## Apply all alembic migrations (against localhost DB)
+	cd $(BACKEND) && source venv/bin/activate && PYTHONPATH=. alembic upgrade head
+
+.PHONY: migrate-down
+migrate-down: ## Roll back one alembic revision
+	cd $(BACKEND) && source venv/bin/activate && PYTHONPATH=. alembic downgrade -1
+
+.PHONY: migrate-status
+migrate-status: ## Show current alembic revision
+	cd $(BACKEND) && source venv/bin/activate && PYTHONPATH=. alembic current
+
+# ── Backend (local dev, against containerized db+redis) ──────────────────────
+.PHONY: api-dev
+api-dev: ## Run FastAPI locally with uvicorn --reload
+	cd $(BACKEND) && source venv/bin/activate && \
+		GRANDLINE_DATABASE_URL=postgresql+psycopg://grandline:grandline@localhost:5432/grandline \
+		GRANDLINE_REDIS_URL=redis://localhost:6379/0 \
+		uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
+
+.PHONY: test
+test: ## Run full backend test suite
+	cd $(BACKEND) && source venv/bin/activate && pytest -q
+
+.PHONY: test-pipeline
+test-pipeline: ## Run pipeline-specific tests only
+	cd $(BACKEND) && source venv/bin/activate && \
+		pytest -q tests/test_pipeline_api.py tests/test_pipeline_service.py tests/test_pipeline_graph.py
+
+.PHONY: lint
+lint: ## Ruff check + mypy
+	cd $(BACKEND) && source venv/bin/activate && ruff check app/ tests/ && mypy app/
+
+.PHONY: fmt
+fmt: ## Ruff format
+	cd $(BACKEND) && source venv/bin/activate && ruff format app/ tests/
+
+# ── Frontend ─────────────────────────────────────────────────────────────────
+.PHONY: frontend-install
+frontend-install: ## Install frontend deps
+	cd $(FRONTEND) && npm install
+
+.PHONY: frontend-dev
+frontend-dev: ## Start Next.js dev server
+	cd $(FRONTEND) && npm run dev
+
+.PHONY: frontend-test
+frontend-test: ## Run frontend tests (vitest)
+	cd $(FRONTEND) && npm test
+
+# ── Full setup + start ───────────────────────────────────────────────────────
+.PHONY: setup
+setup: venv up migrate ## One-shot: venv + infra + migrations
+	@echo ""
+	@echo "  ✓ Setup complete. Next steps:"
+	@echo "    make api-dev        # run the backend locally"
+	@echo "    make frontend-dev   # run the frontend (separate terminal)"
+
+.PHONY: api-mocked
+api-mocked: ## Run FastAPI with PipelineService.start mocked (for smoke test)
+	@PODMAN_SOCK=$$(podman machine inspect --format '{{.ConnectionInfo.PodmanSocket.Path}}' 2>/dev/null || true); \
+	cd $(BACKEND) && source venv/bin/activate && \
+		DOCKER_HOST=unix://$$PODMAN_SOCK \
+		GRANDLINE_DATABASE_URL=postgresql+psycopg://grandline:grandline@localhost:5432/grandline \
+		GRANDLINE_REDIS_URL=redis://localhost:6379/0 \
+		PYTHONPATH=. python3 -m scripts.dev_api_mocked
+
+.PHONY: smoke
+smoke: ## Run the Phase 15.4 manual-test smoke script (requires infra + api-mocked up)
+	cd $(BACKEND) && source venv/bin/activate && \
+		GRANDLINE_DATABASE_URL=postgresql+psycopg://grandline:grandline@localhost:5432/grandline \
+		GRANDLINE_REDIS_URL=redis://localhost:6379/0 \
+		PYTHONPATH=. python3 -m scripts.smoke_pipeline_api

--- a/pdd/context/decisions.md
+++ b/pdd/context/decisions.md
@@ -1,6 +1,14 @@
 # GrandLine — Architectural Decisions
 
-**Last updated**: 2026-04-23
+**Last updated**: 2026-04-24
+
+---
+
+## Decision: Pipeline REST + SSE API on top of PipelineService; background tasks in `app.state.pipeline_tasks`; SSE via ephemeral consumer groups
+**Date**: 2026-04-24
+**What was decided**: Added `app/api/v1/pipeline.py` with five endpoints: `POST /voyages/{id}/start` (202 Accepted, spawns `asyncio.create_task(service.start(...))` registered in `app.state.pipeline_tasks: dict[uuid.UUID, asyncio.Task]` and cleaned up via `task.add_done_callback`), `POST /pause` / `POST /cancel` (200, idempotent on terminal status; `/cancel` also cancels the in-flight task), `GET /status` (uses `PipelineService.reader(session)` — no dial router / execution backend constructed), and `GET /stream` (SSE, `text/event-stream`, one fresh ephemeral consumer group per connection named `sse-<uuid>`, replay-from-start at `id="0"`, ~1s block timeout with `request.is_disconnected()` check each loop, terminates on voyage terminal status or client disconnect, destroys the group in the `finally` block). Running-pipeline idempotency on `POST /start` is 409 `PIPELINE_ALREADY_RUNNING`; COMPLETED voyage also 409. `StartVoyageRequest` has `task: str (10–5000 chars)`, `deploy_tier: Literal["preview"]`, `max_parallel_shipwrights: int | None (ge=1 le=10)`. Shutdown in `app/main.py` lifespan cancels in-flight tasks and awaits up to 5s. No `last-event-id` / SSE resume in v1.
+**Why**: Making `POST /start` 202 + background task keeps the HTTP layer responsive — the graph run takes minutes, not milliseconds, and clients observe it via SSE. The registry is process-local and single-worker by design; a multi-worker deployment would need to move it to Redis, but v1 runs single-worker and the simplicity is worth more than the horizontal-scale story. Ephemeral per-connection consumer groups sidestep cross-client ack coordination: each SSE consumer gets its own replay and the group dies with the connection (clean finally cleanup). Terminating on DB voyage status — rather than a dedicated "stream-end" event — means the SSE endpoint doesn't need to know about every terminal event type; any final state flip closes the stream. Running-pipeline 409 forces callers to explicitly cancel + restart rather than silently stomping on an in-flight run. The 5s shutdown window gives spawning `PipelineFailedEvent` one chance to reach Redis before the loop tears down.
+**Don't suggest**: Persisting `pipeline_tasks` to Redis for multi-worker (out of scope for v1), named SSE events (`event: pipeline_stage_entered\ndata: ...`) — the envelope already carries `event_type` inline, adding a dedicated "pipeline finished" event to terminate SSE (DB status flip is sufficient), reusing a named consumer group across SSE connections (ack coordination headache), making `/start` synchronous (blocks connection for minutes), `last-event-id` support (revisit when stream volume > ~100 events per voyage)
 
 ---
 

--- a/pdd/prompts/features/pipeline/grandline-15-04-api-sse.md
+++ b/pdd/prompts/features/pipeline/grandline-15-04-api-sse.md
@@ -1,0 +1,440 @@
+# Phase 15.4: Pipeline REST + SSE API
+
+## Context
+
+Phase 15.3 landed the master Voyage Pipeline graph
+([pipeline_graph.py](src/backend/app/crew/pipeline_graph.py)),
+`PipelineService` orchestrator
+([pipeline_service.py](src/backend/app/services/pipeline_service.py)),
+and five pipeline-level events (Started / StageEntered / StageCompleted /
+Completed / Failed) on the Den Den Mushi stream. `PipelineService.start()`
+runs the graph to completion synchronously in the caller's event loop. No
+HTTP endpoints, no background tasks, no SSE — all intentionally deferred
+to this phase.
+
+Phase 15.4 is the **API layer**: five REST endpoints plus one SSE stream,
+plus the dependency-injection and background-task wiring needed to spawn
+the graph run without blocking the request. After this phase the frontend
+can start a voyage, observe it live over SSE, pause/cancel mid-run, and
+poll status — feature-complete from a user perspective. Phase 15.5 will
+add the full-stack integration test with real Postgres + Redis.
+
+**Locked decisions driving this phase** (see
+[PLAN-voyage-pipeline.md](PLAN-voyage-pipeline.md)):
+
+- **Background task runner lives at the API layer.** `POST /start` spawns
+  the pipeline via `asyncio.create_task(service.start(...))` and records
+  the task in `app.state.pipeline_tasks: dict[uuid.UUID, asyncio.Task]`
+  keyed by voyage id. The task callback removes itself from the registry
+  on completion (success or failure). The service stays sync-to-graph-
+  completion; only the endpoint wraps it in a task.
+- **SSE semantics**: `data: {json}\n\n` frames, no named events, fresh
+  consumer group per connection (`f"sse-{uuid.uuid4().hex}"`), short
+  block timeout (~1s) with disconnect check each iteration. Termination
+  on voyage terminal status (`COMPLETED` | `FAILED` | `CANCELLED`).
+- **Idempotency on POST /start**: running pipeline → 409;
+  COMPLETED → 409 (force re-run is out of scope; cancel + restart is the
+  workaround). `CHARTED` / `PAUSED` / `FAILED` → accept.
+- **POST /pause** and **POST /cancel**: write voyage.status to PAUSED /
+  CANCELLED and commit. The running graph observes the new status at
+  the next stage boundary (PipelineService already implements this in
+  each stage node). If no pipeline is running, both are idempotent
+  no-ops on terminal status; on PAUSED calling pause again is a no-op,
+  on CANCELLED calling cancel again is a no-op.
+- **GET /status** uses `PipelineService.reader(session)` — a read-only
+  variant that constructs without the live dial router / execution
+  backend / mushi. Returns `PipelineStatusSnapshot` unchanged from
+  Phase 15.3, wrapped in a thin response envelope.
+- **Authorization**: reuse the existing `get_authorized_voyage`
+  dependency ([dependencies.py:89-103](src/backend/app/api/v1/dependencies.py#L89-L103))
+  — 404 if voyage doesn't exist or belongs to another user. No separate
+  pipeline permission model.
+- **Concurrency override validation**: `StartVoyageRequest.max_parallel_shipwrights`
+  is `int | None` with `Field(ge=1, le=10)`. `None` falls through to
+  DialConfig then to the default of 1, matching `PipelineService._resolve_concurrency`
+  ([pipeline_service.py:258-275](src/backend/app/services/pipeline_service.py#L258-L275)).
+- **`deploy_tier` is `Literal["preview"]`** — only preview is wired in
+  this phase; staging / production come later with their own approval
+  flow. Matches the Phase 15.3 service signature.
+- **SSE replay-from-start by default** — fresh consumer groups created
+  at `id="0"` so a late-connecting client sees every event emitted for
+  the voyage so far. No `last-event-id` support in this phase; clients
+  that reconnect get the full stream again.
+- **Background task registry is process-local** — `app.state.pipeline_tasks`
+  is an in-memory dict. Multi-worker deployments are out of scope for
+  v1; the fleet runs single-worker. Tests cover task cleanup on
+  completion + cancellation.
+
+## Deliverables
+
+### 1. Schemas: `app/schemas/pipeline.py`
+
+**Extend the existing file** (already contains `PipelineStatusSnapshot`).
+Add three new models:
+
+```python
+class StartVoyageRequest(BaseModel):
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    task: str = Field(min_length=10, max_length=5000)
+    deploy_tier: Literal["preview"] = "preview"
+    max_parallel_shipwrights: int | None = Field(default=None, ge=1, le=10)
+
+
+class StartVoyageResponse(BaseModel):
+    model_config = ConfigDict(strict=True)
+
+    voyage_id: uuid.UUID
+    status: str              # voyage.status after start (PLANNING typically)
+    accepted: bool = True    # always True on 202; explicit for client clarity
+
+
+class PipelineEventEnvelope(BaseModel):
+    """Wire envelope sent over SSE for each Redis stream message."""
+
+    model_config = ConfigDict(strict=True)
+
+    msg_id: str              # Redis stream message id (for client dedup)
+    event: dict[str, Any]    # parsed event JSON (event_type, voyage_id, payload, ...)
+```
+
+`StartVoyageRequest.task` mirrors Captain's
+[ChartCourseRequest.task](src/backend/app/schemas/captain.py#L72-L73)
+constraints. Don't duplicate the validator — just match the length
+constraints on the field.
+
+### 2. Dependencies: `app/api/v1/dependencies.py`
+
+**Add two new dependency functions** alongside the existing ones:
+
+```python
+def get_pipeline_service(
+    voyage_id: uuid.UUID,
+    dial_router: DialSystemRouter = Depends(get_dial_router),
+    mushi: DenDenMushi = Depends(get_den_den_mushi),
+    session: AsyncSession = Depends(get_db),
+    execution_service: ExecutionService = Depends(get_execution_service),
+    git_service: GitService = Depends(get_git_service),
+    deployment_backend: DeploymentBackend = Depends(get_deployment_backend),
+) -> PipelineService:
+    return PipelineService(
+        session=session,
+        mushi=mushi,
+        dial_router=dial_router,
+        execution_service=execution_service,
+        git_service=git_service,
+        deployment_backend=deployment_backend,
+    )
+
+
+async def get_pipeline_service_reader(
+    session: AsyncSession = Depends(get_db),
+) -> PipelineService:
+    return PipelineService.reader(session)
+```
+
+Mirror the shape of
+[helmsman.py:get_helmsman_service / get_helmsman_reader](src/backend/app/api/v1/helmsman.py#L53-L73).
+No changes to existing dependencies.
+
+### 3. Pipeline router: `app/api/v1/pipeline.py` (new)
+
+**`POST /voyages/{voyage_id}/start` → 202**:
+- Body: `StartVoyageRequest`.
+- Guards: call `require_can_enter_planning(voyage)` eagerly (via
+  `PipelineService.start` internally) — translate `PipelineError` to HTTP
+  409 for `VOYAGE_NOT_PLANNABLE`, 400 for `INVALID_CONCURRENCY`, 422
+  otherwise.
+- **Running-pipeline idempotency**: if
+  `voyage_id in request.app.state.pipeline_tasks` and that task is not
+  yet done → 409 `{"code": "PIPELINE_ALREADY_RUNNING", ...}`.
+- Spawn `asyncio.create_task(service.start(voyage, user.id, body.task,
+  body.deploy_tier, body.max_parallel_shipwrights))`.
+- Register in `request.app.state.pipeline_tasks[voyage_id] = task`.
+- Attach `task.add_done_callback(lambda t: app.state.pipeline_tasks.pop(voyage_id, None))`.
+- Return `StartVoyageResponse(voyage_id=voyage_id, status=voyage.status)`.
+  The status is read from the **pre-spawn** voyage (typically `CHARTED`
+  if never run, or whatever state it was in). The service will update it
+  inside the task.
+
+**`POST /voyages/{voyage_id}/pause` → 200**:
+- Calls `PipelineService.pause(voyage)`. Idempotent on terminal statuses
+  (handled in the service). Returns `{"voyage_id", "status"}`.
+
+**`POST /voyages/{voyage_id}/cancel` → 200**:
+- Calls `PipelineService.cancel(voyage)`. Also cancels the in-flight
+  background task if present: `task.cancel()`. Return
+  `{"voyage_id", "status"}`. Do not `await` the cancelled task in the
+  request; the done_callback will clean up the registry.
+
+**`GET /voyages/{voyage_id}/status` → 200**:
+- Calls `PipelineService.reader(session).get_status(voyage)`. Returns
+  `PipelineStatusSnapshot` directly as the response body.
+
+**`GET /voyages/{voyage_id}/stream` → 200 text/event-stream**:
+- SSE endpoint. Implementation outline:
+  ```python
+  @router.get("/stream")
+  async def stream_events(...) -> StreamingResponse:
+      async def event_generator() -> AsyncGenerator[bytes, None]:
+          group = f"sse-{uuid.uuid4().hex}"
+          await mushi.ensure_group(stream_key(voyage.id), group)
+          consumer = f"sse-{uuid.uuid4().hex[:8]}"
+          try:
+              while True:
+                  if await request.is_disconnected():
+                      break
+                  batch = await mushi.read(
+                      stream=stream_key(voyage.id),
+                      group=group,
+                      consumer=consumer,
+                      count=10,
+                      block_ms=1000,
+                  )
+                  for msg_id, event in batch:
+                      envelope = PipelineEventEnvelope(
+                          msg_id=msg_id, event=event.model_dump(mode="json")
+                      )
+                      yield f"data: {envelope.model_dump_json()}\n\n".encode()
+                      await mushi.ack(stream_key(voyage.id), group, msg_id)
+                  # re-fetch voyage status; close on terminal
+                  refreshed = await session.get(Voyage, voyage.id)
+                  if refreshed and refreshed.status in {
+                      VoyageStatus.COMPLETED.value,
+                      VoyageStatus.FAILED.value,
+                      VoyageStatus.CANCELLED.value,
+                  }:
+                      break
+          finally:
+              # best-effort group cleanup: xgroup_destroy on the fresh group
+              try:
+                  await redis.xgroup_destroy(stream_key(voyage.id), group)
+              except Exception:
+                  pass
+      return StreamingResponse(event_generator(), media_type="text/event-stream")
+  ```
+- `mushi.read` returns `list[tuple[msg_id, DenDenMushiEvent]]`, matches
+  [mushi.py:32-68](src/backend/app/den_den_mushi/mushi.py#L32-L68).
+- Fresh ephemeral consumer group means each SSE connection replays from
+  `id="0"` (mushi.ensure_group default). Clients that reconnect see the
+  full history again — acceptable for v1.
+- Acknowledge each delivered message so the pending list stays empty.
+- Check `request.is_disconnected()` each iteration; bail cleanly on
+  client close.
+- On exit, destroy the group so Redis doesn't accumulate per-connection
+  groups. Best-effort; warn-and-swallow on failure.
+
+**HTTP error mapping** — mirror
+[helmsman.py:_helmsman_http_exception](src/backend/app/api/v1/helmsman.py#L45-L50):
+
+| PipelineError code | HTTP status |
+|---|---|
+| `VOYAGE_NOT_PLANNABLE` | 409 Conflict |
+| `PIPELINE_ALREADY_RUNNING` | 409 Conflict |
+| `INVALID_CONCURRENCY` | 400 Bad Request |
+| (anything else) | 422 Unprocessable Entity |
+
+Body shape: `{"error": {"code": "<CODE>", "message": "..."}}` — matches
+the project-wide convention.
+
+**Router registration**: include the new router in
+[app/api/v1/router.py](src/backend/app/api/v1/router.py) right after
+the helmsman router. Tag: `"pipeline"`.
+
+### 4. App state wiring: `app/main.py`
+
+**Initialize `app.state.pipeline_tasks`** in the FastAPI lifespan (or
+equivalent startup hook). Shape:
+`app.state.pipeline_tasks: dict[uuid.UUID, asyncio.Task[None]] = {}`.
+Nothing else changes in `main.py` — the dial router, mushi, execution
+service, git service, and deployment backend are already attached to
+`app.state` from earlier phases.
+
+On shutdown, cancel any still-running tasks and await them with a short
+timeout (5s) to give them a chance to emit `PipelineFailedEvent` before
+the process exits. Log warnings if any tasks don't finish in time.
+
+### 5. Tests: `tests/test_pipeline_api.py` (new)
+
+Follow the structure of
+[tests/test_helmsman_api.py](src/backend/tests/test_helmsman_api.py).
+Use `httpx.AsyncClient` via the existing `async_client` fixture. All
+crew services mocked at the `PipelineService` boundary (monkeypatch
+`PipelineService.start`, `.pause`, `.cancel`, `.get_status`). For SSE,
+use `httpx.AsyncClient.stream("GET", ...)` and iterate events.
+
+**`TestStartVoyage`**:
+- `test_start_returns_202_and_spawns_task` — happy path, assert
+  registry entry present, task awaited eventually
+- `test_start_rejects_running_pipeline_with_409`
+- `test_start_translates_voyage_not_plannable_to_409`
+- `test_start_translates_invalid_concurrency_to_400`
+- `test_start_validates_task_length` — `task=""` → 422 (Pydantic)
+- `test_start_validates_max_parallel_range` — 0 → 422, 11 → 422
+- `test_start_forbidden_for_other_users_voyage` — 404 via
+  `get_authorized_voyage`
+- `test_start_task_removes_itself_from_registry_on_completion` —
+  confirm `done_callback` pops the entry
+
+**`TestPauseVoyage`** / **`TestCancelVoyage`**:
+- `test_pause_returns_200_and_sets_status_paused`
+- `test_pause_is_idempotent_on_paused`
+- `test_pause_is_idempotent_on_terminal`
+- `test_cancel_returns_200_and_sets_status_cancelled`
+- `test_cancel_is_idempotent_on_terminal`
+- `test_cancel_also_cancels_running_task` — start a task, POST /cancel,
+  assert `task.cancelled()` within timeout
+
+**`TestGetStatus`**:
+- `test_status_returns_snapshot_shape`
+- `test_status_uses_pipeline_reader_not_full_service` — assert no
+  dial router / execution service construction during a status call
+  (patch `get_pipeline_service` and confirm it's NOT invoked)
+- `test_status_forbidden_for_other_users_voyage` — 404
+
+**`TestStreamEvents`**:
+- `test_stream_emits_events_from_redis_and_closes_on_completion` —
+  seed the Redis stream with three events ending in
+  `PipelineCompletedEvent`, open the SSE connection, collect frames,
+  assert three `data: ...` frames and a clean close
+- `test_stream_replays_from_start_for_fresh_connection` — pre-seed
+  two events, then connect, assert both replayed before live updates
+- `test_stream_closes_on_client_disconnect` — open, close client,
+  assert generator exits within short timeout
+- `test_stream_closes_on_voyage_failure` — emit
+  `PipelineFailedEvent`, flip voyage.status to FAILED, assert close
+- `test_stream_emits_valid_sse_frames` — each chunk matches
+  `^data: .+\n\n$` and envelope is JSON-parseable
+- `test_stream_forbidden_for_other_users_voyage` — 404
+
+**`TestPipelineSchemas`**:
+- `test_start_voyage_request_rejects_extra_fields`
+- `test_start_voyage_request_strict_types` — `max_parallel_shipwrights="2"`
+  (string) → validation error under `strict=True`
+- `test_pipeline_event_envelope_round_trip`
+
+**Test fixtures**:
+- Add `pipeline_tasks_registry` fixture that clears
+  `app.state.pipeline_tasks` before and after each test.
+- Reuse `authorized_voyage`, `async_client`, and `mushi_stream`
+  fixtures from the existing conftest if present; add them if not.
+- Mock `PipelineService.start` as an `AsyncMock` that sleeps briefly
+  (`await asyncio.sleep(0.05)`) so task-cleanup callbacks have a chance
+  to fire before assertions.
+- For SSE tests, use the real `DenDenMushi` + `fakeredis` if the
+  project already uses fakeredis, else an in-memory stub matching the
+  `mushi.read` contract. Check existing Redis-using tests
+  ([test_den_den_mushi_mushi.py](src/backend/tests/test_den_den_mushi_mushi.py))
+  for the established pattern.
+
+### 6. No service changes
+
+- Do NOT modify `PipelineService`, `pipeline_graph`, any crew service,
+  or any existing schema. This phase is pure API surface on top of
+  Phase 15.3.
+- Do NOT add new event types; the five from Phase 15.3 are sufficient.
+- Do NOT touch crew routers or dependencies unrelated to the pipeline.
+
+## Test Plan
+
+- [ ] All new tests in `tests/test_pipeline_api.py` pass
+- [ ] `ruff check app/ tests/` clean
+- [ ] `mypy app/` clean
+- [ ] All existing tests (780+) still pass — this phase only adds code
+- [ ] SSE test sends at least three events and the client receives all
+  of them before the stream closes
+- [ ] Background task registry: after a full happy-path test,
+  `app.state.pipeline_tasks` is empty (done_callback fired)
+- [ ] `POST /start` with a running pipeline returns 409 with
+  `PIPELINE_ALREADY_RUNNING` code
+- [ ] `POST /cancel` cancels both the DB status and the `asyncio.Task`
+- [ ] `GET /status` does not construct a dial router (pure read path)
+- [ ] Log one decision to
+  [pdd/context/decisions.md](pdd/context/decisions.md) (see Constraints)
+
+## Constraints
+
+- **API-only phase** — no changes to `PipelineService`, `pipeline_graph`,
+  or any crew service. Every behavior difference is at the HTTP layer.
+- **Background task registry is in-memory** — `app.state.pipeline_tasks`
+  is a `dict[uuid.UUID, asyncio.Task]`. Multi-worker is out of scope;
+  single worker only. Document the limitation in a one-line comment.
+- **`done_callback` cleans up the registry** — on success OR exception
+  OR cancellation. A task that dies without removing itself is a bug.
+- **SSE uses fresh ephemeral consumer groups** — one per connection,
+  replay-from-start (`id="0"`), destroyed on disconnect. Do NOT reuse
+  a shared group name across connections.
+- **Terminate SSE on voyage terminal status** — poll the DB between
+  reads, exit when `COMPLETED | FAILED | CANCELLED`. Don't rely on a
+  dedicated terminator event.
+- **Check `request.is_disconnected()` each loop** — clients closing
+  the connection must release the Redis consumer within ~1s.
+- **Block timeout ~1s** — balances responsiveness with Redis load.
+  Use `BLOCK_MS` from
+  [den_den_mushi/constants.py](src/backend/app/den_den_mushi/constants.py)
+  if a constant already exists; otherwise hardcode `1000`.
+- **Acknowledge every delivered SSE message** — pending list stays
+  empty per connection.
+- **Authorization via `get_authorized_voyage`** — don't invent a new
+  permission model. 404 on foreign voyage is correct.
+- **Error envelope shape** — `{"error": {"code", "message"}}` matches
+  the project-wide convention (see
+  [helmsman.py:45-50](src/backend/app/api/v1/helmsman.py#L45-L50)).
+- **`POST /start` is 202, not 201** — it accepts the request and
+  returns immediately; work continues in the background.
+- **Idempotency on running pipeline is 409, not 200** — callers must
+  explicitly decide to cancel+restart.
+- **`deploy_tier` is `Literal["preview"]` only** — staging / prod come
+  with the approval flow in a later phase. Pydantic rejects other
+  values with 422.
+- **`max_parallel_shipwrights: int | None`** — `None` falls through to
+  DialConfig → default 1. Explicit `int` must satisfy `1 <= x <= 10`.
+- **Shutdown cancels in-flight tasks with 5s await** — emit final
+  events, then let the loop exit. Warn on tasks that don't respond.
+- **No `last-event-id` / SSE resume** — client reconnects get the full
+  replay. Revisit if stream volume grows.
+- **Log one decision** to
+  [pdd/context/decisions.md](pdd/context/decisions.md). Suggested text:
+  *"Phase 15.4 (2026-04-24): Pipeline REST + SSE API. POST /start is
+  202 + background task, registered in `app.state.pipeline_tasks` and
+  cleaned up via done_callback. Running-pipeline idempotency returns
+  409. SSE uses fresh ephemeral consumer groups per connection
+  (replay-from-start), terminates on voyage terminal status, and
+  checks `request.is_disconnected()` each ~1s iteration. No
+  `last-event-id` resume in v1. Background task registry is
+  process-local; multi-worker is out of scope."*
+- **No commit or PR until the user signs off.**
+
+## References
+
+- Plan: [PLAN-voyage-pipeline.md](PLAN-voyage-pipeline.md) (Phase 4)
+- Phase 15.3: [PR #37](https://github.com/harshal2802/GrandLine/pull/37) —
+  `PipelineService`, `pipeline_graph`, pipeline events,
+  `PipelineStatusSnapshot`
+- Service contract (don't modify):
+  - [pipeline_service.py](src/backend/app/services/pipeline_service.py) —
+    `start(voyage, user_id, task, deploy_tier, max_parallel_shipwrights)`,
+    `pause`, `cancel`, `get_status`, `reader(session)`
+  - [pipeline_graph.py](src/backend/app/crew/pipeline_graph.py) —
+    stage nodes, terminal nodes, event emission
+- SSE / Redis primitives:
+  - [den_den_mushi/mushi.py](src/backend/app/den_den_mushi/mushi.py) —
+    `publish`, `ensure_group`, `read`, `ack`
+  - [den_den_mushi/constants.py](src/backend/app/den_den_mushi/constants.py) —
+    `stream_key(voyage_id)`, `BLOCK_MS`
+  - [den_den_mushi/events.py](src/backend/app/den_den_mushi/events.py) —
+    event types + `AnyEvent` union (Phase 15.3 added the five pipeline
+    events)
+- API conventions (copy the shape):
+  - [api/v1/helmsman.py](src/backend/app/api/v1/helmsman.py) —
+    router structure, error mapping, dependency injection
+  - [api/v1/dependencies.py](src/backend/app/api/v1/dependencies.py) —
+    `get_authorized_voyage`, `get_current_user`, existing DI helpers
+  - [api/v1/router.py](src/backend/app/api/v1/router.py) — where to
+    register the new router
+- Voyage model (for status transitions):
+  [models/voyage.py](src/backend/app/models/voyage.py) + `VoyageStatus`
+  enum in [models/enums.py](src/backend/app/models/enums.py)
+- Schema module (to extend):
+  [schemas/pipeline.py](src/backend/app/schemas/pipeline.py) — already
+  contains `PipelineStatusSnapshot`

--- a/src/backend/app/api/v1/dependencies.py
+++ b/src/backend/app/api/v1/dependencies.py
@@ -22,6 +22,7 @@ from app.models.user import User
 from app.models.voyage import Voyage
 from app.services.execution_service import ExecutionService
 from app.services.git_service import GitService
+from app.services.pipeline_service import PipelineService
 
 bearer_scheme = HTTPBearer(auto_error=False)
 
@@ -138,3 +139,27 @@ async def get_dial_router(
         yield router
     finally:
         await router.close()
+
+
+def get_pipeline_service(
+    dial_router: DialSystemRouter = Depends(get_dial_router),
+    mushi: DenDenMushi = Depends(get_den_den_mushi),
+    session: AsyncSession = Depends(get_db),
+    execution_service: ExecutionService = Depends(get_execution_service),
+    git_service: GitService = Depends(get_git_service),
+    deployment_backend: DeploymentBackend = Depends(get_deployment_backend),
+) -> PipelineService:
+    return PipelineService(
+        session=session,
+        mushi=mushi,
+        dial_router=dial_router,
+        execution_service=execution_service,
+        git_service=git_service,
+        deployment_backend=deployment_backend,
+    )
+
+
+async def get_pipeline_service_reader(
+    session: AsyncSession = Depends(get_db),
+) -> PipelineService:
+    return PipelineService.reader(session)

--- a/src/backend/app/api/v1/pipeline.py
+++ b/src/backend/app/api/v1/pipeline.py
@@ -1,0 +1,240 @@
+"""Pipeline REST + SSE API endpoints.
+
+Thin HTTP surface over `PipelineService`. `POST /start` spawns the graph
+via `asyncio.create_task` and records the task in
+`app.state.pipeline_tasks: dict[uuid.UUID, asyncio.Task]`. The task's
+done-callback removes itself from the registry on completion — success,
+failure, or cancellation.
+
+Note: `app.state.pipeline_tasks` is process-local; multi-worker deployments
+are out of scope for v1.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import uuid
+from collections.abc import AsyncGenerator
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi.responses import StreamingResponse
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.v1.dependencies import (
+    get_authorized_voyage,
+    get_current_user,
+    get_den_den_mushi,
+    get_pipeline_service,
+    get_pipeline_service_reader,
+)
+from app.den_den_mushi.constants import stream_key
+from app.den_den_mushi.mushi import DenDenMushi
+from app.models import get_db
+from app.models.enums import VoyageStatus
+from app.models.user import User
+from app.models.voyage import Voyage
+from app.schemas.pipeline import (
+    PipelineEventEnvelope,
+    PipelineStatusSnapshot,
+    StartVoyageRequest,
+    StartVoyageResponse,
+)
+from app.services.pipeline_guards import PipelineError
+from app.services.pipeline_service import PipelineService
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/voyages/{voyage_id}", tags=["pipeline"])
+
+
+_PIPELINE_ERROR_STATUS: dict[str, int] = {
+    "VOYAGE_NOT_PLANNABLE": status.HTTP_409_CONFLICT,
+    "PIPELINE_ALREADY_RUNNING": status.HTTP_409_CONFLICT,
+    "INVALID_CONCURRENCY": status.HTTP_400_BAD_REQUEST,
+}
+
+_TERMINAL_STATUSES = frozenset(
+    {
+        VoyageStatus.COMPLETED.value,
+        VoyageStatus.FAILED.value,
+        VoyageStatus.CANCELLED.value,
+    }
+)
+
+_SSE_BLOCK_MS = 1000
+
+
+def _pipeline_http_exception(exc: PipelineError) -> HTTPException:
+    code = _PIPELINE_ERROR_STATUS.get(exc.code, status.HTTP_422_UNPROCESSABLE_ENTITY)
+    return HTTPException(
+        status_code=code,
+        detail={"error": {"code": exc.code, "message": exc.message}},
+    )
+
+
+def _already_running(request: Request, voyage_id: uuid.UUID) -> bool:
+    registry: dict[uuid.UUID, asyncio.Task[None]] = getattr(request.app.state, "pipeline_tasks", {})
+    existing = registry.get(voyage_id)
+    return existing is not None and not existing.done()
+
+
+@router.post(
+    "/start",
+    response_model=StartVoyageResponse,
+    status_code=status.HTTP_202_ACCEPTED,
+)
+async def start_voyage(
+    voyage_id: uuid.UUID,
+    body: StartVoyageRequest,
+    request: Request,
+    user: User = Depends(get_current_user),
+    voyage: Voyage = Depends(get_authorized_voyage),
+    pipeline_service: PipelineService = Depends(get_pipeline_service),
+) -> StartVoyageResponse:
+    registry: dict[uuid.UUID, asyncio.Task[None]] = request.app.state.pipeline_tasks
+
+    if _already_running(request, voyage_id):
+        raise _pipeline_http_exception(
+            PipelineError(
+                "PIPELINE_ALREADY_RUNNING",
+                f"Pipeline for voyage {voyage_id} is already running",
+            )
+        )
+
+    # Additional 409 guard: completed voyages cannot be re-run. Re-run workflow
+    # is cancel + restart — out of scope for v1.
+    if voyage.status == VoyageStatus.COMPLETED.value:
+        raise _pipeline_http_exception(
+            PipelineError(
+                "VOYAGE_NOT_PLANNABLE",
+                f"Voyage status is {voyage.status}; cannot re-run a completed voyage",
+            )
+        )
+
+    task = asyncio.create_task(
+        pipeline_service.start(
+            voyage,
+            user.id,
+            body.task,
+            body.deploy_tier,
+            body.max_parallel_shipwrights,
+        )
+    )
+    registry[voyage_id] = task
+
+    def _cleanup(_t: asyncio.Task[None]) -> None:
+        registry.pop(voyage_id, None)
+
+    task.add_done_callback(_cleanup)
+
+    return StartVoyageResponse(voyage_id=voyage_id, status=voyage.status)
+
+
+@router.post("/pause", status_code=status.HTTP_200_OK)
+async def pause_voyage(
+    voyage_id: uuid.UUID,
+    user: User = Depends(get_current_user),
+    voyage: Voyage = Depends(get_authorized_voyage),
+    pipeline_service: PipelineService = Depends(get_pipeline_service),
+) -> dict[str, object]:
+    try:
+        await pipeline_service.pause(voyage)
+    except PipelineError as exc:
+        raise _pipeline_http_exception(exc) from exc
+    return {"voyage_id": str(voyage_id), "status": voyage.status}
+
+
+@router.post("/cancel", status_code=status.HTTP_200_OK)
+async def cancel_voyage(
+    voyage_id: uuid.UUID,
+    request: Request,
+    user: User = Depends(get_current_user),
+    voyage: Voyage = Depends(get_authorized_voyage),
+    pipeline_service: PipelineService = Depends(get_pipeline_service),
+) -> dict[str, object]:
+    try:
+        await pipeline_service.cancel(voyage)
+    except PipelineError as exc:
+        raise _pipeline_http_exception(exc) from exc
+
+    registry: dict[uuid.UUID, asyncio.Task[None]] = getattr(request.app.state, "pipeline_tasks", {})
+    task = registry.get(voyage_id)
+    if task is not None and not task.done():
+        task.cancel()
+
+    return {"voyage_id": str(voyage_id), "status": voyage.status}
+
+
+@router.get(
+    "/status",
+    response_model=PipelineStatusSnapshot,
+)
+async def get_pipeline_status(
+    voyage_id: uuid.UUID,
+    user: User = Depends(get_current_user),
+    voyage: Voyage = Depends(get_authorized_voyage),
+    pipeline_reader: PipelineService = Depends(get_pipeline_service_reader),
+) -> PipelineStatusSnapshot:
+    return await pipeline_reader.get_status(voyage)
+
+
+@router.get("/stream")
+async def stream_events(
+    voyage_id: uuid.UUID,
+    request: Request,
+    user: User = Depends(get_current_user),
+    voyage: Voyage = Depends(get_authorized_voyage),
+    mushi: DenDenMushi = Depends(get_den_den_mushi),
+    session: AsyncSession = Depends(get_db),
+) -> StreamingResponse:
+    """Server-Sent Events stream of pipeline events for a voyage.
+
+    One fresh ephemeral consumer group per connection (replay-from-start).
+    Terminates on voyage terminal status (COMPLETED | FAILED | CANCELLED)
+    or client disconnect. No `last-event-id` resume in v1.
+    """
+    stream = stream_key(voyage_id)
+    group = f"sse-{uuid.uuid4().hex}"
+    consumer = f"sse-{uuid.uuid4().hex[:8]}"
+
+    async def event_generator() -> AsyncGenerator[bytes, None]:
+        await mushi.ensure_group(stream, group)
+        try:
+            while True:
+                if await request.is_disconnected():
+                    break
+
+                batch = await mushi.read(
+                    stream=stream,
+                    group=group,
+                    consumer=consumer,
+                    count=10,
+                    block_ms=_SSE_BLOCK_MS,
+                )
+                for msg_id, event in batch:
+                    envelope = PipelineEventEnvelope(
+                        msg_id=msg_id,
+                        event=event.model_dump(mode="json"),
+                    )
+                    yield f"data: {envelope.model_dump_json()}\n\n".encode()
+                    await mushi.ack(stream, group, msg_id)
+
+                # Re-fetch voyage status; close on terminal.
+                refreshed = await session.get(Voyage, voyage.id)
+                if refreshed is not None and refreshed.status in _TERMINAL_STATUSES:
+                    break
+        finally:
+            # Best-effort: destroy the ephemeral group so Redis doesn't
+            # accumulate per-connection groups.
+            try:
+                await mushi._redis.xgroup_destroy(stream, group)  # noqa: SLF001
+            except Exception:  # pragma: no cover - best effort cleanup
+                logger.warning(
+                    "Failed to destroy SSE consumer group %s on stream %s",
+                    group,
+                    stream,
+                    exc_info=True,
+                )
+
+    return StreamingResponse(event_generator(), media_type="text/event-stream")

--- a/src/backend/app/api/v1/pipeline.py
+++ b/src/backend/app/api/v1/pipeline.py
@@ -220,8 +220,11 @@ async def stream_events(
                     yield f"data: {envelope.model_dump_json()}\n\n".encode()
                     await mushi.ack(stream, group, msg_id)
 
-                # Re-fetch voyage status; close on terminal.
-                refreshed = await session.get(Voyage, voyage.id)
+                # Re-fetch voyage status; close on terminal. `populate_existing`
+                # bypasses the identity map so writes committed by the
+                # background pipeline task are visible (without it,
+                # get_authorized_voyage's cached instance shadows updates).
+                refreshed = await session.get(Voyage, voyage.id, populate_existing=True)
                 if refreshed is not None and refreshed.status in _TERMINAL_STATUSES:
                     break
         finally:

--- a/src/backend/app/api/v1/router.py
+++ b/src/backend/app/api/v1/router.py
@@ -9,6 +9,7 @@ from app.api.v1.git import router as git_router
 from app.api.v1.health import router as health_router
 from app.api.v1.helmsman import router as helmsman_router
 from app.api.v1.navigator import router as navigator_router
+from app.api.v1.pipeline import router as pipeline_router
 from app.api.v1.shipwright import router as shipwright_router
 from app.api.v1.vivre_cards import router as vivre_cards_router
 
@@ -24,3 +25,4 @@ v1_router.include_router(navigator_router)
 v1_router.include_router(doctor_router)
 v1_router.include_router(shipwright_router)
 v1_router.include_router(helmsman_router)
+v1_router.include_router(pipeline_router)

--- a/src/backend/app/main.py
+++ b/src/backend/app/main.py
@@ -1,3 +1,6 @@
+import asyncio
+import logging
+import uuid
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 
@@ -14,6 +17,10 @@ from app.execution.factory import create_backend, create_git_backend
 from app.services.execution_service import ExecutionService
 from app.services.git_service import GitService
 
+logger = logging.getLogger(__name__)
+
+_PIPELINE_SHUTDOWN_TIMEOUT_S = 5.0
+
 
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncIterator[None]:
@@ -29,7 +36,26 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
 
     app.state.deployment_backend = InProcessDeploymentBackend()
 
+    # Process-local registry of in-flight pipeline tasks. Keyed by voyage_id.
+    # Multi-worker deployments are out of scope for v1 (single-worker fleet).
+    pipeline_tasks: dict[uuid.UUID, asyncio.Task[None]] = {}
+    app.state.pipeline_tasks = pipeline_tasks
+
     yield
+
+    # Cancel in-flight pipeline tasks and give them a short window to emit
+    # terminal events (e.g. PipelineFailedEvent) before the loop tears down.
+    pending = [t for t in app.state.pipeline_tasks.values() if not t.done()]
+    for task in pending:
+        task.cancel()
+    if pending:
+        done, still_pending = await asyncio.wait(pending, timeout=_PIPELINE_SHUTDOWN_TIMEOUT_S)
+        if still_pending:
+            logger.warning(
+                "Shutdown: %d pipeline task(s) did not finish within %.1fs",
+                len(still_pending),
+                _PIPELINE_SHUTDOWN_TIMEOUT_S,
+            )
 
     await app.state.deployment_backend.close()
     await app.state.git_service.cleanup_all()

--- a/src/backend/app/schemas/pipeline.py
+++ b/src/backend/app/schemas/pipeline.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 import uuid
-from typing import Any
+from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class PipelineStatusSnapshot(BaseModel):
@@ -23,3 +23,32 @@ class PipelineStatusSnapshot(BaseModel):
     last_validation_status: str | None
     last_deployment_status: str | None
     error: dict[str, Any] | None
+
+
+class StartVoyageRequest(BaseModel):
+    """POST /voyages/{id}/start request body."""
+
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    task: str = Field(min_length=10, max_length=5000)
+    deploy_tier: Literal["preview"] = "preview"
+    max_parallel_shipwrights: int | None = Field(default=None, ge=1, le=10)
+
+
+class StartVoyageResponse(BaseModel):
+    """POST /voyages/{id}/start 202 response envelope."""
+
+    model_config = ConfigDict(strict=True)
+
+    voyage_id: uuid.UUID
+    status: str  # voyage.status at the moment of acceptance
+    accepted: bool = True
+
+
+class PipelineEventEnvelope(BaseModel):
+    """Wire envelope sent over SSE for each Redis stream message."""
+
+    model_config = ConfigDict(strict=True)
+
+    msg_id: str  # Redis stream message id (for client dedup)
+    event: dict[str, Any]  # parsed event JSON (event_type, voyage_id, payload, ...)

--- a/src/backend/scripts/dev_api_mocked.py
+++ b/src/backend/scripts/dev_api_mocked.py
@@ -1,0 +1,133 @@
+"""Dev FastAPI server with PipelineService.start mocked out.
+
+The real PipelineService.start invokes Captain → Navigator → Doctor →
+Shipwrights → Doctor → Helmsman, all of which call real LLM providers
+and execute generated code in Docker sandboxes. For Phase 15.4 API
+smoke-testing we don't want any of that — we only want to exercise the
+HTTP surface and the SSE event framing.
+
+This script monkey-patches `PipelineService.start` with a fast stub that
+emits the same five pipeline events to the Redis stream via the injected
+DenDenMushi, flips voyage.status through PLANNING → COMPLETED, and
+returns. That lets the SSE endpoint replay a realistic event sequence
+and the status/pause/cancel endpoints observe lifelike state.
+
+Run via: `make api-mocked` (or `python -m scripts.dev_api_mocked`).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import uuid
+from typing import Any, Literal
+
+import uvicorn
+
+from app.den_den_mushi.constants import stream_key
+from app.den_den_mushi.events import (
+    PipelineCompletedEvent,
+    PipelineStageCompletedEvent,
+    PipelineStageEnteredEvent,
+    PipelineStartedEvent,
+)
+from app.models.enums import CrewRole, VoyageStatus
+from app.services.pipeline_service import PipelineService
+
+logger = logging.getLogger(__name__)
+
+_STAGES: list[str] = ["PLANNING", "PDD", "TDD", "BUILDING", "REVIEWING", "DEPLOYING"]
+
+
+async def _mocked_start(
+    self: PipelineService,
+    voyage: Any,
+    user_id: uuid.UUID,
+    task: str,
+    deploy_tier: Literal["preview"] = "preview",
+    max_parallel_shipwrights: int | None = None,
+) -> None:
+    """Emit synthetic pipeline events for smoke testing — no LLM calls."""
+    stream = stream_key(voyage.id)
+    logger.info("MOCK pipeline start for voyage=%s task=%r", voyage.id, task)
+
+    async def _publish(event: Any) -> None:
+        try:
+            await self._mushi.publish(stream, event)  # type: ignore[attr-defined]
+        except Exception:
+            logger.exception("MOCK publish failed")
+
+    await _publish(
+        PipelineStartedEvent(
+            voyage_id=voyage.id,
+            source_role=CrewRole.CAPTAIN,
+            payload={
+                "task": task,
+                "deploy_tier": deploy_tier,
+                "max_parallel_shipwrights": max_parallel_shipwrights or 1,
+            },
+        )
+    )
+
+    voyage.status = VoyageStatus.PLANNING.value
+    try:
+        self._session.add(voyage)  # type: ignore[attr-defined]
+        await self._session.commit()  # type: ignore[attr-defined]
+    except Exception:
+        logger.exception("MOCK status update failed (PLANNING)")
+
+    for stage in _STAGES:
+        await _publish(
+            PipelineStageEnteredEvent(
+                voyage_id=voyage.id,
+                source_role=CrewRole.CAPTAIN,
+                payload={"stage": stage, "voyage_status": voyage.status},
+            )
+        )
+        await asyncio.sleep(0.3)
+        await _publish(
+            PipelineStageCompletedEvent(
+                voyage_id=voyage.id,
+                source_role=CrewRole.CAPTAIN,
+                payload={"stage": stage, "duration_seconds": 0.3, "skipped": False},
+            )
+        )
+
+    voyage.status = VoyageStatus.COMPLETED.value
+    try:
+        self._session.add(voyage)
+        await self._session.commit()
+    except Exception:
+        logger.exception("MOCK status update failed (COMPLETED)")
+
+    await _publish(
+        PipelineCompletedEvent(
+            voyage_id=voyage.id,
+            source_role=CrewRole.CAPTAIN,
+            payload={
+                "duration_seconds": len(_STAGES) * 0.3,
+                "deployment_url": "http://preview.voyage.local",
+            },
+        )
+    )
+
+
+def main() -> None:
+    logging.basicConfig(
+        level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s"
+    )
+    # Patch before the app is imported into uvicorn's workers.
+    PipelineService.start = _mocked_start  # type: ignore[method-assign]
+    logger.info("PipelineService.start replaced with synthetic-event stub")
+
+    uvicorn.run(
+        "app.main:app",
+        host="0.0.0.0",
+        port=8000,
+        log_level="info",
+        reload=False,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/backend/scripts/smoke_pipeline_api.py
+++ b/src/backend/scripts/smoke_pipeline_api.py
@@ -1,0 +1,280 @@
+"""Phase 15.4 manual smoke test — drives the pipeline REST + SSE API.
+
+Assumes:
+- Postgres + Redis are up (make up)
+- Migrations applied (make migrate)
+- API running with PipelineService.start mocked (make api-mocked)
+
+What this script does:
+1. Registers a fresh test user, captures the JWT.
+2. Inserts a Voyage and a DialConfig directly via SQLAlchemy (no public
+   creation endpoint for voyages).
+3. Hits GET /status on a freshly-charted voyage (expect empty counts).
+4. Opens an SSE connection to GET /stream in a background task.
+5. Hits POST /start with a mocked pipeline that emits 14 synthetic events
+   (started + 6 stage_entered/completed pairs + completed) and flips
+   voyage.status to COMPLETED.
+6. Collects SSE frames, asserts shape, msg_id, event_type sequence.
+7. Tests POST /pause and POST /cancel idempotency on an already-terminal
+   voyage (a fresh voyage is created for each) — both should 200 no-op.
+
+Run via: `make smoke`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+import uuid
+from typing import Any
+
+import httpx
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from app.models.dial_config import DialConfig
+from app.models.enums import VoyageStatus
+from app.models.voyage import Voyage
+
+API = os.environ.get("GRANDLINE_API_URL", "http://localhost:8000")
+DB_URL = os.environ["GRANDLINE_DATABASE_URL"]
+
+
+def _pp(label: str, obj: Any) -> None:
+    print(f"\n── {label} ──")
+    if isinstance(obj, dict | list):
+        print(json.dumps(obj, indent=2, default=str))
+    else:
+        print(obj)
+
+
+async def _insert_voyage(session: AsyncSession, user_id: uuid.UUID, title: str) -> Voyage:
+    voyage = Voyage(
+        user_id=user_id,
+        title=title,
+        description="Phase 15.4 smoke test voyage",
+        status=VoyageStatus.CHARTED.value,
+        phase_status={},
+    )
+    session.add(voyage)
+    await session.flush()
+
+    dial = DialConfig(
+        voyage_id=voyage.id,
+        role_mapping={
+            "captain": {"provider": "anthropic", "model": "claude-sonnet-4-5-20250929"},
+            "navigator": {"provider": "anthropic", "model": "claude-sonnet-4-5-20250929"},
+            "doctor": {"provider": "anthropic", "model": "claude-sonnet-4-5-20250929"},
+            "shipwright": {
+                "provider": "anthropic",
+                "model": "claude-sonnet-4-5-20250929",
+                "max_concurrency": 2,
+            },
+            "helmsman": {"provider": "anthropic", "model": "claude-sonnet-4-5-20250929"},
+        },
+    )
+    session.add(dial)
+    await session.commit()
+    await session.refresh(voyage)
+    return voyage
+
+
+async def _register_and_get_token(client: httpx.AsyncClient) -> tuple[str, uuid.UUID]:
+    suffix = uuid.uuid4().hex[:10]
+    body = {
+        "email": f"smoke+{suffix}@example.com",
+        "username": f"smoke_{suffix}",
+        "password": "SmokeTest!23",
+    }
+    r = await client.post(f"{API}/api/v1/auth/register", json=body)
+    r.raise_for_status()
+    tokens = r.json()
+    access = tokens["access_token"]
+
+    # Decode without verification to grab user id.
+    import base64
+
+    payload_b64 = access.split(".")[1]
+    payload_b64 += "=" * (-len(payload_b64) % 4)
+    payload = json.loads(base64.urlsafe_b64decode(payload_b64))
+    user_id = uuid.UUID(payload["sub"])
+    return access, user_id
+
+
+async def _stream_events(
+    client: httpx.AsyncClient, voyage_id: uuid.UUID, headers: dict[str, str]
+) -> list[dict[str, Any]]:
+    """Open SSE connection and collect envelopes until the server closes."""
+    events: list[dict[str, Any]] = []
+    url = f"{API}/api/v1/voyages/{voyage_id}/stream"
+    async with client.stream("GET", url, headers=headers, timeout=30) as resp:
+        resp.raise_for_status()
+        buffer = b""
+        async for chunk in resp.aiter_bytes():
+            buffer += chunk
+            while b"\n\n" in buffer:
+                frame, buffer = buffer.split(b"\n\n", 1)
+                if not frame.startswith(b"data: "):
+                    continue
+                payload = frame[len(b"data: ") :].decode()
+                events.append(json.loads(payload))
+    return events
+
+
+async def _scenario_start_and_stream(client: httpx.AsyncClient, headers: dict[str, str]) -> None:
+    print("\n" + "=" * 70)
+    print("Scenario 1: start a voyage, tail SSE, verify event sequence")
+    print("=" * 70)
+
+    engine = create_async_engine(DB_URL, echo=False)
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+
+    # Register a user + insert voyage.
+    access, user_id = await _register_and_get_token(client)
+    headers["Authorization"] = f"Bearer {access}"
+    async with session_factory() as session:
+        voyage = await _insert_voyage(session, user_id, "Phase 15.4 smoke — start+stream")
+    print(f"user_id={user_id} voyage_id={voyage.id}")
+
+    # Open SSE in the background before calling start.
+    sse_task = asyncio.create_task(_stream_events(client, voyage.id, headers))
+    await asyncio.sleep(0.2)  # let the consumer group establish
+
+    # POST /start
+    r = await client.post(
+        f"{API}/api/v1/voyages/{voyage.id}/start",
+        headers=headers,
+        json={"task": "build a simple hello world service"},
+    )
+    _pp(f"POST /start -> {r.status_code}", r.json())
+    assert r.status_code == 202, f"expected 202, got {r.status_code}"
+    assert r.json()["accepted"] is True
+
+    # Collect SSE frames.
+    try:
+        events = await asyncio.wait_for(sse_task, timeout=15)
+    except TimeoutError:
+        sse_task.cancel()
+        raise RuntimeError("SSE stream did not close within 15s")
+    _pp(f"SSE frames received ({len(events)})", [e["event"]["event_type"] for e in events])
+
+    # Verify envelope shape + event sequence.
+    types = [e["event"]["event_type"] for e in events]
+    assert types[0] == "pipeline_started", f"first event should be pipeline_started, got {types[0]}"
+    assert types[-1] == "pipeline_completed", "last event should be pipeline_completed"
+    assert types.count("pipeline_stage_entered") == 6
+    assert types.count("pipeline_stage_completed") == 6
+    for env in events:
+        assert "msg_id" in env and "event" in env
+        assert env["event"]["voyage_id"] == str(voyage.id)
+    print("✓ SSE envelope sequence matches expected pipeline flow")
+
+    # POST /start again (voyage is now COMPLETED) → expect 409
+    r2 = await client.post(
+        f"{API}/api/v1/voyages/{voyage.id}/start",
+        headers=headers,
+        json={"task": "build a simple hello world service"},
+    )
+    assert r2.status_code == 409
+    _pp(f"POST /start (on COMPLETED) -> {r2.status_code}", r2.json())
+    print("✓ Re-start on COMPLETED voyage rejected with 409")
+
+    # GET /status
+    r3 = await client.get(f"{API}/api/v1/voyages/{voyage.id}/status", headers=headers)
+    _pp(f"GET /status -> {r3.status_code}", r3.json())
+    assert r3.status_code == 200
+    assert r3.json()["status"] == VoyageStatus.COMPLETED.value
+    print("✓ GET /status reports COMPLETED")
+
+    await engine.dispose()
+
+
+async def _scenario_pause_cancel(client: httpx.AsyncClient, headers: dict[str, str]) -> None:
+    print("\n" + "=" * 70)
+    print("Scenario 2: pause + cancel endpoints")
+    print("=" * 70)
+
+    engine = create_async_engine(DB_URL, echo=False)
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+
+    access, user_id = await _register_and_get_token(client)
+    pause_headers = {"Authorization": f"Bearer {access}"}
+    async with session_factory() as session:
+        voyage = await _insert_voyage(session, user_id, "Phase 15.4 smoke — pause")
+
+    r = await client.post(f"{API}/api/v1/voyages/{voyage.id}/pause", headers=pause_headers)
+    _pp(f"POST /pause -> {r.status_code}", r.json())
+    assert r.status_code == 200
+    assert r.json()["status"] == VoyageStatus.PAUSED.value
+    print("✓ POST /pause flips status to PAUSED")
+
+    # Idempotency
+    r2 = await client.post(f"{API}/api/v1/voyages/{voyage.id}/pause", headers=pause_headers)
+    assert r2.status_code == 200
+    print("✓ POST /pause is idempotent")
+
+    # Now cancel
+    r3 = await client.post(f"{API}/api/v1/voyages/{voyage.id}/cancel", headers=pause_headers)
+    _pp(f"POST /cancel -> {r3.status_code}", r3.json())
+    assert r3.status_code == 200
+    assert r3.json()["status"] == VoyageStatus.CANCELLED.value
+    print("✓ POST /cancel flips status to CANCELLED")
+
+    # Idempotency on terminal
+    r4 = await client.post(f"{API}/api/v1/voyages/{voyage.id}/cancel", headers=pause_headers)
+    assert r4.status_code == 200
+    print("✓ POST /cancel is idempotent on CANCELLED")
+
+    # GET /status on cancelled voyage
+    r5 = await client.get(f"{API}/api/v1/voyages/{voyage.id}/status", headers=pause_headers)
+    assert r5.status_code == 200
+    assert r5.json()["status"] == VoyageStatus.CANCELLED.value
+    print("✓ GET /status reports CANCELLED")
+
+    await engine.dispose()
+
+
+async def _scenario_unauthorized(client: httpx.AsyncClient) -> None:
+    print("\n" + "=" * 70)
+    print("Scenario 3: 404 on foreign voyage id (authorization check)")
+    print("=" * 70)
+
+    # User A creates a voyage; User B tries to access it.
+    access_a, user_a_id = await _register_and_get_token(client)
+    access_b, _user_b_id = await _register_and_get_token(client)
+
+    engine = create_async_engine(DB_URL, echo=False)
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+    async with session_factory() as session:
+        voyage = await _insert_voyage(session, user_a_id, "Phase 15.4 smoke — authz")
+    await engine.dispose()
+
+    headers_b = {"Authorization": f"Bearer {access_b}"}
+    r = await client.get(f"{API}/api/v1/voyages/{voyage.id}/status", headers=headers_b)
+    assert r.status_code == 404, f"expected 404, got {r.status_code}: {r.text}"
+    print("✓ GET /status -> 404 when voyage belongs to another user")
+
+
+async def main() -> int:
+    async with httpx.AsyncClient(timeout=30) as client:
+        # Sanity: API up
+        try:
+            r = await client.get(f"{API}/api/v1/health")
+            r.raise_for_status()
+        except Exception as exc:
+            print(f"API at {API} not reachable: {exc}", file=sys.stderr)
+            print("Run `make api-mocked` in another terminal first.", file=sys.stderr)
+            return 1
+
+        headers: dict[str, str] = {}
+        await _scenario_start_and_stream(client, headers)
+        await _scenario_pause_cancel(client, headers)
+        await _scenario_unauthorized(client)
+
+    print("\n✅ All scenarios passed.\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/src/backend/tests/test_pipeline_api.py
+++ b/src/backend/tests/test_pipeline_api.py
@@ -1,0 +1,633 @@
+"""Tests for Pipeline REST + SSE API endpoints.
+
+Endpoint functions are called directly with mocked dependencies, matching
+the convention in test_helmsman_api.py. The SSE tests drive the inner
+event-generator coroutine produced by StreamingResponse.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import uuid
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+from app.den_den_mushi.events import (
+    PipelineCompletedEvent,
+    PipelineFailedEvent,
+    PipelineStageCompletedEvent,
+    PipelineStageEnteredEvent,
+    PipelineStartedEvent,
+)
+from app.models.enums import CrewRole, VoyageStatus
+from app.schemas.pipeline import (
+    PipelineEventEnvelope,
+    PipelineStatusSnapshot,
+    StartVoyageRequest,
+    StartVoyageResponse,
+)
+from app.services.pipeline_guards import PipelineError
+
+VOYAGE_ID = uuid.uuid4()
+USER_ID = uuid.uuid4()
+
+
+def _mock_user() -> MagicMock:
+    user = MagicMock()
+    user.id = USER_ID
+    return user
+
+
+def _mock_voyage(status: str = VoyageStatus.CHARTED.value) -> MagicMock:
+    voyage = MagicMock()
+    voyage.id = VOYAGE_ID
+    voyage.user_id = USER_ID
+    voyage.status = status
+    voyage.phase_status = {}
+    return voyage
+
+
+def _mock_request(
+    pipeline_tasks: dict[uuid.UUID, asyncio.Task[None]] | None = None,
+    is_disconnected: bool = False,
+) -> MagicMock:
+    request = MagicMock()
+    request.app = MagicMock()
+    request.app.state = MagicMock()
+    request.app.state.pipeline_tasks = pipeline_tasks if pipeline_tasks is not None else {}
+    request.is_disconnected = AsyncMock(return_value=is_disconnected)
+    return request
+
+
+def _snapshot() -> PipelineStatusSnapshot:
+    return PipelineStatusSnapshot(
+        voyage_id=VOYAGE_ID,
+        status=VoyageStatus.COMPLETED.value,
+        plan_exists=True,
+        poneglyph_count=3,
+        health_check_count=3,
+        build_artifact_count=3,
+        phase_status={"1": "BUILT"},
+        last_validation_status="passed",
+        last_deployment_status="completed",
+        error=None,
+    )
+
+
+def _mock_pipeline_service() -> AsyncMock:
+    svc = AsyncMock()
+    svc.start = AsyncMock(return_value=None)
+    svc.pause = AsyncMock(return_value=None)
+    svc.cancel = AsyncMock(return_value=None)
+    svc.get_status = AsyncMock(return_value=_snapshot())
+    return svc
+
+
+# ---------------------------------------------------------------------------
+# Schemas
+# ---------------------------------------------------------------------------
+
+
+class TestPipelineSchemas:
+    def test_start_voyage_request_happy_path(self) -> None:
+        req = StartVoyageRequest(
+            task="build a todo app with auth",
+            deploy_tier="preview",
+            max_parallel_shipwrights=3,
+        )
+        assert req.task == "build a todo app with auth"
+        assert req.deploy_tier == "preview"
+        assert req.max_parallel_shipwrights == 3
+
+    def test_start_voyage_request_defaults(self) -> None:
+        req = StartVoyageRequest(task="build a todo app with auth")
+        assert req.deploy_tier == "preview"
+        assert req.max_parallel_shipwrights is None
+
+    def test_start_voyage_request_rejects_extra_fields(self) -> None:
+        with pytest.raises(Exception):
+            StartVoyageRequest.model_validate({"task": "build a todo app with auth", "bogus": True})
+
+    def test_start_voyage_request_task_too_short(self) -> None:
+        with pytest.raises(Exception):
+            StartVoyageRequest.model_validate({"task": "short"})
+
+    def test_start_voyage_request_rejects_bad_tier(self) -> None:
+        with pytest.raises(Exception):
+            StartVoyageRequest.model_validate(
+                {"task": "build a todo app", "deploy_tier": "production"}
+            )
+
+    def test_start_voyage_request_max_parallel_too_low(self) -> None:
+        with pytest.raises(Exception):
+            StartVoyageRequest.model_validate(
+                {"task": "build a todo app", "max_parallel_shipwrights": 0}
+            )
+
+    def test_start_voyage_request_max_parallel_too_high(self) -> None:
+        with pytest.raises(Exception):
+            StartVoyageRequest.model_validate(
+                {"task": "build a todo app", "max_parallel_shipwrights": 11}
+            )
+
+    def test_start_voyage_request_strict_rejects_coerced_int(self) -> None:
+        # strict=True rejects string→int coercion
+        with pytest.raises(Exception):
+            StartVoyageRequest.model_validate(
+                {"task": "build a todo app", "max_parallel_shipwrights": "2"}
+            )
+
+    def test_pipeline_event_envelope_round_trip(self) -> None:
+        env = PipelineEventEnvelope(
+            msg_id="1700000000-0",
+            event={
+                "event_type": "pipeline_started",
+                "voyage_id": str(VOYAGE_ID),
+                "payload": {"task": "x"},
+            },
+        )
+        raw = env.model_dump_json()
+        parsed = PipelineEventEnvelope.model_validate_json(raw)
+        assert parsed.msg_id == env.msg_id
+        assert parsed.event == env.event
+
+
+# ---------------------------------------------------------------------------
+# POST /start
+# ---------------------------------------------------------------------------
+
+
+class TestStartVoyage:
+    @pytest.mark.asyncio
+    async def test_returns_202_and_registers_task(self) -> None:
+        from app.api.v1.pipeline import start_voyage
+
+        svc = _mock_pipeline_service()
+        svc.start = AsyncMock(return_value=None)
+        body = StartVoyageRequest(task="build a todo app with auth")
+        registry: dict[uuid.UUID, asyncio.Task[None]] = {}
+        request = _mock_request(pipeline_tasks=registry)
+
+        result = await start_voyage(
+            VOYAGE_ID,
+            body,
+            request,
+            _mock_user(),
+            _mock_voyage(),
+            svc,
+        )
+
+        assert isinstance(result, StartVoyageResponse)
+        assert result.voyage_id == VOYAGE_ID
+        assert result.accepted is True
+        # Task was registered at some point. Allow the microtask to drain so
+        # the done_callback removes it.
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        assert VOYAGE_ID not in registry  # cleanup fired
+
+    @pytest.mark.asyncio
+    async def test_task_removed_from_registry_on_success(self) -> None:
+        from app.api.v1.pipeline import start_voyage
+
+        svc = _mock_pipeline_service()
+        svc.start = AsyncMock(return_value=None)
+        body = StartVoyageRequest(task="build a todo app with auth")
+        registry: dict[uuid.UUID, asyncio.Task[None]] = {}
+        request = _mock_request(pipeline_tasks=registry)
+
+        await start_voyage(VOYAGE_ID, body, request, _mock_user(), _mock_voyage(), svc)
+        # yield to the event loop so the spawned task completes
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        assert VOYAGE_ID not in registry
+
+    @pytest.mark.asyncio
+    async def test_task_removed_from_registry_on_failure(self) -> None:
+        from app.api.v1.pipeline import start_voyage
+
+        svc = _mock_pipeline_service()
+        svc.start = AsyncMock(side_effect=PipelineError("BOOM", "boom"))
+        body = StartVoyageRequest(task="build a todo app with auth")
+        registry: dict[uuid.UUID, asyncio.Task[None]] = {}
+        request = _mock_request(pipeline_tasks=registry)
+
+        await start_voyage(VOYAGE_ID, body, request, _mock_user(), _mock_voyage(), svc)
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        assert VOYAGE_ID not in registry
+
+    @pytest.mark.asyncio
+    async def test_rejects_running_pipeline_with_409(self) -> None:
+        from app.api.v1.pipeline import start_voyage
+
+        svc = _mock_pipeline_service()
+        # An in-flight (non-done) task in the registry.
+        running = asyncio.create_task(asyncio.sleep(5))
+        try:
+            registry: dict[uuid.UUID, asyncio.Task[None]] = {VOYAGE_ID: running}
+            request = _mock_request(pipeline_tasks=registry)
+            body = StartVoyageRequest(task="build a todo app with auth")
+
+            with pytest.raises(HTTPException) as exc_info:
+                await start_voyage(VOYAGE_ID, body, request, _mock_user(), _mock_voyage(), svc)
+
+            assert exc_info.value.status_code == 409
+            assert exc_info.value.detail["error"]["code"] == "PIPELINE_ALREADY_RUNNING"
+            svc.start.assert_not_called()
+        finally:
+            running.cancel()
+            try:
+                await running
+            except (asyncio.CancelledError, Exception):
+                pass
+
+    @pytest.mark.asyncio
+    async def test_rejects_completed_voyage_with_409(self) -> None:
+        from app.api.v1.pipeline import start_voyage
+
+        svc = _mock_pipeline_service()
+        body = StartVoyageRequest(task="build a todo app with auth")
+        request = _mock_request()
+
+        with pytest.raises(HTTPException) as exc_info:
+            await start_voyage(
+                VOYAGE_ID,
+                body,
+                request,
+                _mock_user(),
+                _mock_voyage(status=VoyageStatus.COMPLETED.value),
+                svc,
+            )
+
+        assert exc_info.value.status_code == 409
+        svc.start.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_stale_done_task_in_registry_does_not_block(self) -> None:
+        from app.api.v1.pipeline import start_voyage
+
+        svc = _mock_pipeline_service()
+        svc.start = AsyncMock(return_value=None)
+
+        async def _already_done() -> None:
+            return None
+
+        done_task = asyncio.create_task(_already_done())
+        await done_task  # drive it to completion
+
+        registry: dict[uuid.UUID, asyncio.Task[None]] = {VOYAGE_ID: done_task}
+        request = _mock_request(pipeline_tasks=registry)
+        body = StartVoyageRequest(task="build a todo app with auth")
+
+        result = await start_voyage(VOYAGE_ID, body, request, _mock_user(), _mock_voyage(), svc)
+
+        assert result.accepted is True
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+
+# ---------------------------------------------------------------------------
+# POST /pause
+# ---------------------------------------------------------------------------
+
+
+class TestPauseVoyage:
+    @pytest.mark.asyncio
+    async def test_returns_200_and_calls_service_pause(self) -> None:
+        from app.api.v1.pipeline import pause_voyage
+
+        svc = _mock_pipeline_service()
+        voyage = _mock_voyage(status=VoyageStatus.PDD.value)
+
+        async def _pause(v: Any) -> None:
+            v.status = VoyageStatus.PAUSED.value
+
+        svc.pause = AsyncMock(side_effect=_pause)
+
+        result = await pause_voyage(VOYAGE_ID, _mock_user(), voyage, svc)
+
+        assert result["voyage_id"] == str(VOYAGE_ID)
+        assert result["status"] == VoyageStatus.PAUSED.value
+        svc.pause.assert_awaited_once_with(voyage)
+
+    @pytest.mark.asyncio
+    async def test_translates_pipeline_error_to_http(self) -> None:
+        from app.api.v1.pipeline import pause_voyage
+
+        svc = _mock_pipeline_service()
+        svc.pause = AsyncMock(side_effect=PipelineError("UNKNOWN_PAUSE", "nope"))
+
+        with pytest.raises(HTTPException) as exc_info:
+            await pause_voyage(VOYAGE_ID, _mock_user(), _mock_voyage(), svc)
+
+        assert exc_info.value.status_code == 422
+        assert exc_info.value.detail["error"]["code"] == "UNKNOWN_PAUSE"
+
+
+# ---------------------------------------------------------------------------
+# POST /cancel
+# ---------------------------------------------------------------------------
+
+
+class TestCancelVoyage:
+    @pytest.mark.asyncio
+    async def test_returns_200_and_sets_cancelled(self) -> None:
+        from app.api.v1.pipeline import cancel_voyage
+
+        svc = _mock_pipeline_service()
+        voyage = _mock_voyage(status=VoyageStatus.BUILDING.value)
+
+        async def _cancel(v: Any) -> None:
+            v.status = VoyageStatus.CANCELLED.value
+
+        svc.cancel = AsyncMock(side_effect=_cancel)
+        request = _mock_request()
+
+        result = await cancel_voyage(VOYAGE_ID, request, _mock_user(), voyage, svc)
+
+        assert result["status"] == VoyageStatus.CANCELLED.value
+        svc.cancel.assert_awaited_once_with(voyage)
+
+    @pytest.mark.asyncio
+    async def test_also_cancels_running_task(self) -> None:
+        from app.api.v1.pipeline import cancel_voyage
+
+        svc = _mock_pipeline_service()
+        running = asyncio.create_task(asyncio.sleep(10))
+        try:
+            registry: dict[uuid.UUID, asyncio.Task[None]] = {VOYAGE_ID: running}
+            request = _mock_request(pipeline_tasks=registry)
+
+            await cancel_voyage(VOYAGE_ID, request, _mock_user(), _mock_voyage(), svc)
+
+            # Give the event loop a chance to process the cancellation.
+            await asyncio.sleep(0)
+            assert running.cancelled() or running.done()
+        finally:
+            if not running.done():
+                running.cancel()
+                try:
+                    await running
+                except (asyncio.CancelledError, Exception):
+                    pass
+
+    @pytest.mark.asyncio
+    async def test_done_task_in_registry_is_noop(self) -> None:
+        from app.api.v1.pipeline import cancel_voyage
+
+        svc = _mock_pipeline_service()
+
+        async def _already_done() -> None:
+            return None
+
+        done = asyncio.create_task(_already_done())
+        await done
+        registry: dict[uuid.UUID, asyncio.Task[None]] = {VOYAGE_ID: done}
+        request = _mock_request(pipeline_tasks=registry)
+
+        # Should not raise even though the task is already done.
+        result = await cancel_voyage(VOYAGE_ID, request, _mock_user(), _mock_voyage(), svc)
+        assert result["voyage_id"] == str(VOYAGE_ID)
+
+
+# ---------------------------------------------------------------------------
+# GET /status
+# ---------------------------------------------------------------------------
+
+
+class TestGetStatus:
+    @pytest.mark.asyncio
+    async def test_returns_snapshot(self) -> None:
+        from app.api.v1.pipeline import get_pipeline_status
+
+        reader = _mock_pipeline_service()
+        snapshot = _snapshot()
+        reader.get_status = AsyncMock(return_value=snapshot)
+
+        voyage = _mock_voyage()
+        result = await get_pipeline_status(VOYAGE_ID, _mock_user(), voyage, reader)
+
+        assert result is snapshot
+        reader.get_status.assert_awaited_once_with(voyage)
+
+
+# ---------------------------------------------------------------------------
+# GET /stream (SSE)
+# ---------------------------------------------------------------------------
+
+
+def _pipeline_started_event() -> PipelineStartedEvent:
+    return PipelineStartedEvent(
+        voyage_id=VOYAGE_ID,
+        source_role=CrewRole.CAPTAIN,
+        payload={"task": "x", "deploy_tier": "preview", "max_parallel_shipwrights": 1},
+    )
+
+
+def _stage_entered_event(stage: str = "PLANNING") -> PipelineStageEnteredEvent:
+    return PipelineStageEnteredEvent(
+        voyage_id=VOYAGE_ID,
+        source_role=CrewRole.CAPTAIN,
+        payload={"stage": stage, "voyage_status": "PLANNING"},
+    )
+
+
+def _stage_completed_event(stage: str = "PLANNING") -> PipelineStageCompletedEvent:
+    return PipelineStageCompletedEvent(
+        voyage_id=VOYAGE_ID,
+        source_role=CrewRole.CAPTAIN,
+        payload={"stage": stage, "duration_seconds": 0.1, "skipped": False},
+    )
+
+
+def _completed_event() -> PipelineCompletedEvent:
+    return PipelineCompletedEvent(
+        voyage_id=VOYAGE_ID,
+        source_role=CrewRole.CAPTAIN,
+        payload={"duration_seconds": 12.3, "deployment_url": "http://preview.local"},
+    )
+
+
+def _failed_event() -> PipelineFailedEvent:
+    return PipelineFailedEvent(
+        voyage_id=VOYAGE_ID,
+        source_role=CrewRole.CAPTAIN,
+        payload={"stage": "BUILDING", "code": "BUILD_FAILED", "message": "x"},
+    )
+
+
+async def _drain(generator: Any) -> list[bytes]:
+    frames: list[bytes] = []
+    async for chunk in generator:
+        frames.append(chunk)
+    return frames
+
+
+def _build_stream_mocks(
+    read_batches: list[list[tuple[str, Any]]],
+    voyage_final_status: str = VoyageStatus.COMPLETED.value,
+) -> tuple[AsyncMock, AsyncMock]:
+    """Return (mushi, session) mocks wired for SSE tests.
+
+    The mock session.get returns a non-terminal voyage for all status checks
+    except the final one, which returns the terminal status — so the generator
+    emits every batch before the loop exits.
+    """
+    mushi = AsyncMock()
+    mushi.ensure_group = AsyncMock(return_value=None)
+    mushi.ack = AsyncMock(return_value=1)
+    queued = list(read_batches) + [[]]  # trailing empty so the loop can check voyage status
+    mushi.read = AsyncMock(side_effect=queued + [[]] * 10)
+
+    # Expose a nested _redis.xgroup_destroy so the finally-block cleanup works.
+    mushi._redis = MagicMock()
+    mushi._redis.xgroup_destroy = AsyncMock(return_value=1)
+
+    session = AsyncMock()
+    in_flight_voyage = _mock_voyage(status=VoyageStatus.PLANNING.value)
+    terminal_voyage = _mock_voyage(status=voyage_final_status)
+    # One in-flight reply per batch, then the terminal status, then terminal
+    # forever after (defensive trailing copies).
+    session.get = AsyncMock(
+        side_effect=[in_flight_voyage] * len(read_batches) + [terminal_voyage] * 20
+    )
+    return mushi, session
+
+
+class TestStreamEvents:
+    @pytest.mark.asyncio
+    async def test_emits_events_and_closes_on_completion(self) -> None:
+        from app.api.v1.pipeline import stream_events
+
+        mushi, session = _build_stream_mocks(
+            read_batches=[
+                [("1-0", _pipeline_started_event())],
+                [("2-0", _stage_entered_event())],
+                [("3-0", _completed_event())],
+            ],
+            voyage_final_status=VoyageStatus.COMPLETED.value,
+        )
+        request = _mock_request()
+
+        response = await stream_events(
+            VOYAGE_ID, request, _mock_user(), _mock_voyage(), mushi, session
+        )
+        frames = await _drain(response.body_iterator)
+
+        # Three events emitted, each as one SSE frame.
+        assert len(frames) == 3
+        for frame in frames:
+            assert frame.startswith(b"data: ")
+            assert frame.endswith(b"\n\n")
+
+        # Each frame's JSON is a valid PipelineEventEnvelope.
+        for frame in frames:
+            body = frame[len(b"data: ") : -len(b"\n\n")]
+            parsed = json.loads(body)
+            env = PipelineEventEnvelope.model_validate(parsed)
+            assert env.event["voyage_id"] == str(VOYAGE_ID)
+
+        # Acked every delivered message.
+        assert mushi.ack.await_count == 3
+        # Best-effort group cleanup fired.
+        mushi._redis.xgroup_destroy.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_closes_on_client_disconnect(self) -> None:
+        from app.api.v1.pipeline import stream_events
+
+        mushi, session = _build_stream_mocks(read_batches=[])
+        request = _mock_request(is_disconnected=True)
+
+        response = await stream_events(
+            VOYAGE_ID, request, _mock_user(), _mock_voyage(), mushi, session
+        )
+        frames = await _drain(response.body_iterator)
+
+        # Disconnected immediately — no frames produced, no reads attempted.
+        assert frames == []
+        mushi.read.assert_not_called()
+        mushi._redis.xgroup_destroy.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_closes_on_voyage_failure(self) -> None:
+        from app.api.v1.pipeline import stream_events
+
+        mushi, session = _build_stream_mocks(
+            read_batches=[[("1-0", _failed_event())]],
+            voyage_final_status=VoyageStatus.FAILED.value,
+        )
+        request = _mock_request()
+
+        response = await stream_events(
+            VOYAGE_ID, request, _mock_user(), _mock_voyage(), mushi, session
+        )
+        frames = await _drain(response.body_iterator)
+
+        assert len(frames) == 1
+        body = frames[0][len(b"data: ") : -len(b"\n\n")]
+        env = json.loads(body)
+        assert env["event"]["event_type"] == "pipeline_failed"
+
+    @pytest.mark.asyncio
+    async def test_closes_on_voyage_cancelled(self) -> None:
+        from app.api.v1.pipeline import stream_events
+
+        mushi, session = _build_stream_mocks(
+            read_batches=[[("1-0", _stage_entered_event())]],
+            voyage_final_status=VoyageStatus.CANCELLED.value,
+        )
+        request = _mock_request()
+
+        response = await stream_events(
+            VOYAGE_ID, request, _mock_user(), _mock_voyage(), mushi, session
+        )
+        frames = await _drain(response.body_iterator)
+
+        assert len(frames) == 1
+
+    @pytest.mark.asyncio
+    async def test_each_frame_is_valid_sse_format(self) -> None:
+        from app.api.v1.pipeline import stream_events
+
+        mushi, session = _build_stream_mocks(
+            read_batches=[[("1-0", _pipeline_started_event())], [("2-0", _completed_event())]],
+            voyage_final_status=VoyageStatus.COMPLETED.value,
+        )
+        request = _mock_request()
+
+        response = await stream_events(
+            VOYAGE_ID, request, _mock_user(), _mock_voyage(), mushi, session
+        )
+        frames = await _drain(response.body_iterator)
+
+        for frame in frames:
+            decoded = frame.decode("utf-8")
+            assert decoded.startswith("data: ")
+            assert decoded.endswith("\n\n")
+            json.loads(decoded[len("data: ") : -len("\n\n")])  # valid JSON
+
+    @pytest.mark.asyncio
+    async def test_ensures_consumer_group_before_reading(self) -> None:
+        from app.api.v1.pipeline import stream_events
+
+        mushi, session = _build_stream_mocks(
+            read_batches=[[("1-0", _completed_event())]],
+            voyage_final_status=VoyageStatus.COMPLETED.value,
+        )
+        request = _mock_request()
+
+        response = await stream_events(
+            VOYAGE_ID, request, _mock_user(), _mock_voyage(), mushi, session
+        )
+        await _drain(response.body_iterator)
+
+        mushi.ensure_group.assert_awaited_once()
+        # Group name is fresh + ephemeral (starts with "sse-").
+        group_arg = mushi.ensure_group.await_args.args[1]
+        assert group_arg.startswith("sse-")


### PR DESCRIPTION
## Summary
- **POST /voyages/{id}/start** (202 Accepted) — spawns `asyncio.create_task(service.start(...))`, registers in `app.state.pipeline_tasks`, self-cleans via `done_callback`. Running pipeline → 409 `PIPELINE_ALREADY_RUNNING`. Completed voyage → 409.
- **POST /voyages/{id}/pause** and **POST /voyages/{id}/cancel** (200) — idempotent on terminal statuses. `/cancel` also cancels the in-flight `asyncio.Task`.
- **GET /voyages/{id}/status** (200) — uses `PipelineService.reader(session)`; no dial router or execution backend constructed.
- **GET /voyages/{id}/stream** (`text/event-stream`) — SSE. One fresh ephemeral consumer group per connection (replay-from-start), ~1s block timeout with `request.is_disconnected()` check, terminates on voyage terminal status or client disconnect, destroys the group in `finally`.
- New schemas in [app/schemas/pipeline.py](src/backend/app/schemas/pipeline.py): `StartVoyageRequest`, `StartVoyageResponse`, `PipelineEventEnvelope`.
- New DI helpers in [app/api/v1/dependencies.py](src/backend/app/api/v1/dependencies.py): `get_pipeline_service`, `get_pipeline_service_reader`.
- [app/main.py](src/backend/app/main.py) lifespan initializes `pipeline_tasks` registry; shutdown cancels in-flight tasks and awaits up to 5s.
- **27 new tests** in [tests/test_pipeline_api.py](src/backend/tests/test_pipeline_api.py): schemas, start/pause/cancel/status/stream matrix, SSE disconnect + terminal-close paths.

No changes to `PipelineService`, `pipeline_graph`, crew services, or events — pure API surface on top of Phase 15.3.

Prompt: [grandline-15-04-api-sse.md](pdd/prompts/features/pipeline/grandline-15-04-api-sse.md). Decision logged in [pdd/context/decisions.md](pdd/context/decisions.md).

## Test plan
- [x] `ruff check app/ tests/` — clean
- [x] `mypy app/` — clean (only pre-existing `types-python-jose` note, Phase 4, unrelated)
- [x] `pytest tests/test_pipeline_api.py` — 27 passed
- [x] `pytest` — 807 passed, 10 skipped (Phase 15.3 baseline 780 + 27 new; no regressions)
- [ ] Manual: start a voyage via the API, tail the SSE stream, pause + cancel + status endpoints respond as expected