### PR TITLE
test: run all integration tests (0 skipped) + clear warnings; lint clean

### DIFF
--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -1,5 +1,6 @@
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
 testpaths = ["tests"]
 pythonpath = ["."]
 markers = [

--- a/src/backend/tests/test_auth.py
+++ b/src/backend/tests/test_auth.py
@@ -231,6 +231,7 @@ class TestAuthService:
         from app.services.auth_service import register
 
         mock_session = AsyncMock()
+        mock_session.add = MagicMock()
         mock_result = MagicMock()
         mock_result.scalar_one_or_none.return_value = None
         mock_session.execute.return_value = mock_result
@@ -258,6 +259,7 @@ class TestAuthService:
         from app.services.auth_service import AuthError, register
 
         mock_session = AsyncMock()
+        mock_session.add = MagicMock()
         mock_result = MagicMock()
         mock_result.scalar_one_or_none.return_value = MagicMock()  # existing user
         mock_session.execute.return_value = mock_result
@@ -285,6 +287,7 @@ class TestAuthService:
         mock_user.is_active = True
 
         mock_session = AsyncMock()
+        mock_session.add = MagicMock()
         mock_result = MagicMock()
         mock_result.scalar_one_or_none.return_value = mock_user
         mock_session.execute.return_value = mock_result
@@ -307,6 +310,7 @@ class TestAuthService:
         mock_user.is_active = True
 
         mock_session = AsyncMock()
+        mock_session.add = MagicMock()
         mock_result = MagicMock()
         mock_result.scalar_one_or_none.return_value = mock_user
         mock_session.execute.return_value = mock_result
@@ -322,6 +326,7 @@ class TestAuthService:
         from app.services.auth_service import AuthError, login
 
         mock_session = AsyncMock()
+        mock_session.add = MagicMock()
         mock_result = MagicMock()
         mock_result.scalar_one_or_none.return_value = None
         mock_session.execute.return_value = mock_result
@@ -341,6 +346,7 @@ class TestAuthService:
         mock_user.is_active = False
 
         mock_session = AsyncMock()
+        mock_session.add = MagicMock()
         mock_result = MagicMock()
         mock_result.scalar_one_or_none.return_value = mock_user
         mock_session.execute.return_value = mock_result
@@ -365,6 +371,7 @@ class TestAuthService:
         mock_user.is_active = True
 
         mock_session = AsyncMock()
+        mock_session.add = MagicMock()
         mock_result = MagicMock()
         mock_result.scalar_one_or_none.return_value = mock_user
         mock_session.execute.return_value = mock_result
@@ -389,6 +396,7 @@ class TestAuthService:
         old_refresh = create_refresh_token(user_id)
 
         mock_session = AsyncMock()
+        mock_session.add = MagicMock()
         mock_redis = AsyncMock()
         mock_redis.get.return_value = None  # token not in Redis = revoked
 
@@ -404,6 +412,7 @@ class TestAuthService:
         access = create_access_token(user_id)  # wrong type
 
         mock_session = AsyncMock()
+        mock_session.add = MagicMock()
         mock_redis = AsyncMock()
 
         with pytest.raises(AuthError) as exc_info:
@@ -425,6 +434,7 @@ class TestAccessCookie:
         body = RegisterRequest(email="zoro@grandline.dev", username="zoro", password="three-swords")
 
         mock_session = AsyncMock()
+        mock_session.add = MagicMock()
         mock_session.execute.return_value = MagicMock(
             scalar_one_or_none=MagicMock(return_value=None)
         )
@@ -452,6 +462,7 @@ class TestAccessCookie:
         user.hashed_password = hash_password("three-swords")
         user.is_active = True
         mock_session = AsyncMock()
+        mock_session.add = MagicMock()
         mock_session.execute.return_value = MagicMock(
             scalar_one_or_none=MagicMock(return_value=user)
         )
@@ -479,6 +490,7 @@ class TestAccessCookie:
         user.id = user_id
         user.is_active = True
         mock_session = AsyncMock()
+        mock_session.add = MagicMock()
         mock_session.execute.return_value = MagicMock(
             scalar_one_or_none=MagicMock(return_value=user)
         )

--- a/src/backend/tests/test_vivre_card_service.py
+++ b/src/backend/tests/test_vivre_card_service.py
@@ -42,6 +42,7 @@ class TestCheckpoint:
         from app.services.vivre_card_service import checkpoint
 
         session = AsyncMock()
+        session.add = MagicMock()
         state = {"step": 3, "messages": ["hello"]}
 
         card = await checkpoint(
@@ -65,6 +66,7 @@ class TestCheckpoint:
         from app.services.vivre_card_service import checkpoint
 
         session = AsyncMock()
+        session.add = MagicMock()
         nested_state = {
             "step": 5,
             "context": {"messages": [{"role": "user", "content": "plan"}]},
@@ -91,6 +93,7 @@ class TestRestore:
         expected_card = _make_card(card_id=card_id, voyage_id=VOYAGE_ID)
 
         session = AsyncMock()
+        session.add = MagicMock()
         mock_result = MagicMock()
         mock_result.scalar_one_or_none.return_value = expected_card
         session.execute.return_value = mock_result
@@ -105,6 +108,7 @@ class TestRestore:
         from app.services.vivre_card_service import VivreCardError, restore
 
         session = AsyncMock()
+        session.add = MagicMock()
         mock_result = MagicMock()
         mock_result.scalar_one_or_none.return_value = None
         session.execute.return_value = mock_result
@@ -124,6 +128,7 @@ class TestListCards:
         cards = [_make_card(voyage_id=VOYAGE_ID) for _ in range(3)]
 
         session = AsyncMock()
+        session.add = MagicMock()
         # First call: items query
         items_result = MagicMock()
         items_result.scalars.return_value.all.return_value = cards
@@ -144,6 +149,7 @@ class TestListCards:
         cards = [_make_card(voyage_id=VOYAGE_ID, crew_member="captain")]
 
         session = AsyncMock()
+        session.add = MagicMock()
         items_result = MagicMock()
         items_result.scalars.return_value.all.return_value = cards
         count_result = MagicMock()
@@ -162,6 +168,7 @@ class TestListCards:
         cards = [_make_card(voyage_id=VOYAGE_ID)]
 
         session = AsyncMock()
+        session.add = MagicMock()
         items_result = MagicMock()
         items_result.scalars.return_value.all.return_value = cards
         count_result = MagicMock()
@@ -178,6 +185,7 @@ class TestListCards:
         from app.services.vivre_card_service import list_cards
 
         session = AsyncMock()
+        session.add = MagicMock()
         items_result = MagicMock()
         items_result.scalars.return_value.all.return_value = []
         count_result = MagicMock()
@@ -199,6 +207,7 @@ class TestDiff:
         card_b = _make_card(state_data={"step": 1, "output": "done"})
 
         session = AsyncMock()
+        session.add = MagicMock()
         mock_result_a = MagicMock()
         mock_result_a.scalar_one_or_none.return_value = card_a
         mock_result_b = MagicMock()
@@ -219,6 +228,7 @@ class TestDiff:
         card_b = _make_card(state_data={"step": 1})
 
         session = AsyncMock()
+        session.add = MagicMock()
         mock_result_a = MagicMock()
         mock_result_a.scalar_one_or_none.return_value = card_a
         mock_result_b = MagicMock()
@@ -239,6 +249,7 @@ class TestDiff:
         card_b = _make_card(state_data={"step": 3, "status": "done"})
 
         session = AsyncMock()
+        session.add = MagicMock()
         mock_result_a = MagicMock()
         mock_result_a.scalar_one_or_none.return_value = card_a
         mock_result_b = MagicMock()
@@ -259,6 +270,7 @@ class TestDiff:
         card_b = _make_card(state_data=state.copy())
 
         session = AsyncMock()
+        session.add = MagicMock()
         mock_result_a = MagicMock()
         mock_result_a.scalar_one_or_none.return_value = card_a
         mock_result_b = MagicMock()
@@ -276,6 +288,7 @@ class TestDiff:
         from app.services.vivre_card_service import VivreCardError, diff
 
         session = AsyncMock()
+        session.add = MagicMock()
         mock_result = MagicMock()
         mock_result.scalar_one_or_none.return_value = None
         session.execute.return_value = mock_result
@@ -292,6 +305,7 @@ class TestCleanup:
         from app.services.vivre_card_service import cleanup
 
         session = AsyncMock()
+        session.add = MagicMock()
         # First query: distinct crew members
         crew_result = MagicMock()
         crew_result.scalars.return_value.all.return_value = ["captain"]
@@ -316,6 +330,7 @@ class TestCleanup:
         from app.services.vivre_card_service import cleanup
 
         session = AsyncMock()
+        session.add = MagicMock()
         crew_result = MagicMock()
         crew_result.scalars.return_value.all.return_value = []
         session.execute.return_value = crew_result
@@ -330,6 +345,7 @@ class TestCleanup:
         from app.services.vivre_card_service import cleanup
 
         session = AsyncMock()
+        session.add = MagicMock()
         crew_result = MagicMock()
         crew_result.scalars.return_value.all.return_value = ["navigator"]
         # Only 2 cards, keep_last_n=5 — nothing to delete


### PR DESCRIPTION
Addresses the request to ensure **all tests pass with nothing ignored** and **all code guidelines (ruff/eslint) are followed**.

## Tests — nothing skipped
The suite previously reported `868 passed, 19 skipped`. The 19 were integration tests gated on live Redis (10) + Postgres (9). Verified them by standing up both services locally (Redis on :6379, Postgres 16 on :5432 with the `grandline` db + migrations):
- **887 passed, 0 skipped, 0 warnings.**

(The integration tests still skip cleanly on machines without infra by design; CI provides the services via `services:`.)

## Warnings eliminated
- Mock sessions defined `session.add` as an `AsyncMock`, so service calls to the synchronous `session.add(...)` raised `coroutine '…' was never awaited` RuntimeWarnings → stubbed `.add` as `MagicMock` in `test_auth.py` / `test_vivre_card_service.py`.
- Set `asyncio_default_fixture_loop_scope = "function"` to clear the pytest-asyncio deprecation warning.

## Lint / code guidelines — all clean
- Backend: `ruff check .` ✓, `ruff format --check .` ✓, `mypy app/ --ignore-missing-imports` ✓
- Frontend: `next lint` ✓ (no ESLint warnings or errors), `tsc --noEmit` ✓, `vitest` → 53 passed ✓

https://claude.ai/code/session_01M9XXGXcEncSVGjjk7vd7Su

---
_Generated by [Claude Code](https://claude.ai/code/session_01M9XXGXcEncSVGjjk7vd7Su)_