### PR TITLE
style: fix backend lint (ruff import-sort + format) to green CI

### DIFF
--- a/src/backend/app/api/v1/pipeline.py
+++ b/src/backend/app/api/v1/pipeline.py
@@ -262,9 +262,7 @@ async def inject_context(
         action = await pipeline_service.inject(voyage, body.context, body.phase_number)
     except PipelineError as exc:
         raise _pipeline_http_exception(exc) from exc
-    return InterventionResponse(
-        voyage_id=voyage_id, crew_action_id=action.id, status=voyage.status
-    )
+    return InterventionResponse(voyage_id=voyage_id, crew_action_id=action.id, status=voyage.status)
 
 
 @router.post("/redirect", response_model=InterventionResponse, status_code=status.HTTP_200_OK)
@@ -280,9 +278,7 @@ async def redirect_phase(
         action = await pipeline_service.redirect(voyage, body.phase_number, body.instruction)
     except PipelineError as exc:
         raise _pipeline_http_exception(exc) from exc
-    return InterventionResponse(
-        voyage_id=voyage_id, crew_action_id=action.id, status=voyage.status
-    )
+    return InterventionResponse(voyage_id=voyage_id, crew_action_id=action.id, status=voyage.status)
 
 
 @router.get(

--- a/src/backend/app/services/pipeline_service.py
+++ b/src/backend/app/services/pipeline_service.py
@@ -33,11 +33,11 @@ from app.den_den_mushi.mushi import DenDenMushi
 from app.deployment.backend import DeploymentBackend
 from app.dial_system.router import DialSystemRouter
 from app.models.build_artifact import BuildArtifact
+from app.models.crew_action import CrewAction
 from app.models.deployment import Deployment
 from app.models.dial_config import DialConfig
 from app.models.enums import CrewRole, VoyageStatus
 from app.models.health_check import HealthCheck
-from app.models.crew_action import CrewAction
 from app.models.poneglyph import Poneglyph
 from app.models.validation_run import ValidationRun
 from app.models.vivre_card import VivreCard
@@ -322,9 +322,7 @@ class PipelineService:
         await publish_crew_action_recorded(self._mushi, voyage.id, action)
         return action
 
-    async def redirect(
-        self, voyage: Voyage, phase_number: int, instruction: str
-    ) -> CrewAction:
+    async def redirect(self, voyage: Voyage, phase_number: int, instruction: str) -> CrewAction:
         """Reassign a phase's approach (Phase 17).
 
         Records the redirect and resets the targeted phase to PENDING so a

--- a/src/backend/tests/test_pipeline_service.py
+++ b/src/backend/tests/test_pipeline_service.py
@@ -339,9 +339,7 @@ class TestIntervention:
         mock_session.commit.assert_awaited()
 
     @pytest.mark.asyncio
-    async def test_inject_rejected_on_terminal_voyage(
-        self, service: PipelineService
-    ) -> None:
+    async def test_inject_rejected_on_terminal_voyage(self, service: PipelineService) -> None:
         voyage = _mock_voyage(status=VoyageStatus.COMPLETED.value)
         with pytest.raises(PipelineError) as exc:
             await service.inject(voyage, "too late")
@@ -351,18 +349,14 @@ class TestIntervention:
     async def test_redirect_resets_phase_to_pending(
         self, service: PipelineService, mock_session: AsyncMock
     ) -> None:
-        voyage = _mock_voyage(
-            status=VoyageStatus.BUILDING.value, phase_status={"2": "BUILT"}
-        )
+        voyage = _mock_voyage(status=VoyageStatus.BUILDING.value, phase_status={"2": "BUILT"})
         action = await service.redirect(voyage, 2, "try a different algorithm")
         assert voyage.phase_status["2"] == "PENDING"
         assert action.action_type == "phase_redirected"
         mock_session.commit.assert_awaited()
 
     @pytest.mark.asyncio
-    async def test_redirect_rejected_on_terminal_voyage(
-        self, service: PipelineService
-    ) -> None:
+    async def test_redirect_rejected_on_terminal_voyage(self, service: PipelineService) -> None:
         voyage = _mock_voyage(status=VoyageStatus.CANCELLED.value)
         with pytest.raises(PipelineError) as exc:
             await service.redirect(voyage, 1, "nope")


### PR DESCRIPTION
Fixes the failing **Backend (lint + test)** CI job from #44.

The job failed at the lint step:
- `ruff check .` → I001 import-sort error in `pipeline_service.py` (the added `CrewAction` import was out of order).
- `ruff format --check .` → 3 files needed formatting (`pipeline.py`, `pipeline_service.py`, `test_pipeline_service.py`).

Applied `ruff check --fix` + `ruff format`. No logic changes.

Verified locally (exact CI steps):
- `ruff check .` ✓
- `ruff format --check .` ✓
- `mypy app/ --ignore-missing-imports` ✓
- `pytest` → 868 passed, 19 skipped ✓

https://claude.ai/code/session_01M9XXGXcEncSVGjjk7vd7Su

---
_Generated by [Claude Code](https://claude.ai/code/session_01M9XXGXcEncSVGjjk7vd7Su)_