### PR TITLE
ci: gate CD deploys behind DEPLOY_ENABLED so main stops failing

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -2,6 +2,12 @@ name: CD
 
 # Build images → push to GHCR → deploy to staging → manual gate → deploy to
 # prod (#19). Triggered on pushes to main and on version tags.
+#
+# OPT-IN: every job is gated on the `DEPLOY_ENABLED` repository variable. Until
+# a cluster + secrets are provisioned and DEPLOY_ENABLED is set to "true", all
+# jobs skip cleanly (so merges to main never fail on a missing kubeconfig).
+# To activate: set repo variable DEPLOY_ENABLED=true and provide the
+# STAGING_KUBECONFIG / PROD_KUBECONFIG secrets (base64 kubeconfigs).
 on:
   push:
     branches: [main]
@@ -19,6 +25,7 @@ env:
 jobs:
   build-push:
     name: Build & push images
+    if: ${{ vars.DEPLOY_ENABLED == 'true' }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -60,6 +67,7 @@ jobs:
   deploy-staging:
     name: Deploy to staging
     needs: build-push
+    if: ${{ vars.DEPLOY_ENABLED == 'true' }}
     runs-on: ubuntu-latest
     environment: staging
     steps:
@@ -85,6 +93,7 @@ jobs:
   deploy-prod:
     name: Deploy to production
     needs: deploy-staging
+    if: ${{ vars.DEPLOY_ENABLED == 'true' }}
     runs-on: ubuntu-latest
     # The `production` environment requires a manual approval gate configured in
     # repo settings (required reviewers) — this enforces the manual gate (#19).

--- a/src/infra/helm/README.md
+++ b/src/infra/helm/README.md
@@ -49,7 +49,15 @@ helm upgrade --install grandline ./grandline \
 `.github/workflows/cd.yml`: build images (`Dockerfile.prod`) → push to GHCR →
 deploy to **staging** automatically → **manual approval gate** (the
 `production` GitHub Environment with required reviewers) → deploy to **prod**.
-Provide `STAGING_KUBECONFIG` / `PROD_KUBECONFIG` (base64) as environment secrets.
+
+**Opt-in.** Every CD job is gated on the `DEPLOY_ENABLED` repository variable so
+merges to `main` never fail before a cluster exists. To activate:
+
+1. Provision a cluster and create the `STAGING_KUBECONFIG` / `PROD_KUBECONFIG`
+   secrets (base64-encoded kubeconfigs).
+2. Set the repository variable `DEPLOY_ENABLED=true`.
+
+Until then the workflow runs but all jobs skip cleanly (green).
 
 ## Notes
 


### PR DESCRIPTION
## Problem
The PR checks (CI: backend + frontend) were green, but the **CD workflow** (`cd.yml`, added in #19) runs on every push to `main`. Its deploy jobs do:

```
echo "${{ secrets.STAGING_KUBECONFIG }}" | base64 -d > ~/.kube/config
helm upgrade --install ... --wait
```

With no cluster and no `STAGING_KUBECONFIG`/`PROD_KUBECONFIG` secrets configured, the kubeconfig is empty and `helm --wait` can't reach a cluster → the job fails on every merge. That's the failing run.

## Fix
Gate **all** CD jobs (`build-push`, `deploy-staging`, `deploy-prod`) on a `DEPLOY_ENABLED` repository variable:

```yaml
if: ${{ vars.DEPLOY_ENABLED == 'true' }}
```

Until a cluster + secrets are provisioned and `DEPLOY_ENABLED=true` is set, the workflow runs but every job **skips cleanly** (green) — so merges to `main` no longer fail. When ready to deploy, set the variable + secrets and the full build→staging→manual-gate→prod pipeline activates. Documented in `src/infra/helm/README.md`.

No application code changed.

https://claude.ai/code/session_01M9XXGXcEncSVGjjk7vd7Su

---
_Generated by [Claude Code](https://claude.ai/code/session_01M9XXGXcEncSVGjjk7vd7Su)_