### PR TITLE
feat: Claude Code CLI provider + release-readiness fixes (voyage creation, WS auth, deploy hardening)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -23,6 +23,26 @@ env:
   IMAGE_PREFIX: ghcr.io/${{ github.repository }}
 
 jobs:
+  deploy-gate:
+    # Always runs so the workflow shows WHY everything else skipped when
+    # DEPLOY_ENABLED is unset (finding: silent skips confuse operators).
+    name: Deploy gate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Report deploy gating
+        run: |
+          if [ "${{ vars.DEPLOY_ENABLED }}" = "true" ]; then
+            echo "DEPLOY_ENABLED=true — build & deploy jobs will run." >> "$GITHUB_STEP_SUMMARY"
+          else
+            {
+              echo "## Deploys are disabled"
+              echo ""
+              echo "The \`DEPLOY_ENABLED\` repository variable is not \`true\`, so all build/deploy jobs were skipped."
+              echo "To enable: set the repo variable \`DEPLOY_ENABLED=true\` and provide the \`STAGING_KUBECONFIG\` / \`PROD_KUBECONFIG\` secrets."
+              echo "First-deploy runbook: docs/DEPLOYMENT.md"
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
   build-push:
     name: Build & push images
     if: ${{ vars.DEPLOY_ENABLED == 'true' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,3 +87,25 @@ jobs:
 
       - name: Test (vitest)
         run: npm run test
+
+  helm:
+    name: Helm (lint + template)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+
+      - name: helm lint
+        run: helm lint src/infra/helm/grandline
+
+      # Render every environment overlay so chart/values drift (wrong secret
+      # key names, missing values) fails the PR instead of the deploy.
+      - name: Render environment overlays
+        run: |
+          for overlay in dev staging prod; do
+            echo "── values-${overlay}.yaml ──"
+            helm template grandline src/infra/helm/grandline \
+              -f "src/infra/helm/grandline/values-${overlay}.yaml" > /dev/null
+          done

--- a/Makefile
+++ b/Makefile
@@ -102,6 +102,7 @@ migrate-status: ## Show current alembic revision
 api-dev: ## Run FastAPI locally with uvicorn --reload (requires `make up`)
 	@$(DOCKER_HOST_EXPORT); \
 	cd $(BACKEND) && source venv/bin/activate && \
+		GRANDLINE_DEBUG=true \
 		GRANDLINE_DATABASE_URL=postgresql+psycopg://grandline:grandline@localhost:5432/grandline \
 		GRANDLINE_REDIS_URL=redis://localhost:6379/0 \
 		uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
@@ -148,6 +149,7 @@ setup: venv up migrate ## One-shot: venv + infra + migrations
 api-mocked: ## Run FastAPI with PipelineService.start mocked (for smoke test)
 	@$(DOCKER_HOST_EXPORT); \
 	cd $(BACKEND) && source venv/bin/activate && \
+		GRANDLINE_DEBUG=true \
 		GRANDLINE_DATABASE_URL=postgresql+psycopg://grandline:grandline@localhost:5432/grandline \
 		GRANDLINE_REDIS_URL=redis://localhost:6379/0 \
 		PYTHONPATH=. python3 -m scripts.dev_api_mocked

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Users can intervene at any point — pause an agent, redirect work, inject conte
 |---|---|
 | Frontend | Next.js 14+, React, TypeScript, Tailwind CSS, shadcn/ui |
 | Backend | Python, FastAPI, SQLAlchemy |
-| AI/Agents | LangGraph, multi-provider via Dial System |
+| AI/Agents | LangGraph, multi-provider via Dial System (Anthropic API, OpenAI, Ollama, Claude Code CLI) |
 | Message Bus | Redis Streams (Den Den Mushi) |
 | Database | PostgreSQL (Vivre Card state + JSONB) |
 | Deployment | Docker Compose (local-first), Kubernetes + Helm (production) |
@@ -47,6 +47,36 @@ pdd/                — Prompt Driven Development artifacts
   evals/            — Prompt quality evaluations
 docs/               — Documentation (auto-deployed to GitHub Pages)
 ```
+
+## The Dial System (LLM Gateway)
+
+Each crew role dials its own provider/model, with per-role fallback chains. A
+voyage's dial config (`PUT /api/v1/voyages/{id}/dial-config`) maps roles to
+providers:
+
+```json
+{
+  "role_mapping": {
+    "captain":    {"provider": "anthropic",   "model": "claude-sonnet-4-20250514"},
+    "navigator":  {"provider": "claude_code", "model": "sonnet"},
+    "shipwright": {"provider": "openai",      "model": "gpt-4o"},
+    "doctor":     {"provider": "ollama",      "model": "llama3"},
+    "helmsman":   {"provider": "claude_code", "model": "claude-sonnet-4-20250514"}
+  },
+  "fallback_chain": {
+    "captain": ["openai", "ollama"]
+  }
+}
+```
+
+Supported providers:
+
+| Provider | Auth | Notes |
+|---|---|---|
+| `anthropic` | `GRANDLINE_ANTHROPIC_API_KEY` | Anthropic Messages API |
+| `openai` | `GRANDLINE_OPENAI_API_KEY` | OpenAI Chat Completions |
+| `ollama` | none | Local models via `GRANDLINE_OLLAMA_BASE_URL` |
+| `claude_code` | Claude Code CLI login | Runs the local `claude` CLI in print mode — works with a Claude subscription (`claude login` / `CLAUDE_CODE_OAUTH_TOKEN`) or `ANTHROPIC_API_KEY`; no key stored in GrandLine. Install: `npm install -g @anthropic-ai/claude-code`. Tune via `GRANDLINE_CLAUDE_CODE_*` env vars (see `src/backend/.env.example`). |
 
 ## Development
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,0 +1,117 @@
+# GrandLine — First Staging/Production Deploy Runbook
+
+The CD pipeline (`.github/workflows/cd.yml`) is opt-in: every build/deploy job
+is gated on the `DEPLOY_ENABLED` repository variable, and the chart's
+staging/prod overlays expect an externally-provisioned Secret. This runbook is
+the checklist for turning it on for the first time. CI already validates the
+chart (`helm lint` + rendering every overlay) on each PR.
+
+## 0. Prerequisites
+
+- A Kubernetes cluster per environment (staging, prod) with:
+  - an NGINX ingress controller (`ingress.className: nginx`)
+  - cert-manager with a `letsencrypt-prod` ClusterIssuer — or disable TLS
+    (`ingress.tls.enabled=false`) / change the annotation in `values.yaml`
+- DNS records for your real hostnames (the committed
+  `grandline.example.com` / `staging.grandline.example.com` are placeholders —
+  override them, see step 2)
+- GHCR images pullable from the cluster (public packages, or an
+  `imagePullSecret` added to the chart's ServiceAccount)
+- `kubectl` + `helm` access to both clusters
+
+## 1. Provision the application Secret (per environment)
+
+The Deployment consumes the Secret via `envFrom`, so **key names must match
+the backend's `GRANDLINE_`-prefixed settings exactly** (see
+`src/backend/.env.example`):
+
+```bash
+kubectl create namespace grandline-staging
+
+PGPASS="$(openssl rand -hex 24)"
+kubectl -n grandline-staging create secret generic grandline-secrets \
+  --from-literal=POSTGRES_PASSWORD="$PGPASS" \
+  --from-literal=GRANDLINE_JWT_SECRET_KEY="$(openssl rand -hex 32)" \
+  --from-literal=GRANDLINE_DATABASE_URL="postgresql+psycopg://grandline:${PGPASS}@grandline-postgres:5432/grandline" \
+  --from-literal=GRANDLINE_REDIS_URL="redis://grandline-redis:6379/0" \
+  --from-literal=GRANDLINE_ANTHROPIC_API_KEY="sk-ant-..." \
+  --from-literal=GRANDLINE_OPENAI_API_KEY=""
+```
+
+> The backend refuses to boot with the default JWT secret when
+> `GRANDLINE_DEBUG=false`, so a missing/mis-keyed Secret fails loudly at pod
+> start instead of serving with insecure defaults.
+
+Repeat for `grandline-prod`. Prefer sealed-secrets/external-secrets in real
+setups; `kubectl create secret` is the minimum viable path.
+
+## 2. Point the overlays at your domains
+
+Edit (or `--set` at deploy time) in `values-staging.yaml` / `values-prod.yaml`:
+
+- `ingress.host`
+- `backend.env.GRANDLINE_CORS_ORIGINS` (JSON list containing the frontend origin)
+- `frontend.env.NEXT_PUBLIC_API_BASE_URL` (the public API origin; empty string
+  for a same-origin proxy setup)
+
+`NEXT_PUBLIC_*` values are baked at image build time — the CD `build-push` job
+builds with `NEXT_PUBLIC_API_BASE_URL=` (same-origin). If your API is on a
+different origin, set the build-arg in `cd.yml` accordingly.
+
+## 3. Configure GitHub
+
+1. Repo **Variables**: `DEPLOY_ENABLED=true`.
+2. Repo **Secrets**: `STAGING_KUBECONFIG` and `PROD_KUBECONFIG`
+   (base64-encoded kubeconfigs: `base64 -w0 < kubeconfig`).
+3. **Environments**: create `staging` and `production`; add required
+   reviewers on `production` — that approval is the manual gate between
+   staging and prod deploys.
+
+When `DEPLOY_ENABLED` is not `true`, the `deploy-gate` job posts a notice to
+the run summary explaining that deploys were skipped (they no longer skip
+silently).
+
+## 4. Ship it
+
+Push to `main` (or run the CD workflow manually). Sequence:
+`build-push` (GHCR, tags incl. `sha-<short>`) → `deploy-staging`
+(`helm upgrade --install -f values-staging.yaml --set *.image.tag=sha-…`) →
+manual approval → `deploy-prod`.
+
+## 5. Smoke-test staging before approving prod
+
+```bash
+# API up + migrations applied (init container runs alembic upgrade head)
+curl -fsS https://staging.example.com/api/v1/health
+
+# End-to-end: register, chart a course, set sail, watch events
+# (or use the UI: /register → Observation Deck → "+ Chart")
+```
+
+- Register a user, chart a voyage from the deck, confirm the WS stream
+  connects (Network tab: the `/events` connection uses the
+  `grandline-bearer` subprotocol — no token in the URL).
+- `kubectl -n grandline-staging get pods` — backend/frontend Ready, HPA happy.
+
+## 6. Rollback
+
+```bash
+helm -n grandline-staging history grandline
+helm -n grandline-staging rollback grandline <revision>
+```
+
+## Appendix: Claude Code CLI provider in K8s
+
+The `claude_code` dial provider shells out to the `claude` binary, which is
+not in the default backend image. To use it in-cluster, extend
+`src/backend/Dockerfile.prod` with Node + the CLI:
+
+```dockerfile
+RUN apt-get update && apt-get install -y --no-install-recommends nodejs npm \
+ && npm install -g @anthropic-ai/claude-code \
+ && rm -rf /var/lib/apt/lists/*
+```
+
+and provide auth via the Secret (`CLAUDE_CODE_OAUTH_TOKEN=...` from
+`claude setup-token`, or rely on `ANTHROPIC_API_KEY`). API-key based
+providers (`anthropic`, `openai`) need no image changes.

--- a/docs/RELEASE_READINESS.md
+++ b/docs/RELEASE_READINESS.md
@@ -7,10 +7,10 @@ Each finding is marked **FIXED** (addressed in this review's PR) or **OPEN**
 ## Verdict
 
 The codebase is in good shape — clean lint, 900+ passing tests, no TODO/stub
-debt, auth enforced on every endpoint, parameterized SQL throughout. The
-items below were the gaps that mattered. After the FIXED items, the remaining
-release blockers are the **OPEN — blocking** ones: ship-stoppers are the
-missing voyage-creation API and the WS token-in-URL exposure.
+debt, auth enforced on every endpoint, parameterized SQL throughout. All
+**blocking** findings from the original review are now FIXED; one operational
+step remains (run the first staging deploy — see `docs/DEPLOYMENT.md`), plus
+the non-blocking hardening list at the bottom.
 
 ---
 
@@ -64,26 +64,34 @@ missing voyage-creation API and the WS token-in-URL exposure.
    `/app` blanked the screen. **FIXED**: `app/app/error.tsx` route-segment
    boundary with a reset action.
 
-## Open — blocking before public release
+## Former blockers — fixed in the follow-up pass
 
-9. **No voyage-creation endpoint.** The API can list voyages, run the
-   pipeline, and stream events — but there is no `POST /voyages` ("chart a
-   course"); voyages only exist via `scripts/seed.py`. The frontend likewise
-   has no creation flow. Users cannot actually start a voyage end-to-end.
+9. **No voyage-creation endpoint.** ~~Voyages only existed via
+   `scripts/seed.py`.~~ **FIXED**: `POST /api/v1/voyages` ("chart a course")
+   creates the voyage plus a default dial config (provider/model from
+   `GRANDLINE_DIAL_DEFAULT_PROVIDER` / `GRANDLINE_DIAL_DEFAULT_MODEL`), and
+   the Observation Deck sidebar grew a "+ Chart" dialog that creates the
+   voyage and optionally sets sail immediately (`POST /voyages/{id}/start`
+   with the mission text as the task). Users can now go register → chart →
+   sail → watch end-to-end.
 
-10. **WS auth token exposed in URL** — `useVoyageStream.ts` connects to
-    `…/events?token=<jwt>`; the backend WS endpoint reads the token from the
-    query string. Tokens in URLs land in proxy/access logs and browser
-    history. Recommended: authenticate the WS handshake via the (already
-    set) cookie or a `Sec-WebSocket-Protocol` subprotocol, then drop the
-    query param and make the auth cookie HttpOnly (removing finding #4's
-    trade-off entirely).
+10. **WS auth token exposed in URL.** ~~`…/events?token=<jwt>` landed in
+    proxy logs and browser history.~~ **FIXED**: the WS handshake now
+    authenticates via `Sec-WebSocket-Protocol: grandline-bearer, <jwt>`
+    (echoed by the server on accept) with the `access_token` cookie as the
+    same-origin fallback; the `?token=` query param is removed and ignored.
+    Follow-up (non-blocking): moving the cookie to HttpOnly still requires
+    reworking session restore, since the in-memory auth store re-hydrates
+    from that cookie after a page reload.
 
-11. **Production deploy pipeline never exercised** — CD is gated behind
-    `DEPLOY_ENABLED` (off by default) and the chart's prod overlay
-    (`grandline.example.com`, cert-manager issuer) is placeholder. Do one
-    full staging deploy (images → Helm → ingress/TLS → smoke test) before
-    calling the chart release-ready.
+11. **Production deploy pipeline never exercised.** **MOSTLY FIXED**: CI now
+    runs `helm lint` + renders every overlay on each PR (catches chart/values
+    drift like the secret-key mismatch class), CD's new `deploy-gate` job
+    reports loudly when `DEPLOY_ENABLED` is off instead of skipping silently,
+    and `docs/DEPLOYMENT.md` is the first-deploy runbook (secret provisioning
+    with exact key names, domains, GitHub environments, smoke tests,
+    rollback). **Remaining manual step**: provision a staging cluster and run
+    the pipeline once before the public release.
 
 ## Open — recommended hardening (non-blocking)
 
@@ -101,9 +109,8 @@ missing voyage-creation API and the WS token-in-URL exposure.
     limits in some paths; `imagePullPolicy: IfNotPresent` with `latest` tags
     can serve stale images — prefer digest/SHA tags (CD already passes
     `--set image.tag=<sha>`).
-17. **`DEPLOY_ENABLED` skip is silent** — when unset, CD jobs skip without
-    explanation; emit a notice in the workflow so operators know deploys are
-    disabled.
+17. ~~**`DEPLOY_ENABLED` skip is silent**~~ — **FIXED**: the `deploy-gate`
+    job posts the gating state to the workflow run summary.
 
 ---
 

--- a/docs/RELEASE_READINESS.md
+++ b/docs/RELEASE_READINESS.md
@@ -1,0 +1,121 @@
+# GrandLine — Release Readiness Review
+
+Deep review of backend, frontend, infra, and CI/CD (June 2026).
+Each finding is marked **FIXED** (addressed in this review's PR) or **OPEN**
+(needs a decision or follow-up work before/after release).
+
+## Verdict
+
+The codebase is in good shape — clean lint, 900+ passing tests, no TODO/stub
+debt, auth enforced on every endpoint, parameterized SQL throughout. The
+items below were the gaps that mattered. After the FIXED items, the remaining
+release blockers are the **OPEN — blocking** ones: ship-stoppers are the
+missing voyage-creation API and the WS token-in-URL exposure.
+
+---
+
+## Critical — fixed in this pass
+
+1. **Helm secret key names didn't match the backend settings** — `secret.yaml`
+   shipped `GRANDLINE_JWT_SECRET` and `GRANDLINE_DIAL_ANTHROPIC_API_KEY`, but
+   the backend (pydantic `env_prefix="GRANDLINE_"`) reads
+   `GRANDLINE_JWT_SECRET_KEY` and `GRANDLINE_ANTHROPIC_API_KEY`. Because the
+   Deployment uses `envFrom`, both values were **silently ignored**: every K8s
+   deploy ran with the JWT secret `change-me-in-production` and no Anthropic
+   key. **FIXED**: keys renamed in `templates/secret.yaml`, `values.yaml`,
+   `NOTES.txt`, `helm/README.md`; `GRANDLINE_OPENAI_API_KEY` added.
+
+2. **App boots with the default JWT secret in production** — nothing stopped
+   a non-debug deployment from signing tokens with the known default.
+   **FIXED**: `validate_production_settings()` in `app/main.py` refuses to
+   start when `GRANDLINE_DEBUG=false` and the JWT secret is the default. Dev
+   flows (`make api-dev`, docker-compose, Helm dev overlay) set
+   `GRANDLINE_DEBUG=true` and are unaffected.
+
+3. **CORS allowed all methods/headers with credentials** —
+   `allow_methods=["*"]`, `allow_headers=["*"]` combined with
+   `allow_credentials=True`. **FIXED**: restricted to the methods the API
+   serves and `Authorization`/`Content-Type` headers.
+
+4. **No security headers on the frontend** — the non-HttpOnly auth cookie is
+   a documented trade-off "mitigated by CSP", but no CSP existed. **FIXED**:
+   `next.config.mjs` now sends CSP (incl. `frame-ancestors 'none'`,
+   `object-src 'none'`), `X-Frame-Options`, `X-Content-Type-Options`,
+   `Referrer-Policy`, `Permissions-Policy` on every route.
+
+5. **Config drift: `NEXT_PUBLIC_API_URL` vs `NEXT_PUBLIC_API_BASE_URL`** —
+   compose and `.env.example` set a variable the frontend never reads, so the
+   frontend silently fell back to `localhost:8000`. **FIXED** in
+   `docker-compose.yml` + env examples (frontend reads
+   `NEXT_PUBLIC_API_BASE_URL`, see `lib/config.ts`).
+
+6. **Seed data crashed the dial router** — `scripts/seed.py` wrote
+   `fallback_chain={"order": [...]}`, which `build_router_from_config` parses
+   as a role name → `ValueError: 'order' is not a valid CrewRole` → HTTP 500
+   on any completions call for the seeded voyage. **FIXED**: seeded shape is
+   now `role -> [provider, ...]`.
+
+7. **No `.env.example` for backend/frontend** — required vars were
+   undocumented. **FIXED**: `src/backend/.env.example`,
+   `src/frontend/.env.example`, and a corrected
+   `src/infra/docker/.env.example`.
+
+8. **No error boundary in the Observation Deck** — a render error inside
+   `/app` blanked the screen. **FIXED**: `app/app/error.tsx` route-segment
+   boundary with a reset action.
+
+## Open — blocking before public release
+
+9. **No voyage-creation endpoint.** The API can list voyages, run the
+   pipeline, and stream events — but there is no `POST /voyages` ("chart a
+   course"); voyages only exist via `scripts/seed.py`. The frontend likewise
+   has no creation flow. Users cannot actually start a voyage end-to-end.
+
+10. **WS auth token exposed in URL** — `useVoyageStream.ts` connects to
+    `…/events?token=<jwt>`; the backend WS endpoint reads the token from the
+    query string. Tokens in URLs land in proxy/access logs and browser
+    history. Recommended: authenticate the WS handshake via the (already
+    set) cookie or a `Sec-WebSocket-Protocol` subprotocol, then drop the
+    query param and make the auth cookie HttpOnly (removing finding #4's
+    trade-off entirely).
+
+11. **Production deploy pipeline never exercised** — CD is gated behind
+    `DEPLOY_ENABLED` (off by default) and the chart's prod overlay
+    (`grandline.example.com`, cert-manager issuer) is placeholder. Do one
+    full staging deploy (images → Helm → ingress/TLS → smoke test) before
+    calling the chart release-ready.
+
+## Open — recommended hardening (non-blocking)
+
+12. **Dev credentials normalize weak defaults** — compose/dev-overlay use
+    `grandline:grandline` and `changeme-dev*`. Acceptable for local dev, but
+    consider `openssl rand`-generated defaults in `make setup`.
+13. **Redis runs without AUTH and Postgres/Redis ports are host-exposed in
+    compose** — fine locally; never copy to a server.
+14. **Broad `except Exception` blocks** in service-layer code (they re-raise,
+    but narrow types would aid monitoring).
+15. **Provider SDK floors not pinned** — `anthropic>=0.40.0`,
+    `openai>=1.50.0`, `langgraph>=0.4` allow breaking minor upgrades; pin
+    before cutting a release build.
+16. **Postgres StatefulSet lacks `runAsNonRoot`**; Redis has no resource
+    limits in some paths; `imagePullPolicy: IfNotPresent` with `latest` tags
+    can serve stale images — prefer digest/SHA tags (CD already passes
+    `--set image.tag=<sha>`).
+17. **`DEPLOY_ENABLED` skip is silent** — when unset, CD jobs skip without
+    explanation; emit a notice in the workflow so operators know deploys are
+    disabled.
+
+---
+
+## New in this pass: `claude_code` provider
+
+The Dial System now supports **Claude Code CLI** as a provider (see README
+"The Dial System"). It shells out to the local `claude` CLI in non-interactive
+print mode (`--print --output-format json|stream-json`), so it can run on a
+Claude subscription (`claude login` / `CLAUDE_CODE_OAUTH_TOKEN`) or an
+`ANTHROPIC_API_KEY`, with no key stored in GrandLine. Includes streaming,
+failover-compatible error mapping, rate-limit detection, timeouts, and a
+sandboxed working directory (system temp dir by default, never the backend
+cwd). Configure via `GRANDLINE_CLAUDE_CODE_*` (see `src/backend/.env.example`).
+Note: the Claude Code CLI must be installed in the backend runtime image for
+this provider to work in containers (`npm install -g @anthropic-ai/claude-code`).

--- a/src/backend/.env.example
+++ b/src/backend/.env.example
@@ -25,6 +25,12 @@ GRANDLINE_ANTHROPIC_API_KEY=
 GRANDLINE_OPENAI_API_KEY=
 GRANDLINE_OLLAMA_BASE_URL=http://localhost:11434
 
+# Provider/model every crew role gets when a voyage is charted (editable per
+# voyage via PUT /voyages/{id}/dial-config). Set provider to "claude_code"
+# to run new voyages on the Claude Code CLI by default.
+GRANDLINE_DIAL_DEFAULT_PROVIDER=anthropic
+GRANDLINE_DIAL_DEFAULT_MODEL=claude-sonnet-4-20250514
+
 # Claude Code CLI provider ("claude_code"): completions run through the
 # locally-installed `claude` CLI in print mode, so authentication comes from
 # the CLI itself (claude login / CLAUDE_CODE_OAUTH_TOKEN / ANTHROPIC_API_KEY

--- a/src/backend/.env.example
+++ b/src/backend/.env.example
@@ -1,0 +1,44 @@
+# GrandLine backend environment variables.
+# Copy to .env for local development (pydantic-settings loads it). All vars
+# use the GRANDLINE_ prefix and map to fields in app/core/config.py.
+
+# ── Core ────────────────────────────────────────────────
+# Debug relaxes the production-settings guard. MUST be false in production.
+GRANDLINE_DEBUG=true
+GRANDLINE_DATABASE_URL=postgresql+psycopg://grandline:grandline@localhost:5432/grandline
+GRANDLINE_REDIS_URL=redis://localhost:6379/0
+
+# ── Auth (JWT) ──────────────────────────────────────────
+# REQUIRED in production: with GRANDLINE_DEBUG=false the app refuses to start
+# on the insecure default. Generate one with: openssl rand -hex 32
+GRANDLINE_JWT_SECRET_KEY=change-me-in-production
+GRANDLINE_ACCESS_TOKEN_EXPIRE_MINUTES=30
+GRANDLINE_REFRESH_TOKEN_EXPIRE_MINUTES=10080
+
+# ── CORS ────────────────────────────────────────────────
+# JSON list of allowed browser origins.
+GRANDLINE_CORS_ORIGINS=["http://localhost:3000"]
+
+# ── LLM Providers (Dial System) ─────────────────────────
+# Configure only the providers you reference in dial configs.
+GRANDLINE_ANTHROPIC_API_KEY=
+GRANDLINE_OPENAI_API_KEY=
+GRANDLINE_OLLAMA_BASE_URL=http://localhost:11434
+
+# Claude Code CLI provider ("claude_code"): completions run through the
+# locally-installed `claude` CLI in print mode, so authentication comes from
+# the CLI itself (claude login / CLAUDE_CODE_OAUTH_TOKEN / ANTHROPIC_API_KEY
+# in the process env) — useful for running on a Claude subscription.
+# Install: npm install -g @anthropic-ai/claude-code
+GRANDLINE_CLAUDE_CODE_CLI_PATH=claude
+GRANDLINE_CLAUDE_CODE_TIMEOUT_SECONDS=300
+GRANDLINE_CLAUDE_CODE_MAX_TURNS=1
+# cwd for the CLI process; empty = system temp dir (never the backend cwd).
+GRANDLINE_CLAUDE_CODE_WORKSPACE=
+# Extra CLI flags appended to every invocation (shlex-split).
+GRANDLINE_CLAUDE_CODE_EXTRA_ARGS=
+
+# ── Git Integration ─────────────────────────────────────
+GRANDLINE_GITHUB_API_TOKEN=
+GRANDLINE_GIT_AUTHOR_NAME=GrandLine Crew
+GRANDLINE_GIT_AUTHOR_EMAIL=crew@grandline.dev

--- a/src/backend/app/api/v1/observation_deck.py
+++ b/src/backend/app/api/v1/observation_deck.py
@@ -178,9 +178,31 @@ async def list_crew_actions(
 
 # ----------------------- WS: /voyages/{voyage_id}/events --------------------
 
+# Clients authenticate the WS handshake via the subprotocol list:
+#   new WebSocket(url, ["grandline-bearer", <jwt>])
+# The token never appears in the URL (proxy logs, browser history). Same-origin
+# deployments may instead rely on the access_token cookie, which browsers
+# attach to the handshake automatically.
+_WS_BEARER_PROTOCOL = "grandline-bearer"
+
+
+def _ws_credentials(websocket: WebSocket) -> tuple[str | None, str | None]:
+    """Extract ``(token, subprotocol_to_echo)`` from the WS handshake.
+
+    When the client offers the bearer subprotocol we must echo it back on
+    accept() (browsers fail the connection if the server selects none), so the
+    accept subprotocol is returned alongside the token.
+    """
+    header = websocket.headers.get("sec-websocket-protocol", "")
+    offered = [p.strip() for p in header.split(",") if p.strip()]
+    if _WS_BEARER_PROTOCOL in offered:
+        token = next((p for p in offered if p != _WS_BEARER_PROTOCOL), None)
+        return token, _WS_BEARER_PROTOCOL
+    return websocket.cookies.get("access_token"), None
+
 
 async def _authenticate_ws_token(token: str, session: AsyncSession) -> User | None:
-    """Mirror `get_current_user` for the WS query-param path.
+    """Mirror `get_current_user` for the WS handshake path.
 
     Returns the user on success, ``None`` on any auth failure.
     """
@@ -223,9 +245,11 @@ async def _load_authorized_voyage(
 async def voyage_event_stream(
     websocket: WebSocket,
     voyage_id: uuid.UUID,
-    token: str = Query(...),
 ) -> None:
     """Live WS event stream (P1/P4/P10).
+
+    Auth: ``Sec-WebSocket-Protocol: grandline-bearer, <jwt>`` (preferred) or
+    the ``access_token`` cookie. The token is never read from the URL.
 
     Close-code semantics:
       - ``1008`` policy violation → auth failed (missing/invalid/expired token).
@@ -241,21 +265,22 @@ async def voyage_event_stream(
     types (e.g. ``{"type": "intervention", ...}``) later.
     """
     mushi: DenDenMushi = websocket.app.state.den_den_mushi
+    token, accept_protocol = _ws_credentials(websocket)
 
     # Auth + voyage check happen before accept(): on policy/unsupported
     # closes we *don't* upgrade — we close with the appropriate code.
     async with async_session() as session:
-        user = await _authenticate_ws_token(token, session)
+        user = await _authenticate_ws_token(token, session) if token else None
         if user is None:
             # Per RFC 6455 starlette must accept before close-with-code so
             # the close frame actually reaches the client.
-            await websocket.accept()
+            await websocket.accept(subprotocol=accept_protocol)
             await websocket.close(code=_WS_CLOSE_POLICY_VIOLATION)
             return
 
         voyage = await _load_authorized_voyage(session, voyage_id, user)
         if voyage is None:
-            await websocket.accept()
+            await websocket.accept(subprotocol=accept_protocol)
             await websocket.close(code=_WS_CLOSE_UNSUPPORTED_DATA)
             return
 
@@ -263,7 +288,7 @@ async def voyage_event_stream(
         # "already terminal" close.
         initial_terminal = voyage.status in _TERMINAL_STATUSES
 
-    await websocket.accept()
+    await websocket.accept(subprotocol=accept_protocol)
 
     stream = stream_key(voyage_id)
     group = f"sse-{uuid.uuid4().hex}"

--- a/src/backend/app/api/v1/router.py
+++ b/src/backend/app/api/v1/router.py
@@ -13,10 +13,12 @@ from app.api.v1.observation_deck import router as observation_deck_router
 from app.api.v1.pipeline import router as pipeline_router
 from app.api.v1.shipwright import router as shipwright_router
 from app.api.v1.vivre_cards import router as vivre_cards_router
+from app.api.v1.voyages import router as voyages_router
 
 v1_router = APIRouter(prefix="/api/v1")
 v1_router.include_router(health_router, tags=["health"])
 v1_router.include_router(auth_router)
+v1_router.include_router(voyages_router)
 v1_router.include_router(dial_router)
 v1_router.include_router(vivre_cards_router)
 v1_router.include_router(execution_router)

--- a/src/backend/app/api/v1/voyages.py
+++ b/src/backend/app/api/v1/voyages.py
@@ -1,0 +1,65 @@
+"""Voyage lifecycle endpoints.
+
+``POST /voyages`` — chart a course. Creates the voyage (status CHARTED) plus a
+default dial config so the pipeline and dial endpoints work immediately; the
+mapping can be customized afterwards via ``PUT /voyages/{id}/dial-config``.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from fastapi import APIRouter, Depends, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.v1.dependencies import get_current_user
+from app.core.config import settings
+from app.models import get_db
+from app.models.dial_config import DialConfig
+from app.models.enums import CrewRole, VoyageStatus
+from app.models.user import User
+from app.models.voyage import Voyage
+from app.schemas.voyage import VoyageCreate, VoyageRead
+
+router = APIRouter(prefix="/voyages", tags=["voyages"])
+
+
+def _default_dial_config(voyage_id: uuid.UUID) -> DialConfig:
+    """Every crew role dials the deployment's default provider/model."""
+    return DialConfig(
+        id=uuid.uuid4(),
+        voyage_id=voyage_id,
+        role_mapping={
+            role.value: {
+                "provider": settings.dial_default_provider,
+                "model": settings.dial_default_model,
+            }
+            for role in CrewRole
+        },
+        fallback_chain=None,
+    )
+
+
+@router.post("", response_model=VoyageRead, status_code=status.HTTP_201_CREATED)
+async def create_voyage(
+    body: VoyageCreate,
+    session: AsyncSession = Depends(get_db),
+    user: User = Depends(get_current_user),
+) -> Voyage:
+    voyage = Voyage(
+        id=uuid.uuid4(),
+        user_id=user.id,
+        title=body.title,
+        description=body.description,
+        target_repo=body.target_repo,
+        status=VoyageStatus.CHARTED.value,
+        phase_status={},
+    )
+    session.add(voyage)
+    await session.flush()
+
+    session.add(_default_dial_config(voyage.id))
+
+    await session.commit()
+    await session.refresh(voyage)
+    return voyage

--- a/src/backend/app/core/config.py
+++ b/src/backend/app/core/config.py
@@ -23,6 +23,15 @@ class Settings(BaseSettings):
     openai_api_key: str = ""
     ollama_base_url: str = "http://localhost:11434"
 
+    # Claude Code CLI provider (provider name: "claude_code").
+    # Auth comes from the CLI itself (claude login / CLAUDE_CODE_OAUTH_TOKEN /
+    # ANTHROPIC_API_KEY in the process environment) — no key stored here.
+    claude_code_cli_path: str = "claude"
+    claude_code_timeout_seconds: int = 300
+    claude_code_max_turns: int = 1
+    claude_code_workspace: str = ""  # cwd for the CLI; empty = system temp dir
+    claude_code_extra_args: str = ""  # extra CLI flags, shlex-split
+
     # Vivre Card (State Checkpointing)
     vivre_card_checkpoint_interval_seconds: int = 300  # 5 minutes
     vivre_card_cleanup_keep_last_n: int = 10

--- a/src/backend/app/core/config.py
+++ b/src/backend/app/core/config.py
@@ -23,6 +23,11 @@ class Settings(BaseSettings):
     openai_api_key: str = ""
     ollama_base_url: str = "http://localhost:11434"
 
+    # Default provider/model for newly charted voyages (every crew role).
+    # Editable per voyage afterwards via PUT /voyages/{id}/dial-config.
+    dial_default_provider: str = "anthropic"
+    dial_default_model: str = "claude-sonnet-4-20250514"
+
     # Claude Code CLI provider (provider name: "claude_code").
     # Auth comes from the CLI itself (claude login / CLAUDE_CODE_OAUTH_TOKEN /
     # ANTHROPIC_API_KEY in the process environment) — no key stored here.

--- a/src/backend/app/dial_system/adapters/claude_code.py
+++ b/src/backend/app/dial_system/adapters/claude_code.py
@@ -1,0 +1,262 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import shlex
+import tempfile
+from collections.abc import AsyncIterator
+from typing import Any
+
+from app.dial_system.adapters.base import ProviderAdapter, ProviderError
+from app.schemas.dial_system import (
+    CompletionRequest,
+    CompletionResult,
+    RateLimitStatus,
+    TokenUsage,
+)
+
+logger = logging.getLogger(__name__)
+
+PROVIDER_NAME = "claude_code"
+
+# Tail of stderr/output included in ProviderError messages.
+_ERROR_TAIL_CHARS = 500
+
+
+def _build_prompt(messages: list[dict[str, str]]) -> tuple[str, str | None]:
+    """Flatten chat messages into a single CLI prompt + optional system prompt.
+
+    The Claude Code CLI takes one prompt string (via stdin in print mode), so
+    multi-turn history is rendered as a Human/Assistant transcript. System
+    messages are pulled out and passed via --append-system-prompt.
+    """
+    system_parts = [m["content"] for m in messages if m.get("role") == "system"]
+    convo = [m for m in messages if m.get("role") != "system"]
+
+    if len(convo) == 1 and convo[0].get("role") == "user":
+        prompt = convo[0]["content"]
+    else:
+        lines = []
+        for m in convo:
+            label = "Assistant" if m.get("role") == "assistant" else "Human"
+            lines.append(f"{label}: {m['content']}")
+        prompt = "\n\n".join(lines)
+
+    system = "\n\n".join(system_parts) if system_parts else None
+    return prompt, system
+
+
+class ClaudeCodeAdapter(ProviderAdapter):
+    """Adapter that runs completions through the Claude Code CLI (`claude -p`).
+
+    Uses the CLI's non-interactive print mode, so it works with a Claude
+    subscription (`claude` login / CLAUDE_CODE_OAUTH_TOKEN) as well as an
+    ANTHROPIC_API_KEY — no key needs to be configured in GrandLine itself.
+
+    Notes:
+    - `temperature` is not supported by the CLI and is ignored.
+    - `max_tokens` is forwarded via CLAUDE_CODE_MAX_OUTPUT_TOKENS.
+    - Runs with --max-turns (default 1) so the gateway behaves as a text
+      completion endpoint rather than an autonomous agent.
+    """
+
+    def __init__(
+        self,
+        model: str,
+        cli_path: str = "claude",
+        timeout_seconds: int = 300,
+        max_turns: int = 1,
+        workspace: str | None = None,
+        extra_args: str = "",
+    ) -> None:
+        self._model = model
+        self._cli_path = cli_path
+        self._timeout_seconds = timeout_seconds
+        self._max_turns = max_turns
+        # Never run in the backend's own cwd: the CLI's read-only file tools
+        # would otherwise be able to see backend source and config.
+        self._workspace = workspace or tempfile.gettempdir()
+        self._extra_args = shlex.split(extra_args) if extra_args else []
+        self._rate_limited = False
+
+    def _command(self, output_format: str, system: str | None) -> list[str]:
+        cmd = [
+            self._cli_path,
+            "--print",
+            "--output-format",
+            output_format,
+            "--model",
+            self._model,
+            "--max-turns",
+            str(self._max_turns),
+        ]
+        if output_format == "stream-json":
+            # The CLI requires --verbose for stream-json in print mode.
+            cmd.append("--verbose")
+        if system:
+            cmd.extend(["--append-system-prompt", system])
+        cmd.extend(self._extra_args)
+        return cmd
+
+    def _env(self, request: CompletionRequest) -> dict[str, str]:
+        env = dict(os.environ)
+        env["CLAUDE_CODE_MAX_OUTPUT_TOKENS"] = str(request.max_tokens)
+        # Server context: no autoupdater or other non-essential traffic.
+        env["CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC"] = "1"
+        return env
+
+    def _note_rate_limit(self, text: str) -> None:
+        lowered = text.lower()
+        if "rate limit" in lowered or "429" in lowered:
+            self._rate_limited = True
+
+    async def _spawn(
+        self, output_format: str, request: CompletionRequest
+    ) -> tuple[asyncio.subprocess.Process, bytes]:
+        prompt, system = _build_prompt(request.messages)
+        cmd = self._command(output_format, system)
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *cmd,
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                env=self._env(request),
+                cwd=self._workspace,
+            )
+        except FileNotFoundError as exc:
+            raise ProviderError(
+                f"Claude Code CLI not found at {self._cli_path!r}. "
+                "Install it with: npm install -g @anthropic-ai/claude-code"
+            ) from exc
+        return proc, prompt.encode()
+
+    async def complete(self, request: CompletionRequest) -> CompletionResult:
+        proc, prompt = await self._spawn("json", request)
+        try:
+            stdout, stderr = await asyncio.wait_for(
+                proc.communicate(prompt), timeout=self._timeout_seconds
+            )
+        except TimeoutError as exc:
+            proc.kill()
+            await proc.wait()
+            raise ProviderError(
+                f"Claude Code CLI timed out after {self._timeout_seconds}s"
+            ) from exc
+
+        err_text = stderr.decode(errors="replace")
+        if proc.returncode != 0:
+            self._note_rate_limit(err_text)
+            raise ProviderError(
+                f"Claude Code CLI exited with code {proc.returncode}: "
+                f"{err_text[-_ERROR_TAIL_CHARS:]}"
+            )
+
+        try:
+            data: dict[str, Any] = json.loads(stdout.decode(errors="replace"))
+        except json.JSONDecodeError as exc:
+            raise ProviderError(f"Claude Code CLI returned invalid JSON: {exc}") from exc
+
+        result_text = data.get("result") or ""
+        if data.get("is_error") or data.get("subtype") != "success":
+            self._note_rate_limit(f"{err_text} {result_text}")
+            raise ProviderError(
+                f"Claude Code CLI error ({data.get('subtype', 'unknown')}): "
+                f"{str(result_text)[-_ERROR_TAIL_CHARS:]}"
+            )
+
+        usage: dict[str, Any] = data.get("usage") or {}
+        # Cached tokens are billed separately but are still part of the prompt.
+        prompt_tokens = (
+            int(usage.get("input_tokens", 0))
+            + int(usage.get("cache_creation_input_tokens", 0))
+            + int(usage.get("cache_read_input_tokens", 0))
+        )
+        completion_tokens = int(usage.get("output_tokens", 0))
+        # modelUsage (newer CLIs) is keyed by the resolved model ID, which is
+        # more precise than the alias we were configured with (e.g. "sonnet").
+        model = next(iter(data.get("modelUsage") or {}), self._model)
+
+        return CompletionResult(
+            content=result_text,
+            provider=PROVIDER_NAME,
+            model=model,
+            usage=TokenUsage(
+                prompt_tokens=prompt_tokens,
+                completion_tokens=completion_tokens,
+                total_tokens=prompt_tokens + completion_tokens,
+            ),
+        )
+
+    async def stream(self, request: CompletionRequest) -> AsyncIterator[str]:
+        proc, prompt = await self._spawn("stream-json", request)
+        assert proc.stdin is not None and proc.stdout is not None
+
+        async def _run() -> AsyncIterator[str]:
+            assert proc.stdin is not None and proc.stdout is not None
+            proc.stdin.write(prompt)
+            await proc.stdin.drain()
+            proc.stdin.close()
+
+            yielded = False
+            async for raw_line in proc.stdout:
+                line = raw_line.decode(errors="replace").strip()
+                if not line:
+                    continue
+                try:
+                    event: dict[str, Any] = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+
+                if event.get("type") == "assistant":
+                    content = (event.get("message") or {}).get("content") or []
+                    for block in content:
+                        if isinstance(block, dict) and block.get("type") == "text":
+                            text = block.get("text") or ""
+                            if text:
+                                yielded = True
+                                yield text
+                elif event.get("type") == "result":
+                    result_text = str(event.get("result") or "")
+                    if event.get("is_error"):
+                        self._note_rate_limit(result_text)
+                        raise ProviderError(
+                            f"Claude Code CLI error ({event.get('subtype', 'unknown')}): "
+                            f"{result_text[-_ERROR_TAIL_CHARS:]}"
+                        )
+                    # Older CLIs may emit the result text only on this event.
+                    if not yielded and result_text:
+                        yield result_text
+                    break
+
+        try:
+            gen = _run()
+            while True:
+                try:
+                    token = await asyncio.wait_for(gen.__anext__(), timeout=self._timeout_seconds)
+                except StopAsyncIteration:
+                    break
+                yield token
+
+            await asyncio.wait_for(proc.wait(), timeout=self._timeout_seconds)
+            if proc.returncode != 0:
+                stderr = b"" if proc.stderr is None else await proc.stderr.read()
+                err_text = stderr.decode(errors="replace")
+                self._note_rate_limit(err_text)
+                raise ProviderError(
+                    f"Claude Code CLI exited with code {proc.returncode}: "
+                    f"{err_text[-_ERROR_TAIL_CHARS:]}"
+                )
+        except TimeoutError as exc:
+            raise ProviderError(
+                f"Claude Code CLI timed out after {self._timeout_seconds}s"
+            ) from exc
+        finally:
+            if proc.returncode is None:
+                proc.kill()
+                await proc.wait()
+
+    def check_rate_limit(self) -> RateLimitStatus:
+        return RateLimitStatus(is_limited=self._rate_limited)

--- a/src/backend/app/dial_system/factory.py
+++ b/src/backend/app/dial_system/factory.py
@@ -10,6 +10,7 @@ from app.core.config import Settings
 from app.den_den_mushi.mushi import DenDenMushi
 from app.dial_system.adapters.anthropic import AnthropicAdapter
 from app.dial_system.adapters.base import ProviderAdapter
+from app.dial_system.adapters.claude_code import ClaudeCodeAdapter
 from app.dial_system.adapters.ollama import OllamaAdapter
 from app.dial_system.adapters.openai import OpenAIAdapter
 from app.dial_system.rate_limiter import RateLimiter
@@ -30,6 +31,15 @@ def create_adapter(provider: str, model: str, settings: Settings) -> ProviderAda
             client=httpx.AsyncClient(),
             model=model,
             base_url=settings.ollama_base_url,
+        )
+    elif provider in ("claude_code", "claude-code"):
+        return ClaudeCodeAdapter(
+            model=model,
+            cli_path=settings.claude_code_cli_path,
+            timeout_seconds=settings.claude_code_timeout_seconds,
+            max_turns=settings.claude_code_max_turns,
+            workspace=settings.claude_code_workspace or None,
+            extra_args=settings.claude_code_extra_args,
         )
     else:
         raise ValueError(f"Unknown provider: {provider!r}")

--- a/src/backend/app/dial_system/router.py
+++ b/src/backend/app/dial_system/router.py
@@ -46,6 +46,8 @@ class DialSystemRouter:
     def _get_provider_name(self, adapter: ProviderAdapter) -> str:
         """Extract provider name from adapter class."""
         cls_name = type(adapter).__name__.lower()
+        if "claudecode" in cls_name:
+            return "claude_code"
         if "anthropic" in cls_name:
             return "anthropic"
         if "openai" in cls_name:

--- a/src/backend/app/main.py
+++ b/src/backend/app/main.py
@@ -21,9 +21,36 @@ logger = logging.getLogger(__name__)
 
 _PIPELINE_SHUTDOWN_TIMEOUT_S = 5.0
 
+# Methods/headers the API actually uses; anything else is rejected by CORS
+# preflight instead of being blanket-allowed.
+_CORS_ALLOW_METHODS = ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"]
+_CORS_ALLOW_HEADERS = ["Authorization", "Content-Type"]
+
+_DEFAULT_JWT_SECRET = "change-me-in-production"
+
+
+def validate_production_settings() -> None:
+    """Refuse to boot with insecure defaults outside debug mode.
+
+    Dev flows (docker-compose, `make api-dev`) set GRANDLINE_DEBUG=true and
+    are unaffected. Production (debug=false) must configure a real secret.
+    """
+    if settings.debug:
+        return
+    if settings.jwt_secret_key == _DEFAULT_JWT_SECRET:
+        raise RuntimeError(
+            "GRANDLINE_JWT_SECRET_KEY is still the insecure default "
+            f"({_DEFAULT_JWT_SECRET!r}). Set a strong secret, or set "
+            "GRANDLINE_DEBUG=true for local development."
+        )
+
 
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+    # Runs at serve time (uvicorn), not at import time, so tests can import
+    # the app object without production-grade settings.
+    validate_production_settings()
+
     pool = ConnectionPool.from_url(settings.redis_url, decode_responses=True)
     app.state.redis_pool = pool
     app.state.den_den_mushi = DenDenMushi(Redis(connection_pool=pool))
@@ -79,8 +106,8 @@ def create_app() -> FastAPI:
         CORSMiddleware,
         allow_origins=settings.cors_origins,
         allow_credentials=True,
-        allow_methods=["*"],
-        allow_headers=["*"],
+        allow_methods=_CORS_ALLOW_METHODS,
+        allow_headers=_CORS_ALLOW_HEADERS,
     )
     app.add_middleware(DefaultDenyMiddleware)
 

--- a/src/backend/app/schemas/voyage.py
+++ b/src/backend/app/schemas/voyage.py
@@ -2,15 +2,17 @@ import uuid
 from datetime import datetime
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 from app.models.enums import VoyageStatus
 
 
 class VoyageCreate(BaseModel):
-    title: str
-    description: str | None = None
-    target_repo: str | None = None
+    model_config = ConfigDict(extra="forbid")
+
+    title: str = Field(min_length=1, max_length=255)
+    description: str | None = Field(default=None, max_length=5000)
+    target_repo: str | None = Field(default=None, max_length=500)
 
 
 class VoyageRead(BaseModel):

--- a/src/backend/scripts/seed.py
+++ b/src/backend/scripts/seed.py
@@ -115,7 +115,11 @@ async def seed() -> None:
         ]
         session.add_all(actions)
 
-        # Create dial config (LLM gateway configuration)
+        # Create dial config (LLM gateway configuration).
+        # Providers: "anthropic", "openai", "ollama", or "claude_code" (runs
+        # the local Claude Code CLI, e.g. on a Claude subscription).
+        # fallback_chain maps role -> ordered list of fallback provider names,
+        # matching what dial_system.factory.build_router_from_config expects.
         dial_config = DialConfig(
             id=uuid.uuid4(),
             voyage_id=voyage_id,
@@ -127,8 +131,11 @@ async def seed() -> None:
                 "helmsman": {"provider": "anthropic", "model": "claude-sonnet-4-20250514"},
             },
             fallback_chain={
-                "order": ["anthropic", "openai"],
-                "openai": {"model": "gpt-4o"},
+                "captain": ["openai"],
+                "navigator": ["openai"],
+                "shipwright": ["openai"],
+                "doctor": ["openai"],
+                "helmsman": ["openai"],
             },
         )
         session.add(dial_config)

--- a/src/backend/tests/test_dial_claude_code_adapter.py
+++ b/src/backend/tests/test_dial_claude_code_adapter.py
@@ -1,0 +1,339 @@
+"""Tests for the Claude Code CLI adapter with a mocked subprocess."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.dial_system.adapters.base import ProviderError
+from app.dial_system.adapters.claude_code import ClaudeCodeAdapter, _build_prompt
+from app.models.enums import CrewRole
+from app.schemas.dial_system import CompletionRequest, CompletionResult
+
+
+def _make_request(messages: list[dict[str, str]] | None = None) -> CompletionRequest:
+    return CompletionRequest(
+        messages=messages or [{"role": "user", "content": "Hello"}],
+        role=CrewRole.CAPTAIN,
+        max_tokens=100,
+        temperature=0.7,
+    )
+
+
+def _result_json(**overrides: Any) -> bytes:
+    data: dict[str, Any] = {
+        "type": "result",
+        "subtype": "success",
+        "is_error": False,
+        "result": "Hello from Claude Code!",
+        "session_id": "abc",
+        "usage": {
+            "input_tokens": 10,
+            "output_tokens": 5,
+            "cache_creation_input_tokens": 2,
+            "cache_read_input_tokens": 3,
+        },
+    }
+    data.update(overrides)
+    return json.dumps(data).encode()
+
+
+class _FakeStdout:
+    def __init__(self, lines: list[bytes]) -> None:
+        self._lines = lines
+
+    def __aiter__(self):
+        async def _gen():
+            for line in self._lines:
+                yield line
+
+        return _gen()
+
+
+class _FakeProcess:
+    def __init__(
+        self,
+        stdout: bytes = b"",
+        stderr: bytes = b"",
+        returncode: int = 0,
+        stream_lines: list[bytes] | None = None,
+        hang: bool = False,
+    ) -> None:
+        self.returncode = returncode
+        self._stdout = stdout
+        self._stderr = stderr
+        self._hang = hang
+        self.killed = False
+        self.communicate_input: bytes | None = None
+
+        self.stdin = MagicMock()
+        self.stdin.drain = AsyncMock()
+        self.stdout = _FakeStdout(stream_lines or [])
+        self.stderr = MagicMock()
+        self.stderr.read = AsyncMock(return_value=stderr)
+
+    async def communicate(self, input: bytes | None = None) -> tuple[bytes, bytes]:
+        if self._hang:
+            await asyncio.sleep(60)
+        self.communicate_input = input
+        return self._stdout, self._stderr
+
+    def kill(self) -> None:
+        self.killed = True
+
+    async def wait(self) -> int:
+        return self.returncode
+
+
+def _patch_subprocess(monkeypatch: pytest.MonkeyPatch, proc: _FakeProcess) -> dict[str, Any]:
+    """Patch create_subprocess_exec; returns a dict capturing the call."""
+    captured: dict[str, Any] = {}
+
+    async def fake_exec(*cmd: str, **kwargs: Any) -> _FakeProcess:
+        captured["cmd"] = list(cmd)
+        captured["kwargs"] = kwargs
+        return proc
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+    return captured
+
+
+class TestBuildPrompt:
+    def test_single_user_message_passes_through(self) -> None:
+        prompt, system = _build_prompt([{"role": "user", "content": "Hello"}])
+        assert prompt == "Hello"
+        assert system is None
+
+    def test_system_messages_extracted(self) -> None:
+        prompt, system = _build_prompt(
+            [
+                {"role": "system", "content": "Be brief."},
+                {"role": "user", "content": "Hello"},
+            ]
+        )
+        assert prompt == "Hello"
+        assert system == "Be brief."
+
+    def test_multi_turn_rendered_as_transcript(self) -> None:
+        prompt, _ = _build_prompt(
+            [
+                {"role": "user", "content": "Hi"},
+                {"role": "assistant", "content": "Hello!"},
+                {"role": "user", "content": "How are you?"},
+            ]
+        )
+        assert prompt == "Human: Hi\n\nAssistant: Hello!\n\nHuman: How are you?"
+
+
+class TestClaudeCodeAdapter:
+    @pytest.mark.asyncio
+    async def test_complete_returns_completion_result(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        proc = _FakeProcess(stdout=_result_json())
+        _patch_subprocess(monkeypatch, proc)
+
+        adapter = ClaudeCodeAdapter(model="sonnet")
+        result = await adapter.complete(_make_request())
+
+        assert isinstance(result, CompletionResult)
+        assert result.content == "Hello from Claude Code!"
+        assert result.provider == "claude_code"
+        assert result.model == "sonnet"
+        # prompt tokens include cache creation + cache read tokens
+        assert result.usage.prompt_tokens == 15
+        assert result.usage.completion_tokens == 5
+        assert result.usage.total_tokens == 20
+        assert proc.communicate_input == b"Hello"
+
+    @pytest.mark.asyncio
+    async def test_complete_builds_expected_command(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        proc = _FakeProcess(stdout=_result_json())
+        captured = _patch_subprocess(monkeypatch, proc)
+
+        adapter = ClaudeCodeAdapter(
+            model="claude-sonnet-4-20250514",
+            cli_path="/usr/local/bin/claude",
+            max_turns=2,
+            extra_args="--permission-mode plan",
+        )
+        await adapter.complete(
+            _make_request(
+                [
+                    {"role": "system", "content": "Be brief."},
+                    {"role": "user", "content": "Hello"},
+                ]
+            )
+        )
+
+        cmd = captured["cmd"]
+        assert cmd[0] == "/usr/local/bin/claude"
+        assert "--print" in cmd
+        assert cmd[cmd.index("--output-format") + 1] == "json"
+        assert cmd[cmd.index("--model") + 1] == "claude-sonnet-4-20250514"
+        assert cmd[cmd.index("--max-turns") + 1] == "2"
+        assert cmd[cmd.index("--append-system-prompt") + 1] == "Be brief."
+        assert cmd[-2:] == ["--permission-mode", "plan"]
+
+        env = captured["kwargs"]["env"]
+        assert env["CLAUDE_CODE_MAX_OUTPUT_TOKENS"] == "100"
+
+    @pytest.mark.asyncio
+    async def test_complete_resolves_model_from_model_usage(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        proc = _FakeProcess(
+            stdout=_result_json(modelUsage={"claude-sonnet-4-20250514": {"inputTokens": 10}})
+        )
+        _patch_subprocess(monkeypatch, proc)
+
+        adapter = ClaudeCodeAdapter(model="sonnet")
+        result = await adapter.complete(_make_request())
+
+        assert result.model == "claude-sonnet-4-20250514"
+
+    @pytest.mark.asyncio
+    async def test_complete_raises_provider_error_on_nonzero_exit(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        proc = _FakeProcess(stderr=b"boom", returncode=1)
+        _patch_subprocess(monkeypatch, proc)
+
+        adapter = ClaudeCodeAdapter(model="sonnet")
+        with pytest.raises(ProviderError, match="exited with code 1"):
+            await adapter.complete(_make_request())
+
+    @pytest.mark.asyncio
+    async def test_complete_marks_rate_limited_from_stderr(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        proc = _FakeProcess(stderr=b"API rate limit exceeded", returncode=1)
+        _patch_subprocess(monkeypatch, proc)
+
+        adapter = ClaudeCodeAdapter(model="sonnet")
+        with pytest.raises(ProviderError):
+            await adapter.complete(_make_request())
+
+        assert adapter.check_rate_limit().is_limited is True
+
+    @pytest.mark.asyncio
+    async def test_complete_raises_provider_error_on_error_result(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        proc = _FakeProcess(
+            stdout=_result_json(subtype="error_max_turns", is_error=True, result="")
+        )
+        _patch_subprocess(monkeypatch, proc)
+
+        adapter = ClaudeCodeAdapter(model="sonnet")
+        with pytest.raises(ProviderError, match="error_max_turns"):
+            await adapter.complete(_make_request())
+
+    @pytest.mark.asyncio
+    async def test_complete_raises_provider_error_on_invalid_json(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        proc = _FakeProcess(stdout=b"not json")
+        _patch_subprocess(monkeypatch, proc)
+
+        adapter = ClaudeCodeAdapter(model="sonnet")
+        with pytest.raises(ProviderError, match="invalid JSON"):
+            await adapter.complete(_make_request())
+
+    @pytest.mark.asyncio
+    async def test_complete_raises_provider_error_when_cli_missing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        async def fake_exec(*cmd: str, **kwargs: Any) -> _FakeProcess:
+            raise FileNotFoundError(cmd[0])
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+
+        adapter = ClaudeCodeAdapter(model="sonnet", cli_path="claude-missing")
+        with pytest.raises(ProviderError, match="not found"):
+            await adapter.complete(_make_request())
+
+    @pytest.mark.asyncio
+    async def test_complete_times_out(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        proc = _FakeProcess(hang=True)
+        _patch_subprocess(monkeypatch, proc)
+
+        adapter = ClaudeCodeAdapter(model="sonnet", timeout_seconds=0)
+        with pytest.raises(ProviderError, match="timed out"):
+            await adapter.complete(_make_request())
+
+        assert proc.killed is True
+
+    @pytest.mark.asyncio
+    async def test_stream_yields_text_from_assistant_events(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        lines = [
+            json.dumps({"type": "system", "subtype": "init"}).encode(),
+            json.dumps(
+                {
+                    "type": "assistant",
+                    "message": {"content": [{"type": "text", "text": "Hello"}]},
+                }
+            ).encode(),
+            json.dumps(
+                {
+                    "type": "assistant",
+                    "message": {"content": [{"type": "text", "text": " world"}]},
+                }
+            ).encode(),
+            json.dumps(
+                {"type": "result", "subtype": "success", "is_error": False, "result": "ignored"}
+            ).encode(),
+        ]
+        proc = _FakeProcess(stream_lines=lines)
+        _patch_subprocess(monkeypatch, proc)
+
+        adapter = ClaudeCodeAdapter(model="sonnet")
+        tokens = [t async for t in adapter.stream(_make_request())]
+
+        assert tokens == ["Hello", " world"]
+
+    @pytest.mark.asyncio
+    async def test_stream_falls_back_to_result_text(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        lines = [
+            json.dumps(
+                {"type": "result", "subtype": "success", "is_error": False, "result": "Hi!"}
+            ).encode(),
+        ]
+        proc = _FakeProcess(stream_lines=lines)
+        _patch_subprocess(monkeypatch, proc)
+
+        adapter = ClaudeCodeAdapter(model="sonnet")
+        tokens = [t async for t in adapter.stream(_make_request())]
+
+        assert tokens == ["Hi!"]
+
+    @pytest.mark.asyncio
+    async def test_stream_raises_provider_error_on_error_result(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        lines = [
+            json.dumps(
+                {
+                    "type": "result",
+                    "subtype": "error_during_execution",
+                    "is_error": True,
+                    "result": "something broke",
+                }
+            ).encode(),
+        ]
+        proc = _FakeProcess(stream_lines=lines)
+        _patch_subprocess(monkeypatch, proc)
+
+        adapter = ClaudeCodeAdapter(model="sonnet")
+        with pytest.raises(ProviderError, match="error_during_execution"):
+            _ = [t async for t in adapter.stream(_make_request())]
+
+    def test_check_rate_limit_not_limited_by_default(self) -> None:
+        adapter = ClaudeCodeAdapter(model="sonnet")
+        assert adapter.check_rate_limit().is_limited is False

--- a/src/backend/tests/test_dial_factory.py
+++ b/src/backend/tests/test_dial_factory.py
@@ -9,6 +9,7 @@ import pytest
 
 from app.core.config import Settings
 from app.dial_system.adapters.anthropic import AnthropicAdapter
+from app.dial_system.adapters.claude_code import ClaudeCodeAdapter
 from app.dial_system.adapters.ollama import OllamaAdapter
 from app.dial_system.adapters.openai import OpenAIAdapter
 from app.dial_system.factory import build_router_from_config, create_adapter
@@ -37,6 +38,14 @@ class TestCreateAdapter:
     def test_creates_ollama_adapter(self) -> None:
         adapter = create_adapter("ollama", "llama3", _make_settings())
         assert isinstance(adapter, OllamaAdapter)
+
+    def test_creates_claude_code_adapter(self) -> None:
+        adapter = create_adapter("claude_code", "sonnet", _make_settings())
+        assert isinstance(adapter, ClaudeCodeAdapter)
+
+    def test_creates_claude_code_adapter_with_dash_alias(self) -> None:
+        adapter = create_adapter("claude-code", "sonnet", _make_settings())
+        assert isinstance(adapter, ClaudeCodeAdapter)
 
     def test_raises_for_unknown_provider(self) -> None:
         with pytest.raises(ValueError, match="Unknown provider"):

--- a/src/backend/tests/test_observation_deck_ws.py
+++ b/src/backend/tests/test_observation_deck_ws.py
@@ -15,7 +15,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from starlette.websockets import WebSocketState
 
-from app.api.v1.observation_deck import voyage_event_stream
+from app.api.v1.observation_deck import _ws_credentials, voyage_event_stream
 from app.den_den_mushi.events import PipelineCompletedEvent, PipelineStartedEvent
 from app.models.enums import CrewRole, VoyageStatus
 from app.models.voyage import Voyage
@@ -46,13 +46,28 @@ def _mock_voyage(status_: str = VoyageStatus.PDD.value) -> Voyage:
     return v
 
 
-def _mock_websocket(initial_state: WebSocketState = WebSocketState.CONNECTING) -> MagicMock:
-    """A WebSocket double that records accept/close/send_json calls."""
+def _mock_websocket(
+    initial_state: WebSocketState = WebSocketState.CONNECTING,
+    *,
+    token: str | None = TOKEN,
+    cookies: dict[str, str] | None = None,
+) -> MagicMock:
+    """A WebSocket double that records accept/close/send_json calls.
+
+    By default the handshake carries the bearer subprotocol
+    (``Sec-WebSocket-Protocol: grandline-bearer, <token>``); pass
+    ``token=None`` for a bare handshake and ``cookies=`` for cookie auth.
+    """
     ws = MagicMock()
     ws.client_state = initial_state
+    ws.headers = (
+        {"sec-websocket-protocol": f"grandline-bearer, {token}"} if token is not None else {}
+    )
+    ws.cookies = cookies or {}
 
-    async def _accept() -> None:
+    async def _accept(subprotocol: str | None = None) -> None:
         ws.client_state = WebSocketState.CONNECTED
+        ws._accepted_subprotocol = subprotocol
 
     async def _close(code: int = 1000, reason: str | None = None) -> None:
         ws.client_state = WebSocketState.DISCONNECTED
@@ -63,6 +78,7 @@ def _mock_websocket(initial_state: WebSocketState = WebSocketState.CONNECTING) -
 
     ws._sent_frames = []
     ws._closed_with = None
+    ws._accepted_subprotocol = None
     ws.accept = AsyncMock(side_effect=_accept)
     ws.close = AsyncMock(side_effect=_close)
     ws.send_json = AsyncMock(side_effect=_send_json)
@@ -143,19 +159,88 @@ def _build_mushi(read_batches: list[list[tuple[str, Any]]]) -> AsyncMock:
 # ---------------------------------------------------------------------------
 
 
+class TestWsCredentials:
+    def test_extracts_token_from_bearer_subprotocol(self) -> None:
+        ws = _mock_websocket(token="jwt-abc")
+        token, accept_protocol = _ws_credentials(ws)
+        assert token == "jwt-abc"
+        assert accept_protocol == "grandline-bearer"
+
+    def test_falls_back_to_cookie(self) -> None:
+        ws = _mock_websocket(token=None, cookies={"access_token": "jwt-cookie"})
+        token, accept_protocol = _ws_credentials(ws)
+        assert token == "jwt-cookie"
+        assert accept_protocol is None
+
+    def test_no_credentials(self) -> None:
+        ws = _mock_websocket(token=None)
+        token, accept_protocol = _ws_credentials(ws)
+        assert token is None
+        assert accept_protocol is None
+
+
 class TestWsAuth:
     @pytest.mark.asyncio
     async def test_invalid_token_closes_with_1008(self, monkeypatch: pytest.MonkeyPatch) -> None:
         # No user returned for token → auth fails.
         _patch_session_factory(monkeypatch, handshake_user=None, handshake_voyage=None)
-        ws = _mock_websocket()
+        ws = _mock_websocket(token="bad-token")
         ws.app.state.den_den_mushi = AsyncMock()
 
-        await voyage_event_stream(ws, VOYAGE_ID, token="bad-token")
+        await voyage_event_stream(ws, VOYAGE_ID)
 
         ws.accept.assert_awaited_once()
         ws.close.assert_awaited_once()
         assert ws._closed_with[0] == _POLICY
+        # The offered bearer subprotocol is echoed even on the failure close
+        # so the browser surfaces our close code instead of failing the
+        # handshake.
+        assert ws._accepted_subprotocol == "grandline-bearer"
+
+    @pytest.mark.asyncio
+    async def test_missing_credentials_close_with_1008(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # No subprotocol, no cookie → 1008 without hitting the authenticator.
+        auth = AsyncMock(return_value=_mock_user())
+        monkeypatch.setattr("app.api.v1.observation_deck._authenticate_ws_token", auth)
+        ws = _mock_websocket(token=None)
+        ws.app.state.den_den_mushi = AsyncMock()
+
+        await voyage_event_stream(ws, VOYAGE_ID)
+
+        auth.assert_not_awaited()
+        assert ws._closed_with[0] == _POLICY
+
+    @pytest.mark.asyncio
+    async def test_token_in_query_string_is_ignored(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Regression guard: handshake credentials come from the subprotocol or
+        # cookie only — a ?token= query param must no longer authenticate.
+        auth = AsyncMock(return_value=_mock_user())
+        monkeypatch.setattr("app.api.v1.observation_deck._authenticate_ws_token", auth)
+        ws = _mock_websocket(token=None)
+        ws.query_params = {"token": TOKEN}
+        ws.app.state.den_den_mushi = AsyncMock()
+
+        await voyage_event_stream(ws, VOYAGE_ID)
+
+        auth.assert_not_awaited()
+        assert ws._closed_with[0] == _POLICY
+
+    @pytest.mark.asyncio
+    async def test_cookie_auth_accepts_without_subprotocol(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        terminal = _mock_voyage(status_=VoyageStatus.COMPLETED.value)
+        _patch_session_factory(monkeypatch, handshake_user=_mock_user(), handshake_voyage=terminal)
+        mushi = _build_mushi([[]])
+        ws = _mock_websocket(token=None, cookies={"access_token": TOKEN})
+        ws.app.state.den_den_mushi = mushi
+
+        await voyage_event_stream(ws, VOYAGE_ID)
+
+        assert ws._accepted_subprotocol is None
+        assert ws._closed_with[0] == _TERMINAL_NORMAL
 
     @pytest.mark.asyncio
     async def test_voyage_not_found_closes_with_1003(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -163,7 +248,7 @@ class TestWsAuth:
         ws = _mock_websocket()
         ws.app.state.den_den_mushi = AsyncMock()
 
-        await voyage_event_stream(ws, VOYAGE_ID, token=TOKEN)
+        await voyage_event_stream(ws, VOYAGE_ID)
 
         ws.close.assert_awaited_once()
         assert ws._closed_with[0] == _UNSUPPORTED
@@ -193,7 +278,7 @@ class TestWsForwarding:
         ws = _mock_websocket()
         ws.app.state.den_den_mushi = mushi
 
-        await voyage_event_stream(ws, VOYAGE_ID, token=TOKEN)
+        await voyage_event_stream(ws, VOYAGE_ID)
 
         # One forwarded event in the canonical envelope shape.
         assert len(ws._sent_frames) == 1
@@ -221,7 +306,7 @@ class TestWsForwarding:
         ws = _mock_websocket()
         ws.app.state.den_den_mushi = mushi
 
-        await voyage_event_stream(ws, VOYAGE_ID, token=TOKEN)
+        await voyage_event_stream(ws, VOYAGE_ID)
 
         assert len(ws._sent_frames) == 1
         assert ws._closed_with[0] == _TERMINAL_NORMAL
@@ -242,7 +327,7 @@ class TestWsForwarding:
         ws = _mock_websocket()
         ws.app.state.den_den_mushi = mushi
 
-        await voyage_event_stream(ws, VOYAGE_ID, token=TOKEN)
+        await voyage_event_stream(ws, VOYAGE_ID)
 
         frame = ws._sent_frames[0]
         # Forward-compatible envelope: {"type": "event", "payload": {...}}
@@ -264,7 +349,7 @@ class TestWsForwarding:
 
         # Should not raise — the unexpected error is logged and the finally
         # block still runs.
-        await voyage_event_stream(ws, VOYAGE_ID, token=TOKEN)
+        await voyage_event_stream(ws, VOYAGE_ID)
 
         mushi._redis.xgroup_destroy.assert_awaited()
 

--- a/src/backend/tests/test_production_settings_guard.py
+++ b/src/backend/tests/test_production_settings_guard.py
@@ -1,0 +1,26 @@
+"""Tests for the production-settings startup guard."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.core.config import settings
+from app.main import validate_production_settings
+
+
+class TestValidateProductionSettings:
+    def test_allows_default_secret_in_debug(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(settings, "debug", True)
+        monkeypatch.setattr(settings, "jwt_secret_key", "change-me-in-production")
+        validate_production_settings()
+
+    def test_rejects_default_secret_outside_debug(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(settings, "debug", False)
+        monkeypatch.setattr(settings, "jwt_secret_key", "change-me-in-production")
+        with pytest.raises(RuntimeError, match="GRANDLINE_JWT_SECRET_KEY"):
+            validate_production_settings()
+
+    def test_allows_custom_secret_outside_debug(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(settings, "debug", False)
+        monkeypatch.setattr(settings, "jwt_secret_key", "a-real-secret")
+        validate_production_settings()

--- a/src/backend/tests/test_voyages_api.py
+++ b/src/backend/tests/test_voyages_api.py
@@ -1,0 +1,96 @@
+"""Tests for POST /voyages (chart a course)."""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from pydantic import ValidationError
+
+from app.api.v1.voyages import create_voyage
+from app.models.dial_config import DialConfig
+from app.models.enums import CrewRole, VoyageStatus
+from app.models.voyage import Voyage
+from app.schemas.voyage import VoyageCreate
+
+USER_ID = uuid.uuid4()
+
+
+def _mock_user() -> MagicMock:
+    user = MagicMock()
+    user.id = USER_ID
+    user.is_active = True
+    return user
+
+
+def _mock_session(added: list[Any]) -> AsyncMock:
+    session = AsyncMock()
+    session.add = MagicMock(side_effect=added.append)
+    return session
+
+
+class TestCreateVoyage:
+    @pytest.mark.asyncio
+    async def test_creates_charted_voyage_for_current_user(self) -> None:
+        added: list[Any] = []
+        session = _mock_session(added)
+
+        voyage = await create_voyage(
+            VoyageCreate(title="Find One Piece", description="Sail the GrandLine"),
+            session=session,
+            user=_mock_user(),
+        )
+
+        assert isinstance(voyage, Voyage)
+        assert voyage.user_id == USER_ID
+        assert voyage.title == "Find One Piece"
+        assert voyage.description == "Sail the GrandLine"
+        assert voyage.status == VoyageStatus.CHARTED.value
+        assert voyage.phase_status == {}
+        session.commit.assert_awaited_once()
+        session.refresh.assert_awaited_once_with(voyage)
+
+    @pytest.mark.asyncio
+    async def test_creates_default_dial_config_for_all_roles(self) -> None:
+        added: list[Any] = []
+        session = _mock_session(added)
+
+        voyage = await create_voyage(
+            VoyageCreate(title="Find One Piece"),
+            session=session,
+            user=_mock_user(),
+        )
+
+        dial_configs = [obj for obj in added if isinstance(obj, DialConfig)]
+        assert len(dial_configs) == 1
+        config = dial_configs[0]
+        assert config.voyage_id == voyage.id
+        assert set(config.role_mapping) == {role.value for role in CrewRole}
+        for role_cfg in config.role_mapping.values():
+            assert role_cfg["provider"]
+            assert role_cfg["model"]
+        assert config.fallback_chain is None
+
+    @pytest.mark.asyncio
+    async def test_optional_fields_default_to_none(self) -> None:
+        added: list[Any] = []
+        session = _mock_session(added)
+
+        voyage = await create_voyage(
+            VoyageCreate(title="Find One Piece"),
+            session=session,
+            user=_mock_user(),
+        )
+
+        assert voyage.description is None
+        assert voyage.target_repo is None
+
+    def test_rejects_empty_title(self) -> None:
+        with pytest.raises(ValidationError):
+            VoyageCreate(title="")
+
+    def test_rejects_unknown_fields(self) -> None:
+        with pytest.raises(ValidationError):
+            VoyageCreate(title="x", status="COMPLETED")  # type: ignore[call-arg]

--- a/src/frontend/.env.example
+++ b/src/frontend/.env.example
@@ -1,0 +1,11 @@
+# GrandLine frontend environment variables.
+# Copy to .env.local for local development. NEXT_PUBLIC_* vars are inlined at
+# BUILD time — production images must be built with the right values.
+
+# Backend API origin. Leave empty for a same-origin reverse-proxy setup
+# (the production ingress); defaults to http://localhost:8000 in dev.
+NEXT_PUBLIC_API_BASE_URL=http://localhost:8000
+
+# WebSocket origin. Derived from NEXT_PUBLIC_API_BASE_URL (http→ws) unless
+# explicitly overridden.
+# NEXT_PUBLIC_WS_BASE_URL=ws://localhost:8000

--- a/src/frontend/app/app/error.tsx
+++ b/src/frontend/app/app/error.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { useEffect } from "react";
+
+// Route-segment error boundary for the Observation Deck. Without this, any
+// render/data error inside /app crashes to a blank screen.
+export default function DeckError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error("Observation Deck error:", error);
+  }, [error]);
+
+  return (
+    <div className="flex min-h-[50vh] flex-col items-center justify-center gap-4 p-6 text-center">
+      <h2 className="text-lg font-semibold text-ocean-100">
+        The deck hit rough waters
+      </h2>
+      <p className="max-w-md text-sm text-ocean-400">
+        Something went wrong while rendering the Observation Deck. Your voyage
+        is still running — try reloading the view.
+      </p>
+      <button
+        type="button"
+        onClick={reset}
+        className="rounded-md border border-ocean-500 px-4 py-2 text-sm text-ocean-100 hover:bg-ocean-800"
+      >
+        Try again
+      </button>
+    </div>
+  );
+}

--- a/src/frontend/components/observation-deck/ChartCourseDialog.tsx
+++ b/src/frontend/components/observation-deck/ChartCourseDialog.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { useState } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useQueryClient } from "@tanstack/react-query";
+import { createVoyage, startVoyage, MIN_TASK_LENGTH } from "@/lib/voyages";
+
+// "Chart a course" — create a voyage (and optionally set sail immediately,
+// using the mission text as the pipeline task).
+export function ChartCourseDialog({ onClose }: { onClose: () => void }) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const params = useSearchParams();
+  const queryClient = useQueryClient();
+
+  const [title, setTitle] = useState("");
+  const [mission, setMission] = useState("");
+  const [setSail, setSetSail] = useState(true);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const missionTooShort = setSail && mission.trim().length < MIN_TASK_LENGTH;
+  const canSubmit = title.trim().length > 0 && !missionTooShort && !busy;
+
+  const submit = async () => {
+    if (!canSubmit) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const voyage = await createVoyage({
+        title: title.trim(),
+        description: mission.trim() || null,
+      });
+      if (setSail) {
+        await startVoyage(voyage.id, mission.trim());
+      }
+      // Refresh every voyage list (sidebar + sea chart lanes).
+      void queryClient.invalidateQueries({ queryKey: ["sidebar"] });
+      void queryClient.invalidateQueries({ queryKey: ["sea-chart-active"] });
+      void queryClient.invalidateQueries({ queryKey: ["sea-chart-terminal"] });
+      // Select the new voyage in the current view.
+      const next = new URLSearchParams(params.toString());
+      next.set("voyage", voyage.id);
+      router.push(`${pathname}?${next.toString()}`);
+      onClose();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to chart course");
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center"
+      role="dialog"
+      aria-label="Chart a course"
+    >
+      <div className="absolute inset-0 bg-black/50" onClick={onClose} aria-hidden />
+      <div className="relative w-full max-w-md rounded-xl border border-ocean-700 bg-ocean-900 p-5 shadow-2xl">
+        <h3 className="mb-3 text-sm font-semibold text-ocean-100">Chart a course</h3>
+
+        <label className="mb-1 block text-xs text-ocean-400" htmlFor="voyage-title">
+          Voyage title
+        </label>
+        <input
+          id="voyage-title"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          maxLength={255}
+          autoFocus
+          className="mb-3 w-full rounded border border-ocean-700 bg-ocean-950 px-2 py-1.5 text-sm text-ocean-100 outline-none focus:border-ocean-400"
+          placeholder="e.g. Build a URL shortener"
+        />
+
+        <label className="mb-1 block text-xs text-ocean-400" htmlFor="voyage-mission">
+          Mission for the crew
+        </label>
+        <textarea
+          id="voyage-mission"
+          value={mission}
+          onChange={(e) => setMission(e.target.value)}
+          rows={4}
+          maxLength={5000}
+          className="w-full rounded border border-ocean-700 bg-ocean-950 px-2 py-1.5 text-sm text-ocean-100 outline-none focus:border-ocean-400"
+          placeholder="Describe what the crew should build, test, and deploy…"
+        />
+
+        <label className="mt-3 flex items-center gap-2 text-xs text-ocean-300">
+          <input
+            type="checkbox"
+            checked={setSail}
+            onChange={(e) => setSetSail(e.target.checked)}
+            className="accent-ocean-400"
+          />
+          Set sail immediately (start the pipeline)
+        </label>
+        {missionTooShort && (
+          <p className="mt-1 text-xs text-amber-400">
+            The mission needs at least {MIN_TASK_LENGTH} characters to set sail.
+          </p>
+        )}
+        {error && <p className="mt-2 text-xs text-rose-400">{error}</p>}
+
+        <div className="mt-4 flex justify-end gap-2">
+          <button
+            onClick={onClose}
+            className="rounded border border-ocean-700 px-3 py-1 text-sm text-ocean-300 hover:bg-ocean-800"
+          >
+            Cancel
+          </button>
+          <button
+            disabled={!canSubmit}
+            onClick={() => void submit()}
+            className="rounded bg-ocean-500 px-3 py-1 text-sm text-ocean-950 hover:bg-ocean-400 disabled:opacity-50"
+          >
+            {busy ? "Charting…" : setSail ? "Chart & set sail" : "Chart course"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/frontend/components/observation-deck/Sidebar.tsx
+++ b/src/frontend/components/observation-deck/Sidebar.tsx
@@ -1,7 +1,9 @@
 "use client";
 
+import { useState } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useVoyages } from "@/hooks/useVoyages";
+import { ChartCourseDialog } from "./ChartCourseDialog";
 import { StatusBadge } from "./StatusBadge";
 
 export function Sidebar() {
@@ -9,6 +11,7 @@ export function Sidebar() {
   const pathname = usePathname();
   const params = useSearchParams();
   const active = params.get("voyage");
+  const [charting, setCharting] = useState(false);
 
   const { data, isLoading, error, fetchNextPage, hasNextPage } = useVoyages({
     queryKey: "sidebar",
@@ -25,18 +28,28 @@ export function Sidebar() {
 
   return (
     <aside className="flex w-64 shrink-0 flex-col border-r border-ocean-800 bg-ocean-900/60">
-      <div className="border-b border-ocean-800 px-4 py-3">
+      <div className="flex items-center justify-between border-b border-ocean-800 px-4 py-3">
         <h2 className="text-sm font-semibold uppercase tracking-wider text-ocean-400">
           Voyages
         </h2>
+        <button
+          onClick={() => setCharting(true)}
+          className="rounded border border-ocean-600 px-2 py-0.5 text-xs text-ocean-200 hover:bg-ocean-700/60"
+          aria-label="Chart a course"
+        >
+          + Chart
+        </button>
       </div>
+      {charting && <ChartCourseDialog onClose={() => setCharting(false)} />}
       <nav className="flex-1 overflow-y-auto p-2" aria-label="Voyages">
         {isLoading && <p className="px-2 py-3 text-sm text-ocean-500">Loading…</p>}
         {error && (
           <p className="px-2 py-3 text-sm text-rose-400">Failed to load voyages</p>
         )}
         {!isLoading && voyages.length === 0 && (
-          <p className="px-2 py-3 text-sm text-ocean-500">No voyages yet.</p>
+          <p className="px-2 py-3 text-sm text-ocean-500">
+            No voyages yet. Chart a course to begin.
+          </p>
         )}
         <ul className="space-y-1">
           {voyages.map((v) => (

--- a/src/frontend/hooks/useVoyageStream.ts
+++ b/src/frontend/hooks/useVoyageStream.ts
@@ -146,7 +146,12 @@ export function useVoyageStream(voyageId: string | null): StreamControls {
       store.getState().setConnectionState("connecting");
       store.getState().beginConnection(id);
 
-      const ws = new WebSocket(`${WS_V1}/voyages/${id}/events?token=${encodeURIComponent(token)}`);
+      // Token rides in the subprotocol list, never the URL (proxy logs /
+      // browser history). The backend echoes "grandline-bearer" on accept.
+      const ws = new WebSocket(`${WS_V1}/voyages/${id}/events`, [
+        "grandline-bearer",
+        token,
+      ]);
       wsRef.current = ws;
       let opened = false;
 

--- a/src/frontend/lib/voyages.test.ts
+++ b/src/frontend/lib/voyages.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createVoyage, startVoyage, MIN_TASK_LENGTH } from "@/lib/voyages";
+import { useAuthStore } from "@/stores/auth";
+
+describe("voyage lifecycle API", () => {
+  beforeEach(() => {
+    useAuthStore.setState({ accessToken: "access-1", refreshToken: "refresh-1" });
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+    useAuthStore.getState().logout();
+  });
+
+  it("POSTs /voyages with the create payload", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ id: "v1", title: "Find One Piece" }), {
+        status: 201,
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const voyage = await createVoyage({
+      title: "Find One Piece",
+      description: "Sail the GrandLine",
+    });
+
+    expect(voyage.id).toBe("v1");
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain("/voyages");
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(init.body as string)).toEqual({
+      title: "Find One Piece",
+      description: "Sail the GrandLine",
+    });
+  });
+
+  it("POSTs /voyages/{id}/start with the task", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ voyage_id: "v1", status: "CHARTED" }), {
+        status: 202,
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await startVoyage("v1", "Build a URL shortener");
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain("/voyages/v1/start");
+    expect(JSON.parse(init.body as string)).toEqual({
+      task: "Build a URL shortener",
+      deploy_tier: "preview",
+    });
+  });
+
+  it("exposes the backend's minimum task length", () => {
+    expect(MIN_TASK_LENGTH).toBe(10);
+  });
+});

--- a/src/frontend/lib/voyages.ts
+++ b/src/frontend/lib/voyages.ts
@@ -1,0 +1,31 @@
+// Voyage lifecycle API calls: chart a course (POST /voyages) and set sail
+// (POST /voyages/{id}/start). All go through apiFetch so auth refresh (P4)
+// is handled.
+
+import { apiFetch } from "@/lib/api";
+import type { VoyageListItem } from "@/lib/types";
+
+export type VoyageCreatePayload = {
+  title: string;
+  description?: string | null;
+  target_repo?: string | null;
+};
+
+// Backend validation: StartVoyageRequest.task requires >= 10 chars.
+export const MIN_TASK_LENGTH = 10;
+
+export function createVoyage(payload: VoyageCreatePayload) {
+  return apiFetch<VoyageListItem>("/voyages", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+}
+
+export function startVoyage(id: string, task: string) {
+  return apiFetch<{ voyage_id: string; status: string }>(`/voyages/${id}/start`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ task, deploy_tier: "preview" }),
+  });
+}

--- a/src/frontend/next.config.mjs
+++ b/src/frontend/next.config.mjs
@@ -1,6 +1,44 @@
+// Security headers for every route. The auth cookie is intentionally
+// non-HttpOnly (WS handshake needs it — see backend auth.py), so CSP is the
+// documented XSS mitigation; keep it in place.
+//
+// connect-src allows localhost:8000 for dev and https/wss for deployments
+// where the API lives on another origin (NEXT_PUBLIC_API_BASE_URL).
+const contentSecurityPolicy = [
+  "default-src 'self'",
+  // Next.js requires inline scripts for hydration; 'unsafe-eval' only in dev.
+  process.env.NODE_ENV === "development"
+    ? "script-src 'self' 'unsafe-inline' 'unsafe-eval'"
+    : "script-src 'self' 'unsafe-inline'",
+  "style-src 'self' 'unsafe-inline'",
+  "img-src 'self' data: blob:",
+  "font-src 'self' data:",
+  "connect-src 'self' http://localhost:8000 ws://localhost:8000 https: wss:",
+  "object-src 'none'",
+  "base-uri 'self'",
+  "form-action 'self'",
+  "frame-ancestors 'none'",
+].join("; ");
+
+const securityHeaders = [
+  { key: "Content-Security-Policy", value: contentSecurityPolicy },
+  { key: "X-Frame-Options", value: "DENY" },
+  { key: "X-Content-Type-Options", value: "nosniff" },
+  { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+  { key: "Permissions-Policy", value: "camera=(), microphone=(), geolocation=()" },
+];
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: "standalone",
+  async headers() {
+    return [
+      {
+        source: "/:path*",
+        headers: securityHeaders,
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/src/infra/docker/.env.example
+++ b/src/infra/docker/.env.example
@@ -1,5 +1,6 @@
-# GrandLine Environment Variables
-# Copy this file to .env and fill in the values
+# GrandLine Environment Variables (docker-compose dev)
+# Copy this file to .env (same directory as docker-compose.yml) and fill in
+# the values. DEV DEFAULTS ONLY — never reuse these credentials in production.
 
 # ── PostgreSQL ──────────────────────────────────────────
 POSTGRES_USER=grandline
@@ -10,12 +11,26 @@ POSTGRES_DB=grandline
 GRANDLINE_DATABASE_URL=postgresql+psycopg://grandline:grandline@db:5432/grandline
 GRANDLINE_REDIS_URL=redis://redis:6379/0
 GRANDLINE_CORS_ORIGINS=["http://localhost:3000"]
+# debug=true relaxes the production-settings guard (insecure-default JWT
+# secret is tolerated). Production MUST run with GRANDLINE_DEBUG=false and a
+# real GRANDLINE_JWT_SECRET_KEY.
 GRANDLINE_DEBUG=true
+# GRANDLINE_JWT_SECRET_KEY=
 
 # ── Frontend (Next.js) ─────────────────────────────────
-NEXT_PUBLIC_API_URL=http://localhost:8000
+NEXT_PUBLIC_API_BASE_URL=http://localhost:8000
 
-# ── LLM Providers (for future Dial System) ─────────────
-# ANTHROPIC_API_KEY=
-# OPENAI_API_KEY=
-# OLLAMA_BASE_URL=http://localhost:11434
+# ── LLM Providers (Dial System) ────────────────────────
+# Provider keys use the backend settings prefix: GRANDLINE_*.
+# GRANDLINE_ANTHROPIC_API_KEY=
+# GRANDLINE_OPENAI_API_KEY=
+# GRANDLINE_OLLAMA_BASE_URL=http://localhost:11434
+
+# Claude Code CLI provider ("claude_code") — runs the locally-installed
+# `claude` CLI, so it can use your Claude subscription (claude login /
+# CLAUDE_CODE_OAUTH_TOKEN) instead of an API key.
+# GRANDLINE_CLAUDE_CODE_CLI_PATH=claude
+# GRANDLINE_CLAUDE_CODE_TIMEOUT_SECONDS=300
+# GRANDLINE_CLAUDE_CODE_MAX_TURNS=1
+# GRANDLINE_CLAUDE_CODE_WORKSPACE=
+# GRANDLINE_CLAUDE_CODE_EXTRA_ARGS=

--- a/src/infra/docker/docker-compose.yml
+++ b/src/infra/docker/docker-compose.yml
@@ -10,6 +10,10 @@ services:
       - GRANDLINE_REDIS_URL=redis://redis:6379/0
       - GRANDLINE_CORS_ORIGINS=["http://localhost:3000"]
       - GRANDLINE_DEBUG=true
+      # Dial System provider credentials — set in .env (see .env.example).
+      - GRANDLINE_ANTHROPIC_API_KEY=${GRANDLINE_ANTHROPIC_API_KEY:-}
+      - GRANDLINE_OPENAI_API_KEY=${GRANDLINE_OPENAI_API_KEY:-}
+      - GRANDLINE_OLLAMA_BASE_URL=${GRANDLINE_OLLAMA_BASE_URL:-http://localhost:11434}
     depends_on:
       db:
         condition: service_healthy
@@ -26,7 +30,7 @@ services:
     ports:
       - "3000:3000"
     environment:
-      - NEXT_PUBLIC_API_URL=http://localhost:8000
+      - NEXT_PUBLIC_API_BASE_URL=http://localhost:8000
     depends_on:
       - api
     volumes:

--- a/src/infra/helm/README.md
+++ b/src/infra/helm/README.md
@@ -33,9 +33,11 @@ external-secrets, or CI) with:
 
 - `GRANDLINE_DATABASE_URL`
 - `GRANDLINE_REDIS_URL`
-- `GRANDLINE_JWT_SECRET`
+- `GRANDLINE_JWT_SECRET_KEY`
 - `POSTGRES_PASSWORD`
-- `GRANDLINE_DIAL_ANTHROPIC_API_KEY` (and any other provider keys)
+- `GRANDLINE_ANTHROPIC_API_KEY` / `GRANDLINE_OPENAI_API_KEY` (and any other
+  provider keys — names must match the backend's `GRANDLINE_`-prefixed
+  settings exactly, since the Deployment consumes the Secret via `envFrom`)
 
 ```bash
 helm upgrade --install grandline ./grandline \

--- a/src/infra/helm/grandline/templates/NOTES.txt
+++ b/src/infra/helm/grandline/templates/NOTES.txt
@@ -12,7 +12,8 @@ Components:
 ⚠  secrets.create=true — a DEV secret was rendered into the cluster. For
    staging/prod set secrets.create=false and provision "{{ .Values.secrets.existingSecret }}"
    out-of-band with: GRANDLINE_DATABASE_URL, GRANDLINE_REDIS_URL,
-   GRANDLINE_JWT_SECRET, POSTGRES_PASSWORD, GRANDLINE_DIAL_ANTHROPIC_API_KEY.
+   GRANDLINE_JWT_SECRET_KEY, POSTGRES_PASSWORD, GRANDLINE_ANTHROPIC_API_KEY,
+   GRANDLINE_OPENAI_API_KEY.
 {{- end }}
 
 {{- if .Values.ingress.enabled }}

--- a/src/infra/helm/grandline/templates/secret.yaml
+++ b/src/infra/helm/grandline/templates/secret.yaml
@@ -10,8 +10,11 @@ metadata:
 type: Opaque
 stringData:
   POSTGRES_PASSWORD: {{ .Values.secrets.data.POSTGRES_PASSWORD | quote }}
-  GRANDLINE_JWT_SECRET: {{ .Values.secrets.data.GRANDLINE_JWT_SECRET | quote }}
+  # Key names must match the backend Settings env vars (GRANDLINE_ prefix +
+  # field name) exactly — the deployment consumes this Secret via envFrom.
+  GRANDLINE_JWT_SECRET_KEY: {{ .Values.secrets.data.GRANDLINE_JWT_SECRET_KEY | quote }}
   GRANDLINE_DATABASE_URL: {{ printf "postgresql+psycopg://%s:%s@%s-postgres:%v/%s" .Values.postgres.username .Values.secrets.data.POSTGRES_PASSWORD (include "grandline.fullname" .) .Values.postgres.port .Values.postgres.database | quote }}
   GRANDLINE_REDIS_URL: {{ printf "redis://%s-redis:%v/0" (include "grandline.fullname" .) .Values.redis.port | quote }}
-  GRANDLINE_DIAL_ANTHROPIC_API_KEY: {{ .Values.secrets.data.GRANDLINE_DIAL_ANTHROPIC_API_KEY | quote }}
+  GRANDLINE_ANTHROPIC_API_KEY: {{ .Values.secrets.data.GRANDLINE_ANTHROPIC_API_KEY | quote }}
+  GRANDLINE_OPENAI_API_KEY: {{ .Values.secrets.data.GRANDLINE_OPENAI_API_KEY | quote }}
 {{- end }}

--- a/src/infra/helm/grandline/values.yaml
+++ b/src/infra/helm/grandline/values.yaml
@@ -94,15 +94,18 @@ sandbox:
 
 secrets:
   # When false, the chart expects an existing Secret named `existingSecret`
-  # holding GRANDLINE_DATABASE_URL, GRANDLINE_REDIS_URL, GRANDLINE_JWT_SECRET,
-  # POSTGRES_PASSWORD, and provider API keys. Production MUST set create=false.
+  # holding GRANDLINE_DATABASE_URL, GRANDLINE_REDIS_URL,
+  # GRANDLINE_JWT_SECRET_KEY, POSTGRES_PASSWORD, and provider API keys.
+  # Production MUST set create=false. Key names must match the backend's
+  # GRANDLINE_-prefixed settings exactly (the Deployment uses envFrom).
   create: true
   existingSecret: grandline-secrets
   # Only used when create=true (dev). Override via --set / sealed secrets.
   data:
     POSTGRES_PASSWORD: changeme-dev
-    GRANDLINE_JWT_SECRET: changeme-dev-jwt-secret
-    GRANDLINE_DIAL_ANTHROPIC_API_KEY: ""
+    GRANDLINE_JWT_SECRET_KEY: changeme-dev-jwt-secret
+    GRANDLINE_ANTHROPIC_API_KEY: ""
+    GRANDLINE_OPENAI_API_KEY: ""
 
 ingress:
   enabled: true


### PR DESCRIPTION
## Summary

Deep release-readiness review of GrandLine, the new **Claude Code CLI provider** for the Dial System, and fixes for every blocking finding. Full review with fixed/open status lives in `docs/RELEASE_READINESS.md`.

### New: `claude_code` Dial System provider
- `ClaudeCodeAdapter` runs completions through the local `claude` CLI in print mode (`--print --output-format json|stream-json`), so crews can run on a **Claude subscription** (`claude login` / `CLAUDE_CODE_OAUTH_TOKEN`) or `ANTHROPIC_API_KEY` — no key stored in GrandLine.
- Streaming, failover-compatible `ProviderError` mapping, rate-limit detection, timeouts, `max_tokens` forwarding, temp-dir workspace (CLI never runs in the backend cwd).
- Configurable via `GRANDLINE_CLAUDE_CODE_*`; `GRANDLINE_DIAL_DEFAULT_PROVIDER=claude_code` makes new voyages use it by default. Documented in README + `.env.example`s + K8s appendix in `docs/DEPLOYMENT.md`.

### Critical fixes from the review
- **Helm secret keys didn't match backend env names** (`GRANDLINE_JWT_SECRET`→`GRANDLINE_JWT_SECRET_KEY`, `GRANDLINE_DIAL_ANTHROPIC_API_KEY`→`GRANDLINE_ANTHROPIC_API_KEY`): with `envFrom`, K8s deploys silently ran on the default JWT secret and without an Anthropic key.
- **Startup guard**: backend refuses to serve with the default JWT secret unless `GRANDLINE_DEBUG=true`.
- **CORS** restricted to explicit methods/headers (was `*` with credentials); **frontend security headers** (CSP, X-Frame-Options, nosniff, Referrer-Policy, Permissions-Policy); `/app` error boundary.
- Seeded `fallback_chain` shape fixed (old shape crashed `build_router_from_config`); `NEXT_PUBLIC_API_URL`→`NEXT_PUBLIC_API_BASE_URL` drift fixed; backend/frontend `.env.example` added.

### Blockers implemented
1. **Voyage creation end-to-end**: `POST /api/v1/voyages` (creates voyage + default dial config for all five roles) and an Observation Deck **"+ Chart"** dialog that creates the voyage and optionally sets sail immediately. Register → chart → sail → watch now works without the seed script.
2. **WS auth without token-in-URL**: handshake authenticates via `Sec-WebSocket-Protocol: grandline-bearer, <jwt>` (cookie fallback for same-origin); `?token=` removed and ignored, with a regression test.
3. **Deploy pipeline hardening**: CI `helm lint` + renders all overlays per PR; CD `deploy-gate` job reports the `DEPLOY_ENABLED` state instead of silent skips; `docs/DEPLOYMENT.md` first-deploy runbook.

## Testing
- Backend: **900 passed**, 19 skipped (infra-dependent integration tests); `ruff check`/`format` clean; `mypy --ignore-missing-imports` clean.
- Frontend: 56 vitest tests pass; eslint + tsc clean; production `next build` succeeds.
- Workflows YAML-validated; Helm template↔values references hand-verified (the new CI helm job validates renders going forward).

https://claude.ai/code/session_01GC6ekfqN4PxAXEu6nyJG32

---
_Generated by [Claude Code](https://claude.ai/code/session_01GC6ekfqN4PxAXEu6nyJG32)_