### PR TITLE
chore: gitignore Redis *.rdb snapshots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,9 @@ htmlcov/
 .pytest_cache/
 .coverage
 
+# Redis (local dev/integration snapshots)
+*.rdb
+
 # Misc
 *.log
 tmp.md


### PR DESCRIPTION
Ignores Redis `*.rdb` snapshot files. Running `redis-server` locally for the integration test suite drops a `dump.rdb` in the working directory; this keeps that runtime artifact out of git.

One-line `.gitignore` change, no code impact.

https://claude.ai/code/session_01M9XXGXcEncSVGjjk7vd7Su

---
_Generated by [Claude Code](https://claude.ai/code/session_01M9XXGXcEncSVGjjk7vd7Su)_