### PR TITLE
docs: replace placeholder GitHub Pages with interactive product mockup

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - "docs/**"
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/docs/assets/deck.js
+++ b/docs/assets/deck.js
@@ -1,0 +1,679 @@
+/* ==========================================================================
+   GrandLine product mockup — Observation Deck simulation
+   All data is generated in the browser. No backend, no network calls.
+   Event types, statuses, and copy mirror the real platform contracts:
+   - VoyageStatus: CHARTED PLANNING PDD TDD BUILDING REVIEWING DEPLOYING
+                   COMPLETED FAILED PAUSED CANCELLED
+   - Den Den Mushi event types: voyage_plan_created, poneglyph_drafted, ...
+   ========================================================================== */
+(function () {
+  "use strict";
+
+  var $ = function (sel, root) { return (root || document).querySelector(sel); };
+  var $$ = function (sel, root) { return Array.prototype.slice.call((root || document).querySelectorAll(sel)); };
+
+  /* ------------------------------------------------------------------ *
+   * Static reference data (mirrors frontend StatusBadge / SeaChart)
+   * ------------------------------------------------------------------ */
+  var GLYPH = {
+    CHARTED: "○", PLANNING: "◔", PDD: "◑", TDD: "◑", BUILDING: "◕",
+    REVIEWING: "◕", DEPLOYING: "◕", COMPLETED: "●", FAILED: "✕",
+    PAUSED: "❚❚", CANCELLED: "⊘"
+  };
+  var COLUMNS = [
+    { id: "col-planning", title: "Planning", statuses: ["CHARTED", "PLANNING"] },
+    { id: "col-pdd", title: "PDD", statuses: ["PDD"] },
+    { id: "col-tdd", title: "TDD", statuses: ["TDD"] },
+    { id: "col-building", title: "Building", statuses: ["BUILDING"] },
+    { id: "col-reviewing", title: "Reviewing", statuses: ["REVIEWING"] },
+    { id: "col-deploying", title: "Deploying", statuses: ["DEPLOYING"] }
+  ];
+  var TERMINAL = ["COMPLETED", "FAILED", "CANCELLED"];
+  var ROLES = ["captain", "navigator", "doctor", "shipwright", "helmsman"];
+  var ACTIVITY = {
+    voyage_plan_created: "Charting the course…",
+    poneglyph_drafted: "Drafting Poneglyphs…",
+    health_check_written: "Writing health checks…",
+    phase_build_started: "Building…",
+    code_generated: "Generating code…",
+    tests_passed: "Tests green ✓",
+    phase_build_failed: "Build failed ✕",
+    validation_passed: "Validation passed ✓",
+    validation_failed: "Validation failed ✕",
+    deployment_started: "Deploying…",
+    deployment_completed: "Deployed ✓",
+    deployment_failed: "Deploy failed ✕",
+    pipeline_stage_entered: "Entering stage…",
+    checkpoint_created: "Vivre Card saved",
+    pipeline_completed: "Voyage complete ✓"
+  };
+
+  /* ------------------------------------------------------------------ *
+   * Demo fleet — one scripted voyage + static dressing
+   * ------------------------------------------------------------------ */
+  var voyages = [
+    { id: "vg-7f3a2c91", title: "Realtime fleet telemetry API", status: "CHARTED",
+      phases: { 1: "PENDING", 2: "PENDING", 3: "PENDING", 4: "PENDING" },
+      demo: true, lastEvent: null, failure: null },
+    { id: "vg-1b9e4d02", title: "JWT auth hardening", status: "REVIEWING",
+      phases: { 1: "BUILT", 2: "BUILT", 3: "BUILT" }, lastEvent: Date.now() - 95e3 },
+    { id: "vg-5c8d1e77", title: "Sandbox image cache warm-up", status: "PAUSED",
+      phases: { 1: "BUILT", 2: "BUILDING", 3: "PENDING" }, lastEvent: Date.now() - 14 * 60e3, pausedCol: "col-building" },
+    { id: "vg-9a2f6b13", title: "Observation Deck theme polish", status: "COMPLETED",
+      phases: { 1: "BUILT", 2: "BUILT" }, lastEvent: Date.now() - 3 * 3600e3 },
+    { id: "vg-3e7c0a58", title: "Payment webhook retries", status: "FAILED",
+      phases: { 1: "BUILT", 2: "FAILED" }, lastEvent: Date.now() - 7 * 3600e3,
+      failure: { stage: "BUILDING", code: "max_iterations_exceeded", message: "Phase 2 exceeded 3 build iterations — escalated to fleet admiral" } }
+  ];
+  var demo = voyages[0];
+
+  /* The scripted voyage. d = ms gap at 1× before the step fires.
+     Mirrors real event_type strings published on grandline:events:{voyage_id}. */
+  var SCRIPT = [
+    { d: 600,  type: "pipeline_started",        role: "captain",    sum: "Voyage accepted — task handed to the Captain", status: "PLANNING" },
+    { d: 1400, type: "pipeline_stage_entered",  role: "captain",    sum: "Entered stage PLANNING", stagePing: true },
+    { d: 2600, type: "voyage_plan_created",     role: "captain",    sum: "Mission decomposed into 4 phases: schema, ingest API, aggregation worker, dashboard endpoint", ck: "plan_created" },
+    { d: 1500, type: "pipeline_stage_entered",  role: "navigator",  sum: "Entered stage PDD", status: "PDD" },
+    { d: 2200, type: "poneglyph_drafted",       role: "navigator",  sum: "Poneglyph drafted for phase 1 — telemetry tables + Alembic migration", phase: 1 },
+    { d: 1900, type: "poneglyph_drafted",       role: "navigator",  sum: "Poneglyphs drafted for phases 2–4 — endpoints, worker, contracts", ck: "poneglyph_drafted" },
+    { d: 1500, type: "pipeline_stage_entered",  role: "doctor",     sum: "Entered stage TDD", status: "TDD" },
+    { d: 2600, type: "health_check_written",    role: "doctor",     sum: "12 failing health checks written (pytest) — red as expected, TDD holds", ck: "health_check_written" },
+    { d: 1500, type: "pipeline_stage_entered",  role: "shipwright", sum: "Entered stage BUILDING — 2 parallel Shipwrights on independent phases", status: "BUILDING" },
+    { d: 1200, type: "phase_build_started",     role: "shipwright", sum: "Phase 1 build started on branch agent/shipwright/vg-7f3a2c", phase: 1, ph: { 1: "BUILDING" } },
+    { d: 2300, type: "code_generated",          role: "shipwright", sum: "Phase 1 iteration 1 — 6 files generated, running Doctor's checks in sandbox", phase: 1 },
+    { d: 2100, type: "tests_passed",            role: "shipwright", sum: "Phase 1 green — 4/4 checks passing, committed to agent branch", phase: 1, ph: { 1: "BUILT" }, ck: "iteration_1" },
+    { d: 1300, type: "phase_build_started",     role: "shipwright", sum: "Phases 2 + 3 build started (parallel layer)", ph: { 2: "BUILDING", 3: "BUILDING" } },
+    { d: 2400, type: "code_generated",          role: "shipwright", sum: "Phase 2 iteration 1 — 2/5 checks failing, analyzing tracebacks", phase: 2, fail: true },
+    { d: 2200, type: "code_generated",          role: "shipwright", sum: "Phase 2 iteration 2 — regenerated handler with idempotency key", phase: 2 },
+    { d: 1800, type: "tests_passed",            role: "shipwright", sum: "Phase 3 green — worker drains queue in sandbox run", phase: 3, ph: { 3: "BUILT" } },
+    { d: 1700, type: "tests_passed",            role: "shipwright", sum: "Phase 2 green on iteration 2 — Vivre Card checkpointed", phase: 2, ph: { 2: "BUILT" }, ck: "iteration_2" },
+    { d: 1300, type: "phase_build_started",     role: "shipwright", sum: "Phase 4 build started — dashboard endpoint", phase: 4, ph: { 4: "BUILDING" } },
+    { d: 2400, type: "tests_passed",            role: "shipwright", sum: "Phase 4 green — 12/12 health checks passing overall", phase: 4, ph: { 4: "BUILT" } },
+    { d: 1500, type: "pipeline_stage_entered",  role: "doctor",     sum: "Entered stage REVIEWING", status: "REVIEWING" },
+    { d: 2600, type: "validation_passed",       role: "doctor",     sum: "Full suite re-run in clean sandbox — 12/12 passing, coverage 91%", ck: "stage_REVIEWING" },
+    { d: 1500, type: "pipeline_stage_entered",  role: "helmsman",   sum: "Entered stage DEPLOYING", status: "DEPLOYING" },
+    { d: 1600, type: "deployment_started",      role: "helmsman",   sum: "Deploying tier=preview ref=agent/shipwright/vg-7f3a2c", ck: "deployment_started" },
+    { d: 2800, type: "deployment_completed",    role: "helmsman",   sum: "Preview live — https://preview-vg7f3a.grandline.dev (auto tier, no approval needed)" },
+    { d: 1700, type: "pipeline_completed",      role: "captain",    sum: "Voyage COMPLETED — staging awaits PR merge, production awaits fleet admiral approval", status: "COMPLETED" }
+  ];
+
+  /* ------------------------------------------------------------------ *
+   * Simulation state
+   * ------------------------------------------------------------------ */
+  var sim = {
+    idx: 0, timer: null, running: false, started: false, finished: false,
+    paused: false, cancelled: false, speed: 1,
+    events: [],          // EventEnvelope-ish: {ts, type, role, sum, phase, fail}
+    counts: { captain: 0, navigator: 0, doctor: 0, shipwright: 0, helmsman: 0 },
+    activeRole: null, prevRole: null,
+    statusBeforePause: null,
+    scrubbing: false
+  };
+
+  /* ------------------------------------------------------------------ *
+   * Rendering — Sea Chart
+   * ------------------------------------------------------------------ */
+  function relTime(ts) {
+    if (!ts) return "—";
+    var s = Math.max(1, Math.round((Date.now() - ts) / 1000));
+    if (s < 60) return s + "s ago";
+    var m = Math.round(s / 60);
+    if (m < 60) return m + "m ago";
+    return Math.round(m / 60) + "h ago";
+  }
+
+  function badgeHTML(status) {
+    return '<span class="badge st-' + status + '"><span class="g">' + GLYPH[status] + "</span>" + status + "</span>";
+  }
+
+  function cardHTML(v) {
+    var phases = Object.keys(v.phases);
+    var built = phases.filter(function (k) { return v.phases[k] === "BUILT"; }).length;
+    var pct = phases.length ? Math.round((built / phases.length) * 100) : 0;
+    var chips = phases.map(function (k) {
+      return '<span class="phase-chip ' + v.phases[k] + '" title="phase ' + k + ": " + v.phases[k] + '">' + k + "</span>";
+    }).join("");
+    return (
+      '<div class="sea-card" data-v="' + v.id + '">' +
+      '<div class="t">' + v.title + "</div>" +
+      badgeHTML(v.status) +
+      '<div class="progress"><span style="width:' + pct + '%"></span></div>' +
+      '<div class="phase-chips">' + chips + "</div>" +
+      '<div class="meta"><span>' + relTime(v.lastEvent) + "</span>" +
+      '<a href="#" class="open-details" data-v="' + v.id + '">Open details</a></div>' +
+      "</div>"
+    );
+  }
+
+  function columnFor(v) {
+    if (v.status === "PAUSED") return v.pausedCol || "col-building";
+    for (var i = 0; i < COLUMNS.length; i++) {
+      if (COLUMNS[i].statuses.indexOf(v.status) !== -1) return COLUMNS[i].id;
+    }
+    return null;
+  }
+
+  function renderSeaChart() {
+    COLUMNS.forEach(function (c) {
+      var host = $("#" + c.id + " .cards");
+      var items = voyages.filter(function (v) { return columnFor(v) === c.id && TERMINAL.indexOf(v.status) === -1; });
+      host.innerHTML = items.map(cardHTML).join("") || "";
+      $("#" + c.id + " .count").textContent = items.length;
+    });
+    var term = voyages.filter(function (v) { return TERMINAL.indexOf(v.status) !== -1; });
+    $("#terminal-cards").innerHTML = term.map(cardHTML).join("");
+    $("#terminal-count").textContent = term.length;
+    $$(".open-details").forEach(function (a) {
+      a.addEventListener("click", function (e) { e.preventDefault(); openDrawer(a.getAttribute("data-v")); });
+    });
+  }
+
+  /* ------------------------------------------------------------------ *
+   * Rendering — Sidebar
+   * ------------------------------------------------------------------ */
+  function renderSidebar() {
+    var host = $("#voyage-list");
+    host.innerHTML = voyages.map(function (v) {
+      return (
+        '<button class="voyage-item' + (v.demo ? " active" : "") + '" data-v="' + v.id + '">' +
+        '<span class="t">' + v.title + "</span>" + badgeHTML(v.status) + "</button>"
+      );
+    }).join("");
+  }
+
+  /* ------------------------------------------------------------------ *
+   * Rendering — Crew Map
+   * ------------------------------------------------------------------ */
+  var NODE_POS = { captain: 90, navigator: 270, doctor: 450, shipwright: 630, helmsman: 810 };
+
+  function setActiveRole(role, type) {
+    $$(".cm-node").forEach(function (n) { n.classList.toggle("active", n.getAttribute("data-role") === role); });
+    if (role && ACTIVITY[type]) {
+      var label = $("#cm-activity");
+      label.textContent = ACTIVITY[type];
+      label.setAttribute("x", NODE_POS[role]);
+      label.setAttribute("opacity", "1");
+      clearTimeout(setActiveRole._t);
+      setActiveRole._t = setTimeout(function () { label.setAttribute("opacity", "0"); }, 2000);
+    }
+  }
+
+  function flashEdge(from, to) {
+    if (!from || !to || from === to) return;
+    var edge = $('.cm-edge[data-edge="' + from + "-" + to + '"]') || $('.cm-edge[data-edge="' + to + "-" + from + '"]');
+    if (!edge) return;
+    edge.classList.add("flash");
+    var dot = $("#cm-dot");
+    dot.setAttribute("opacity", "1");
+    var x1 = NODE_POS[from], x2 = NODE_POS[to];
+    var t0 = performance.now(), dur = 600;
+    function step(t) {
+      var p = Math.min(1, (t - t0) / dur);
+      dot.setAttribute("cx", x1 + (x2 - x1) * p);
+      dot.setAttribute("cy", 110 - Math.sin(p * Math.PI) * 26);
+      if (p < 1) requestAnimationFrame(step);
+      else { dot.setAttribute("opacity", "0"); edge.classList.remove("flash"); }
+    }
+    requestAnimationFrame(step);
+  }
+
+  function renderCounts() {
+    ROLES.forEach(function (r) {
+      var el = $("#count-" + r);
+      if (el) el.textContent = sim.counts[r];
+      var b = $('.cm-count[data-role="' + r + '"]');
+      var bg = $('.cm-count-bg[data-role="' + r + '"]');
+      if (b) { b.textContent = sim.counts[r]; }
+      if (bg) { bg.setAttribute("opacity", sim.counts[r] ? "1" : "0"); }
+      if (b) { b.setAttribute("opacity", sim.counts[r] ? "1" : "0"); }
+    });
+    $("#cm-total").textContent = sim.events.length;
+  }
+
+  /* ------------------------------------------------------------------ *
+   * Rendering — Ship's Log
+   * ------------------------------------------------------------------ */
+  var logFilters = { roles: {}, failOnly: false, q: "" };
+
+  function logRowHTML(ev) {
+    var t = new Date(ev.ts).toLocaleTimeString();
+    return (
+      '<div class="log-row' + (ev.fail ? " fail" : "") + ' new" data-role="' + ev.role + '" data-ts="' + ev.ts + '">' +
+      '<span class="ts">' + t + "</span>" +
+      '<span class="role-badge rb-' + ev.role + '">' + ev.role + "</span>" +
+      '<span class="sum">' + ev.sum + "</span>" +
+      '<span class="at">' + ev.type + (ev.phase ? " · ph " + ev.phase : "") + "</span>" +
+      "</div>"
+    );
+  }
+
+  function rowVisible(ev) {
+    var anyRole = Object.keys(logFilters.roles).some(function (r) { return logFilters.roles[r]; });
+    if (anyRole && !logFilters.roles[ev.role]) return false;
+    if (logFilters.failOnly && !ev.fail && !/fail/i.test(ev.type)) return false;
+    if (logFilters.q && (ev.sum + " " + ev.type).toLowerCase().indexOf(logFilters.q) === -1) return false;
+    if (sim.scrubbing && ev.ts > sim.cursorTs) return false;
+    return true;
+  }
+
+  function renderLog() {
+    var host = $("#log-rows");
+    var rows = sim.events.filter(rowVisible);
+    host.innerHTML = rows.length
+      ? rows.map(logRowHTML).join("")
+      : '<div class="log-row"><span class="ts">—</span><span class="role-badge rb-system">system</span><span class="sum">No entries yet — press <b>⛵ Set Sail</b> to run the demo voyage.</span><span class="at"></span></div>';
+    host.scrollTop = host.scrollHeight;
+  }
+
+  /* ------------------------------------------------------------------ *
+   * Details drawer
+   * ------------------------------------------------------------------ */
+  function openDrawer(vid) {
+    var v = voyages.filter(function (x) { return x.id === vid; })[0];
+    if (!v) return;
+    $("#drawer-title").textContent = v.title;
+    $("#d-status").innerHTML = badgeHTML(v.status);
+    $("#d-crew").textContent = v.demo && sim.activeRole && !sim.finished ? sim.activeRole : "idle";
+    var done = Object.keys(v.phases).filter(function (k) { return v.phases[k] === "BUILT"; });
+    $("#d-phases-done").textContent = done.length ? done.join(", ") : "none yet";
+    $("#d-phase-table").innerHTML = Object.keys(v.phases).map(function (k) {
+      return "<tr><td class='mono'>Phase " + k + "</td><td><span class='phase-chip " + v.phases[k] + "'>" + v.phases[k] + "</span></td></tr>";
+    }).join("");
+    var f = $("#d-failure");
+    if (v.failure) {
+      f.style.display = "block";
+      f.innerHTML = "<b>✕ " + v.failure.stage + "</b> · <code>" + v.failure.code + "</code><br>" + v.failure.message;
+    } else { f.style.display = "none"; }
+    var evs = v.demo ? sim.events.slice(-12).reverse() : [];
+    $("#d-events").innerHTML = evs.length
+      ? evs.map(function (e) { return "<div class='dial-event'><b>" + e.role + "</b> · " + e.type + "</div>"; }).join("")
+      : "<div class='dial-event'>No buffered events for this voyage.</div>";
+    $("#d-first").textContent = sim.events.length && v.demo ? new Date(sim.events[0].ts).toLocaleString() : "—";
+    $("#d-last").textContent = v.demo && sim.events.length ? new Date(sim.events[sim.events.length - 1].ts).toLocaleString() : (v.lastEvent ? new Date(v.lastEvent).toLocaleString() : "—");
+    $("#d-buffered").textContent = v.demo ? sim.events.length : 0;
+    $("#drawer").classList.add("open");
+  }
+
+  /* ------------------------------------------------------------------ *
+   * Toasts
+   * ------------------------------------------------------------------ */
+  function toast(title, sub) {
+    var el = document.createElement("div");
+    el.className = "toast";
+    el.innerHTML = "<b>" + title + "</b>" + (sub ? '<div class="sub">' + sub + "</div>" : "");
+    $("#toasts").appendChild(el);
+    setTimeout(function () { el.style.opacity = "0"; el.style.transition = "opacity .4s"; }, 3400);
+    setTimeout(function () { el.remove(); }, 3900);
+  }
+
+  /* ------------------------------------------------------------------ *
+   * Simulation engine
+   * ------------------------------------------------------------------ */
+  function emit(step) {
+    var ev = { ts: Date.now(), type: step.type, role: step.role, sum: step.sum, phase: step.phase || null, fail: !!step.fail };
+    sim.events.push(ev);
+    sim.counts[step.role]++;
+
+    if (step.status) {
+      demo.status = step.status;
+      if (step.status === "BUILDING") demo.pausedCol = "col-building";
+    }
+    if (step.ph) Object.keys(step.ph).forEach(function (k) { demo.phases[k] = step.ph[k]; });
+    demo.lastEvent = ev.ts;
+
+    flashEdge(sim.prevRole, step.role);
+    sim.prevRole = sim.activeRole = step.role;
+    setActiveRole(step.role, step.type);
+    renderCounts();
+    renderSeaChart();
+    renderSidebar();
+    renderLog();
+    updatePlayback();
+
+    if (step.ck) toast("Vivre Card checkpoint", "reason=" + step.ck + " · crew=" + step.role);
+    if (step.type === "pipeline_completed") {
+      finishDemo();
+    }
+  }
+
+  function scheduleNext() {
+    if (sim.idx >= SCRIPT.length || sim.paused || sim.cancelled) return;
+    var step = SCRIPT[sim.idx];
+    sim.timer = setTimeout(function () {
+      sim.idx++;
+      emit(step);
+      scheduleNext();
+    }, step.d / sim.speed);
+  }
+
+  function startDemo() {
+    if (sim.running && !sim.finished) return;
+    // reset
+    clearTimeout(sim.timer);
+    sim.idx = 0; sim.events = []; sim.running = true; sim.started = true;
+    sim.finished = false; sim.paused = false; sim.cancelled = false;
+    sim.activeRole = null; sim.prevRole = null; sim.scrubbing = false;
+    ROLES.forEach(function (r) { sim.counts[r] = 0; });
+    demo.status = "CHARTED";
+    demo.phases = { 1: "PENDING", 2: "PENDING", 3: "PENDING", 4: "PENDING" };
+    demo.failure = null; demo.lastEvent = null;
+    setConn("live");
+    $("#sail-btn").textContent = "⛵ Voyage running…";
+    $("#sail-btn").disabled = true;
+    setInterventionState();
+    renderAll();
+    scheduleNext();
+  }
+
+  function finishDemo() {
+    sim.finished = true; sim.running = false;
+    clearTimeout(sim.timer);
+    setConn("ended");
+    $("#sail-btn").textContent = "↻ Replay voyage";
+    $("#sail-btn").disabled = false;
+    setActiveRole(null);
+    setInterventionState();
+    toast("Voyage COMPLETED ●", "preview deployed · staging + production gated");
+  }
+
+  function setConn(state) {
+    var chip = $("#conn-chip");
+    chip.className = "conn " + (state === "live" ? "live" : state === "ended" ? "ended" : "paused");
+    $("#conn-label").textContent = state === "live" ? "Live" : state === "ended" ? "Voyage ended" : "Paused";
+    $("#conn-transport").textContent = state === "live" ? "· ws" : state === "ended" ? "· read-only" : "· ws";
+  }
+
+  /* ------------------------------------------------------------------ *
+   * Interventions (fleet admiral controls)
+   * ------------------------------------------------------------------ */
+  function setInterventionState() {
+    var active = sim.running && !sim.finished && !sim.cancelled;
+    $("#iv-pause").style.display = active && !sim.paused ? "" : "none";
+    $("#iv-resume").style.display = active && sim.paused ? "" : "none";
+    $("#iv-pause").disabled = !active;
+    $("#iv-resume").disabled = !active;
+    $("#iv-inject").disabled = !active;
+    $("#iv-cancel").disabled = !active;
+  }
+
+  function intervene(type, sum, role) {
+    var ev = { ts: Date.now(), type: type, role: role || "captain", sum: sum, phase: null, fail: false };
+    sim.events.push(ev);
+    renderLog(); updatePlayback(); renderCounts();
+  }
+
+  $("#iv-pause").addEventListener("click", function () {
+    if (!sim.running || sim.paused) return;
+    sim.paused = true;
+    clearTimeout(sim.timer);
+    sim.statusBeforePause = demo.status;
+    demo.status = "PAUSED";
+    setConn("paused");
+    intervene("crew_action_recorded", "PIPELINE_PAUSED — voyage paused by fleet admiral; Vivre Card checkpoint created (reason=pause)");
+    toast("Voyage paused ❚❚", "Vivre Card checkpoint · reason=pause");
+    setInterventionState(); renderSeaChart(); renderSidebar();
+  });
+
+  $("#iv-resume").addEventListener("click", function () {
+    if (!sim.paused) return;
+    sim.paused = false;
+    demo.status = sim.statusBeforePause || "BUILDING";
+    setConn("live");
+    intervene("crew_action_recorded", "PIPELINE_RESUMED — restored from Vivre Card; stage guards skip already-satisfied phases");
+    toast("Voyage resumed ▶", "restored from checkpoint — no work lost");
+    setInterventionState(); renderSeaChart(); renderSidebar();
+    scheduleNext();
+  });
+
+  $("#iv-inject").addEventListener("click", function () { $("#inject-modal").classList.add("open"); });
+  $("#inject-cancel").addEventListener("click", function () { $("#inject-modal").classList.remove("open"); });
+  $("#inject-send").addEventListener("click", function () {
+    var txt = $("#inject-text").value.trim();
+    if (txt.length < 10) { $("#inject-text").focus(); return; }
+    $("#inject-modal").classList.remove("open");
+    intervene("crew_action_recorded", "CONTEXT_INJECTED — “" + txt.slice(0, 120) + "” appended to the active agent's context window");
+    toast("Context injected ✎", "delivered to " + (sim.activeRole || "crew") + " via Den Den Mushi");
+    $("#inject-text").value = "";
+  });
+
+  $("#iv-cancel").addEventListener("click", function () { $("#cancel-modal").classList.add("open"); });
+  $("#cancel-keep").addEventListener("click", function () { $("#cancel-modal").classList.remove("open"); });
+  $("#cancel-confirm").addEventListener("click", function () {
+    $("#cancel-modal").classList.remove("open");
+    sim.cancelled = true; sim.running = false; sim.finished = true;
+    clearTimeout(sim.timer);
+    demo.status = "CANCELLED";
+    setConn("ended");
+    intervene("crew_action_recorded", "PIPELINE_CANCELLED — graceful shutdown; final Vivre Card preserved for post-mortem");
+    toast("Voyage cancelled ⊘", "state preserved — nothing lost");
+    $("#sail-btn").textContent = "↻ Replay voyage";
+    $("#sail-btn").disabled = false;
+    setActiveRole(null);
+    setInterventionState(); renderSeaChart(); renderSidebar();
+  });
+
+  /* ------------------------------------------------------------------ *
+   * Playback scrubber
+   * ------------------------------------------------------------------ */
+  function updatePlayback() {
+    var r = $("#scrubber");
+    if (!sim.events.length) { r.disabled = true; return; }
+    r.disabled = false;
+    r.min = sim.events[0].ts;
+    r.max = sim.events[sim.events.length - 1].ts;
+    if (!sim.scrubbing) r.value = r.max;
+    $("#pt-start").textContent = new Date(+r.min).toLocaleTimeString();
+    $("#pt-end").textContent = sim.scrubbing ? "scrubbing" : new Date(+r.max).toLocaleTimeString();
+    $("#pt-end").style.color = sim.scrubbing ? "var(--amber)" : "";
+  }
+
+  $("#scrubber").addEventListener("input", function () {
+    sim.scrubbing = true;
+    sim.cursorTs = +this.value;
+    $("#return-live").style.display = "";
+    renderLog(); updatePlayback();
+  });
+  $("#return-live").addEventListener("click", function () {
+    sim.scrubbing = false;
+    this.style.display = "none";
+    renderLog(); updatePlayback();
+  });
+
+  /* Speed control */
+  $("#speed-btn").addEventListener("click", function () {
+    sim.speed = sim.speed === 1 ? 2 : sim.speed === 2 ? 4 : 1;
+    this.textContent = sim.speed + "×";
+  });
+
+  $("#sail-btn").addEventListener("click", startDemo);
+
+  /* ------------------------------------------------------------------ *
+   * Tabs, palette, shortcuts, chart dialog
+   * ------------------------------------------------------------------ */
+  function showView(name) {
+    $$(".deck-tab").forEach(function (t) { t.classList.toggle("active", t.getAttribute("data-view") === name); });
+    $$(".deck-view").forEach(function (v) { v.classList.toggle("active", v.id === "view-" + name); });
+  }
+  $$(".deck-tab").forEach(function (t) {
+    t.addEventListener("click", function () { showView(t.getAttribute("data-view")); });
+  });
+
+  /* Ship's Log filters */
+  $$(".filter-chip[data-role]").forEach(function (c) {
+    c.addEventListener("click", function () {
+      var r = c.getAttribute("data-role");
+      logFilters.roles[r] = !logFilters.roles[r];
+      c.classList.toggle("on", logFilters.roles[r]);
+      renderLog();
+    });
+  });
+  $("#fail-only").addEventListener("click", function () {
+    logFilters.failOnly = !logFilters.failOnly;
+    this.classList.toggle("on", logFilters.failOnly);
+    renderLog();
+  });
+  $("#log-search").addEventListener("input", function () {
+    logFilters.q = this.value.toLowerCase();
+    renderLog();
+  });
+  $("#clear-filters").addEventListener("click", function () {
+    logFilters.roles = {}; logFilters.failOnly = false; logFilters.q = "";
+    $("#log-search").value = "";
+    $$(".filter-chip").forEach(function (c) { c.classList.remove("on"); });
+    renderLog();
+  });
+
+  /* Chart-a-course dialog */
+  $("#chart-open").addEventListener("click", function () { $("#chart-modal").classList.add("open"); });
+  $("#chart-cancel").addEventListener("click", function () { $("#chart-modal").classList.remove("open"); });
+  $("#chart-create").addEventListener("click", function () {
+    var title = $("#chart-title").value.trim() || "Untitled voyage";
+    var sail = $("#chart-sail").checked;
+    voyages.push({ id: "vg-" + Math.random().toString(16).slice(2, 10), title: title, status: "CHARTED",
+      phases: { 1: "PENDING" }, lastEvent: Date.now() });
+    $("#chart-modal").classList.remove("open");
+    $("#chart-title").value = ""; $("#chart-task").value = "";
+    renderSeaChart(); renderSidebar();
+    toast("Course charted ○", sail ? "POST /voyages → /start · status=CHARTED" : "POST /voyages · status=CHARTED");
+  });
+
+  /* Drawer */
+  $("#drawer-close").addEventListener("click", function () { $("#drawer").classList.remove("open"); });
+  $$(".drawer-tab").forEach(function (t) {
+    t.addEventListener("click", function () {
+      $$(".drawer-tab").forEach(function (x) { x.classList.remove("active"); });
+      t.classList.add("active");
+      $$(".drawer-pane").forEach(function (p) { p.style.display = p.id === "pane-" + t.getAttribute("data-pane") ? "block" : "none"; });
+    });
+  });
+
+  /* Command palette + keyboard shortcuts (mirrors P14 editable-focus guard) */
+  var PALETTE_CMDS = [
+    { label: "Go to Sea Chart", kbd: "g s", run: function () { showView("sea"); } },
+    { label: "Go to Crew Map", kbd: "g c", run: function () { showView("map"); } },
+    { label: "Go to Ship's Log", kbd: "g l", run: function () { showView("log"); } },
+    { label: "Set sail / replay demo voyage", kbd: "", run: startDemo },
+    { label: "Return to live", kbd: "", run: function () { sim.scrubbing = false; $("#return-live").style.display = "none"; renderLog(); updatePlayback(); } },
+    { label: "Keyboard shortcuts", kbd: "?", run: function () { $("#help-modal").classList.add("open"); } }
+  ];
+  function renderPalette(q) {
+    var list = $("#palette-list");
+    list.innerHTML = PALETTE_CMDS
+      .filter(function (c) { return c.label.toLowerCase().indexOf((q || "").toLowerCase()) !== -1; })
+      .map(function (c, i) {
+        return '<button class="palette-item' + (i === 0 ? " sel" : "") + '" data-i="' + PALETTE_CMDS.indexOf(c) + '">' +
+          "<span>" + c.label + "</span>" + (c.kbd ? '<span class="kbd">' + c.kbd + "</span>" : "") + "</button>";
+      }).join("");
+    $$(".palette-item").forEach(function (b) {
+      b.addEventListener("click", function () {
+        closePalette();
+        PALETTE_CMDS[+b.getAttribute("data-i")].run();
+      });
+    });
+  }
+  function openPalette() { $("#palette").classList.add("open"); $("#palette-input").value = ""; renderPalette(""); $("#palette-input").focus(); }
+  function closePalette() { $("#palette").classList.remove("open"); }
+  $("#palette-input").addEventListener("input", function () { renderPalette(this.value); });
+  $("#palette").addEventListener("click", function (e) { if (e.target === this) closePalette(); });
+  $("#palette-open").addEventListener("click", openPalette);
+  $("#help-close").addEventListener("click", function () { $("#help-modal").classList.remove("open"); });
+
+  var chord = null;
+  document.addEventListener("keydown", function (e) {
+    var el = document.activeElement;
+    var editing = el && (el.tagName === "INPUT" || el.tagName === "TEXTAREA" || el.tagName === "SELECT" || el.isContentEditable);
+    if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
+      e.preventDefault();
+      $("#palette").classList.contains("open") ? closePalette() : openPalette();
+      return;
+    }
+    if (e.key === "Escape") {
+      closePalette();
+      $$(".modal-backdrop").forEach(function (m) { m.classList.remove("open"); });
+      $("#drawer").classList.remove("open");
+      return;
+    }
+    if (editing) return; // P14 editable-focus guard
+    if (e.key === "?") { $("#help-modal").classList.add("open"); return; }
+    if (e.key === "/") { e.preventDefault(); showView("log"); $("#log-search").focus(); return; }
+    if (e.key === "f") { $("#deck-body").classList.toggle("focus"); return; }
+    if (e.key === "g") { chord = "g"; setTimeout(function () { chord = null; }, 900); return; }
+    if (chord === "g") {
+      if (e.key === "s") showView("sea");
+      if (e.key === "c") showView("map");
+      if (e.key === "l") showView("log");
+      chord = null;
+    }
+  });
+
+  /* ------------------------------------------------------------------ *
+   * Dial System failover simulation
+   * ------------------------------------------------------------------ */
+  var dialDown = false;
+  function dialEvent(cls, text) {
+    var host = $("#dial-events");
+    var el = document.createElement("div");
+    el.className = "dial-event " + (cls || "");
+    el.textContent = text;
+    host.prepend(el);
+    while (host.children.length > 8) host.lastChild.remove();
+  }
+  $("#dial-sim").addEventListener("click", function () {
+    if (!dialDown) {
+      dialDown = true;
+      this.textContent = "↻ Restore anthropic";
+      $$('.provider-chip[data-p="anthropic"]').forEach(function (c) { c.classList.add("down"); });
+      $$("[data-active-provider]").forEach(function (cell) {
+        cell.innerHTML = '<span class="provider-chip"><span class="pd"></span>openai</span> <span class="mono" style="color:var(--ocean-500)">gpt-4o</span>';
+      });
+      dialEvent("warn", "rate_limit detected · provider=anthropic · window=60s tokens>100k");
+      setTimeout(function () { dialEvent("", "checkpoint_created · reason=failover · crew=captain (Vivre Card saved)"); }, 450);
+      setTimeout(function () { dialEvent("ok", "provider_switched · captain → openai · resumed mid-voyage, no work lost"); }, 950);
+    } else {
+      dialDown = false;
+      this.textContent = "⚡ Simulate anthropic rate-limit";
+      $$('.provider-chip[data-p="anthropic"]').forEach(function (c) { c.classList.remove("down"); });
+      $$("[data-active-provider]").forEach(function (cell) {
+        cell.innerHTML = '<span class="provider-chip"><span class="pd"></span>anthropic</span> <span class="mono" style="color:var(--ocean-500)">claude-sonnet-4</span>';
+      });
+      dialEvent("ok", "provider restored · captain → anthropic (primary)");
+    }
+  });
+
+  /* ------------------------------------------------------------------ *
+   * Pipeline section: cycle the active stage highlight
+   * ------------------------------------------------------------------ */
+  (function cycleStages() {
+    var stages = $$("#pipeline-flow .stage");
+    if (!stages.length) return;
+    var i = 0;
+    setInterval(function () {
+      stages.forEach(function (s, j) { s.classList.toggle("active", j === i); });
+      i = (i + 1) % stages.length;
+    }, 1600);
+  })();
+
+  /* ------------------------------------------------------------------ *
+   * Boot
+   * ------------------------------------------------------------------ */
+  function renderAll() {
+    renderSeaChart(); renderSidebar(); renderLog(); renderCounts(); updatePlayback(); setInterventionState();
+  }
+  renderAll();
+  setInterval(function () { if (!sim.running) renderSeaChart(); }, 15000); // refresh relative timestamps
+
+  /* Auto-start the demo when the deck scrolls into view */
+  if ("IntersectionObserver" in window) {
+    var seen = false;
+    var io = new IntersectionObserver(function (entries) {
+      entries.forEach(function (en) {
+        if (en.isIntersecting && !seen && !sim.started) {
+          seen = true;
+          setTimeout(startDemo, 700);
+          io.disconnect();
+        }
+      });
+    }, { threshold: 0.35 });
+    io.observe($("#deck"));
+  }
+})();

--- a/docs/assets/styles.css
+++ b/docs/assets/styles.css
@@ -1,0 +1,528 @@
+/* ==========================================================================
+   GrandLine — interactive product mockup
+   Dark nautical theme mirroring the real frontend (Tailwind "ocean" palette)
+   ========================================================================== */
+
+:root {
+  --ocean-50: #f0f9ff;
+  --ocean-100: #e0f2fe;
+  --ocean-200: #bae6fd;
+  --ocean-300: #7dd3fc;
+  --ocean-400: #38bdf8;
+  --ocean-500: #0ea5e9;
+  --ocean-600: #0284c7;
+  --ocean-700: #0369a1;
+  --ocean-800: #075985;
+  --ocean-900: #0c4a6e;
+  --ocean-950: #082f49;
+  --abyss: #04101f;
+
+  --emerald: #34d399;
+  --amber: #fbbf24;
+  --amber-soft: #fcd34d;
+  --rose: #fb7185;
+  --rose-soft: #fda4af;
+  --indigo: #a5b4fc;
+  --violet: #c4b5fd;
+  --cyan: #67e8f9;
+  --sky: #7dd3fc;
+
+  --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  --font-mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
+
+  --radius: 10px;
+  --radius-lg: 16px;
+  --border: 1px solid rgba(3, 105, 161, 0.45);
+  --border-soft: 1px solid rgba(3, 105, 161, 0.25);
+  --shadow: 0 10px 30px rgba(2, 8, 23, 0.55);
+}
+
+* { margin: 0; padding: 0; box-sizing: border-box; }
+
+html { scroll-behavior: smooth; }
+
+body {
+  font-family: var(--font-sans);
+  background:
+    radial-gradient(1200px 600px at 80% -10%, rgba(14, 165, 233, 0.16), transparent 60%),
+    radial-gradient(900px 500px at 10% 20%, rgba(2, 132, 199, 0.12), transparent 55%),
+    linear-gradient(180deg, var(--abyss) 0%, var(--ocean-950) 55%, #061c30 100%);
+  background-attachment: fixed;
+  color: var(--ocean-100);
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+}
+
+::selection { background: rgba(56, 189, 248, 0.35); }
+
+a { color: var(--ocean-300); text-decoration: none; }
+a:hover { color: var(--ocean-100); }
+
+code, .mono { font-family: var(--font-mono); font-size: 0.86em; }
+
+:focus-visible { outline: 2px solid var(--ocean-300); outline-offset: 2px; border-radius: 4px; }
+
+.container { max-width: 1180px; margin: 0 auto; padding: 0 1.25rem; }
+
+/* --------------------------------------------------------------------------
+   Top navigation
+   -------------------------------------------------------------------------- */
+.nav {
+  position: sticky; top: 0; z-index: 60;
+  backdrop-filter: blur(10px);
+  background: rgba(4, 16, 31, 0.82);
+  border-bottom: var(--border-soft);
+}
+.nav-inner {
+  display: flex; align-items: center; gap: 1.25rem;
+  padding: 0.8rem 1.25rem; max-width: 1180px; margin: 0 auto;
+}
+.brand { display: flex; align-items: center; gap: 0.55rem; font-weight: 700; font-size: 1.05rem; color: #fff; }
+.brand .anchor { color: var(--ocean-400); font-size: 1.2rem; }
+.nav-links { display: flex; gap: 1.1rem; margin-left: auto; align-items: center; flex-wrap: wrap; }
+.nav-links a { font-size: 0.9rem; color: var(--ocean-300); }
+.nav-links a:hover { color: #fff; }
+.nav-cta {
+  background: var(--ocean-500); color: #fff !important; padding: 0.45rem 0.95rem;
+  border-radius: 8px; font-weight: 600; font-size: 0.88rem;
+}
+.nav-cta:hover { background: var(--ocean-400); }
+.mock-tag {
+  font-size: 0.68rem; letter-spacing: 0.08em; text-transform: uppercase;
+  color: var(--amber-soft); border: 1px solid rgba(251, 191, 36, 0.45);
+  padding: 0.15rem 0.5rem; border-radius: 999px; white-space: nowrap;
+}
+
+/* --------------------------------------------------------------------------
+   Hero
+   -------------------------------------------------------------------------- */
+.hero { position: relative; overflow: hidden; padding: 6.5rem 0 5rem; text-align: center; }
+.hero h1 {
+  font-size: clamp(2.3rem, 6vw, 4rem); font-weight: 800; color: #fff;
+  line-height: 1.12; letter-spacing: -0.02em; margin-bottom: 1.1rem;
+}
+.hero h1 .accent { color: var(--ocean-400); }
+.hero .sub {
+  max-width: 660px; margin: 0 auto 2.2rem; color: var(--ocean-200); font-size: 1.12rem;
+}
+.hero-ctas { display: flex; gap: 0.9rem; justify-content: center; flex-wrap: wrap; }
+.btn {
+  display: inline-flex; align-items: center; gap: 0.5rem;
+  padding: 0.7rem 1.35rem; border-radius: 10px; font-weight: 600; font-size: 0.95rem;
+  border: 1px solid transparent; cursor: pointer; transition: all 0.15s ease;
+}
+.btn-primary { background: var(--ocean-500); color: #fff; }
+.btn-primary:hover { background: var(--ocean-400); color: #fff; transform: translateY(-1px); }
+.btn-ghost { border-color: rgba(125, 211, 252, 0.4); color: var(--ocean-200); background: transparent; }
+.btn-ghost:hover { border-color: var(--ocean-300); color: #fff; }
+
+.hero-waves {
+  position: absolute; inset: auto 0 -2px 0; height: 110px; pointer-events: none; opacity: 0.6;
+}
+.hero-badges { display: flex; gap: 0.55rem; justify-content: center; flex-wrap: wrap; margin-top: 2.4rem; }
+.pill {
+  font-size: 0.74rem; color: var(--ocean-300); border: var(--border-soft);
+  background: rgba(12, 74, 110, 0.35); padding: 0.3rem 0.75rem; border-radius: 999px;
+}
+
+/* --------------------------------------------------------------------------
+   Sections
+   -------------------------------------------------------------------------- */
+section { padding: 4.5rem 0; }
+.section-head { text-align: center; max-width: 720px; margin: 0 auto 2.8rem; }
+.kicker {
+  font-size: 0.74rem; letter-spacing: 0.16em; text-transform: uppercase;
+  color: var(--ocean-400); font-weight: 700; margin-bottom: 0.6rem;
+}
+.section-head h2 { color: #fff; font-size: clamp(1.6rem, 3.6vw, 2.3rem); font-weight: 800; margin-bottom: 0.7rem; }
+.section-head p { color: var(--ocean-300); font-size: 1.02rem; }
+
+.card {
+  background: linear-gradient(180deg, rgba(12, 74, 110, 0.42), rgba(8, 47, 73, 0.55));
+  border: var(--border-soft); border-radius: var(--radius-lg); padding: 1.4rem;
+}
+
+/* Crew */
+.crew-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 1rem; }
+.crew-card { text-align: left; position: relative; transition: transform 0.18s ease, border-color 0.18s ease; }
+.crew-card:hover { transform: translateY(-4px); border-color: rgba(56, 189, 248, 0.55); }
+.crew-emoji { font-size: 1.9rem; }
+.crew-card h3 { color: #fff; font-size: 1.08rem; margin: 0.55rem 0 0.1rem; }
+.crew-role { color: var(--ocean-400); font-size: 0.78rem; font-weight: 700; letter-spacing: 0.06em; text-transform: uppercase; }
+.crew-card p { color: var(--ocean-200); font-size: 0.88rem; margin-top: 0.55rem; }
+.crew-meta { margin-top: 0.8rem; display: flex; flex-wrap: wrap; gap: 0.35rem; }
+.chip {
+  font-size: 0.68rem; font-family: var(--font-mono); color: var(--ocean-300);
+  background: rgba(2, 132, 199, 0.18); border: 1px solid rgba(2, 132, 199, 0.35);
+  padding: 0.12rem 0.45rem; border-radius: 6px;
+}
+
+/* Pipeline state machine */
+.pipeline-flow {
+  display: flex; align-items: center; gap: 0.4rem; flex-wrap: wrap; justify-content: center;
+  margin-bottom: 1.6rem;
+}
+.stage {
+  display: flex; flex-direction: column; align-items: center; gap: 0.3rem;
+  min-width: 96px; padding: 0.7rem 0.6rem; border-radius: var(--radius);
+  border: var(--border-soft); background: rgba(8, 47, 73, 0.5);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+.stage .glyph { font-size: 1.05rem; }
+.stage .name { font-family: var(--font-mono); font-size: 0.72rem; color: #fff; letter-spacing: 0.04em; }
+.stage .who { font-size: 0.66rem; color: var(--ocean-400); }
+.stage.active { border-color: var(--ocean-300); box-shadow: 0 0 18px rgba(56, 189, 248, 0.25); }
+.flow-arrow { color: var(--ocean-600); font-size: 1rem; }
+.side-states { display: flex; gap: 0.5rem; justify-content: center; flex-wrap: wrap; }
+.pipeline-quote {
+  text-align: center; color: var(--ocean-300); font-style: italic; margin-top: 2rem; font-size: 0.98rem;
+}
+
+/* --------------------------------------------------------------------------
+   Status badges (mirrors StatusBadge.tsx)
+   -------------------------------------------------------------------------- */
+.badge {
+  display: inline-flex; align-items: center; gap: 0.3rem;
+  font-family: var(--font-mono); font-size: 0.68rem; letter-spacing: 0.03em;
+  border-radius: 999px; padding: 0.14rem 0.55rem;
+  border: 1px solid rgba(3, 105, 161, 0.5); background: rgba(8, 47, 73, 0.6);
+  white-space: nowrap;
+}
+.badge .g { font-size: 0.78rem; line-height: 1; }
+.st-CHARTED   { color: var(--ocean-400); }
+.st-PLANNING  { color: var(--sky); }
+.st-PDD       { color: var(--sky); }
+.st-TDD       { color: var(--indigo); }
+.st-BUILDING  { color: var(--amber); }
+.st-REVIEWING { color: var(--violet); }
+.st-DEPLOYING { color: var(--cyan); }
+.st-COMPLETED { color: var(--emerald); }
+.st-FAILED    { color: var(--rose); }
+.st-PAUSED    { color: var(--amber); }
+.st-CANCELLED { color: var(--ocean-500); }
+
+/* --------------------------------------------------------------------------
+   Observation Deck mock (the centerpiece)
+   -------------------------------------------------------------------------- */
+.deck-frame {
+  border: var(--border); border-radius: var(--radius-lg); overflow: hidden;
+  box-shadow: var(--shadow); background: rgba(4, 16, 31, 0.92);
+}
+.deck-note { text-align: center; color: var(--ocean-500); font-size: 0.78rem; margin-top: 0.8rem; }
+
+.deck-topbar {
+  display: flex; align-items: center; gap: 1rem; flex-wrap: wrap;
+  padding: 0.65rem 1rem; border-bottom: var(--border-soft);
+  background: rgba(8, 47, 73, 0.45);
+}
+.deck-title { display: flex; align-items: center; gap: 0.45rem; color: #fff; font-weight: 700; font-size: 0.92rem; }
+.deck-tabs { display: flex; gap: 0.25rem; }
+.deck-tab {
+  font-size: 0.8rem; color: var(--ocean-300); background: transparent; border: 1px solid transparent;
+  padding: 0.32rem 0.8rem; border-radius: 8px; cursor: pointer; font-family: var(--font-sans);
+}
+.deck-tab:hover { color: #fff; }
+.deck-tab.active { background: rgba(2, 132, 199, 0.25); border-color: rgba(56, 189, 248, 0.45); color: #fff; }
+.deck-top-right { margin-left: auto; display: flex; align-items: center; gap: 0.7rem; flex-wrap: wrap; }
+
+.conn {
+  display: inline-flex; align-items: center; gap: 0.4rem; font-size: 0.74rem; color: var(--ocean-200);
+  border: var(--border-soft); padding: 0.22rem 0.6rem; border-radius: 999px; background: rgba(8, 47, 73, 0.5);
+}
+.conn .dot { width: 8px; height: 8px; border-radius: 50%; background: var(--emerald); }
+.conn.live .dot { background: var(--emerald); box-shadow: 0 0 8px rgba(52, 211, 153, 0.8); }
+.conn.ended .dot { background: var(--ocean-400); }
+.conn.paused .dot { background: var(--amber); }
+.conn .transport { font-family: var(--font-mono); color: var(--ocean-400); }
+
+.deck-body { display: flex; min-height: 520px; }
+.deck-sidebar {
+  width: 230px; flex-shrink: 0; border-right: var(--border-soft);
+  padding: 0.8rem; display: flex; flex-direction: column; gap: 0.45rem;
+  background: rgba(6, 28, 48, 0.55);
+}
+.deck-sidebar h4 {
+  display: flex; align-items: center; justify-content: space-between;
+  color: var(--ocean-300); font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.1em;
+}
+.chart-btn {
+  font-size: 0.72rem; color: #fff; background: var(--ocean-600); border: none; cursor: pointer;
+  border-radius: 6px; padding: 0.2rem 0.55rem; font-family: var(--font-sans);
+}
+.chart-btn:hover { background: var(--ocean-500); }
+.voyage-item {
+  text-align: left; display: flex; flex-direction: column; gap: 0.25rem;
+  background: transparent; border: 1px solid transparent; border-radius: 8px;
+  padding: 0.5rem 0.55rem; cursor: pointer; color: var(--ocean-100); font-family: var(--font-sans);
+}
+.voyage-item:hover { background: rgba(2, 132, 199, 0.14); }
+.voyage-item.active { border-color: rgba(56, 189, 248, 0.5); background: rgba(2, 132, 199, 0.2); }
+.voyage-item .t { font-size: 0.8rem; font-weight: 600; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.show-more { font-size: 0.72rem; color: var(--ocean-400); background: none; border: none; cursor: pointer; padding: 0.3rem; }
+
+.deck-main { flex: 1; min-width: 0; display: flex; flex-direction: column; }
+.deck-view { flex: 1; padding: 0.9rem; overflow-x: auto; display: none; }
+.deck-view.active { display: block; }
+
+/* Sea Chart */
+.sea-columns { display: grid; grid-template-columns: repeat(6, minmax(134px, 1fr)); gap: 0.5rem; min-width: 850px; }
+.sea-col {
+  background: rgba(8, 47, 73, 0.35); border: var(--border-soft); border-radius: var(--radius);
+  padding: 0.55rem; min-height: 270px;
+}
+.sea-col h5 {
+  font-size: 0.7rem; letter-spacing: 0.09em; text-transform: uppercase; color: var(--ocean-300);
+  display: flex; justify-content: space-between; margin-bottom: 0.55rem;
+}
+.sea-col h5 .count { color: var(--ocean-500); }
+.sea-card {
+  background: linear-gradient(180deg, rgba(12, 74, 110, 0.55), rgba(8, 47, 73, 0.75));
+  border: 1px solid rgba(3, 105, 161, 0.55); border-radius: 8px; padding: 0.6rem;
+  margin-bottom: 0.55rem; cursor: pointer; transition: border-color 0.15s ease, transform 0.25s ease;
+}
+.sea-card:hover { border-color: rgba(56, 189, 248, 0.7); }
+.sea-card.pulse { animation: cardIn 0.45s ease; }
+@keyframes cardIn { from { transform: translateY(6px); opacity: 0.3; } to { transform: none; opacity: 1; } }
+.sea-card .t { font-size: 0.78rem; font-weight: 600; color: #fff; margin-bottom: 0.4rem; }
+.progress { height: 4px; border-radius: 4px; background: rgba(3, 105, 161, 0.4); overflow: hidden; margin: 0.45rem 0; }
+.progress span { display: block; height: 100%; background: var(--emerald); width: 0; transition: width 0.5s ease; }
+.phase-chips { display: flex; gap: 0.25rem; flex-wrap: wrap; margin: 0.35rem 0; }
+.phase-chip {
+  font-family: var(--font-mono); font-size: 0.62rem; padding: 0.06rem 0.4rem; border-radius: 5px;
+  border: 1px solid rgba(3, 105, 161, 0.5); color: var(--ocean-300);
+}
+.phase-chip.BUILDING { color: var(--amber); border-color: rgba(251, 191, 36, 0.5); }
+.phase-chip.BUILT { color: var(--emerald); border-color: rgba(52, 211, 153, 0.5); }
+.phase-chip.FAILED { color: var(--rose); border-color: rgba(251, 113, 133, 0.5); }
+.sea-card .meta { display: flex; justify-content: space-between; align-items: center; font-size: 0.66rem; color: var(--ocean-400); }
+.terminal-strip { margin-top: 0.8rem; border-top: var(--border-soft); padding-top: 0.6rem; min-width: 850px; }
+.terminal-strip summary { cursor: pointer; font-size: 0.74rem; color: var(--ocean-400); }
+.terminal-cards { display: flex; gap: 0.55rem; margin-top: 0.55rem; flex-wrap: wrap; }
+.terminal-cards .sea-card { width: 230px; margin: 0; }
+
+/* Crew Map */
+.crewmap-wrap { position: relative; }
+svg.crewmap { width: 100%; height: auto; display: block; }
+.cm-node circle { fill: rgba(12, 74, 110, 0.85); stroke: var(--ocean-700); stroke-width: 2; transition: stroke 0.2s ease; }
+.cm-node.active circle { stroke: var(--ocean-300); filter: drop-shadow(0 0 8px rgba(56, 189, 248, 0.65)); }
+.cm-node text { fill: var(--ocean-100); font-family: var(--font-sans); }
+.cm-node .emoji { font-size: 22px; }
+.cm-node .label { font-size: 11px; fill: var(--ocean-300); }
+.cm-edge { stroke: rgba(3, 105, 161, 0.7); stroke-width: 2; fill: none; }
+.cm-edge.flash { stroke: var(--cyan); filter: drop-shadow(0 0 6px rgba(103, 232, 249, 0.7)); }
+.cm-dot { fill: var(--cyan); }
+.cm-activity { font-family: var(--font-mono); font-size: 10.5px; fill: var(--amber-soft); }
+.cm-count { font-family: var(--font-mono); font-size: 10px; fill: #04101f; font-weight: 700; }
+.cm-count-bg { fill: var(--amber); }
+.cm-legend { display: flex; gap: 0.9rem; flex-wrap: wrap; padding: 0.6rem 0.2rem 0; font-size: 0.72rem; color: var(--ocean-300); }
+.cm-legend b { color: #fff; font-family: var(--font-mono); }
+
+/* Ship's Log */
+.log-toolbar { display: flex; gap: 0.45rem; flex-wrap: wrap; align-items: center; margin-bottom: 0.7rem; }
+.log-search {
+  background: rgba(8, 47, 73, 0.6); border: var(--border-soft); color: var(--ocean-100);
+  border-radius: 8px; padding: 0.38rem 0.7rem; font-size: 0.8rem; width: 200px; font-family: var(--font-sans);
+}
+.log-search::placeholder { color: var(--ocean-500); }
+.filter-chip {
+  font-size: 0.72rem; padding: 0.26rem 0.65rem; border-radius: 999px; cursor: pointer;
+  border: var(--border-soft); background: transparent; color: var(--ocean-300); font-family: var(--font-sans);
+}
+.filter-chip.on { background: rgba(2, 132, 199, 0.3); border-color: rgba(56, 189, 248, 0.55); color: #fff; }
+.log-rows { display: flex; flex-direction: column; gap: 0.2rem; max-height: 380px; overflow-y: auto; }
+.log-row {
+  display: grid; grid-template-columns: 84px 96px 1fr auto; gap: 0.6rem; align-items: baseline;
+  font-size: 0.78rem; padding: 0.4rem 0.55rem; border-radius: 7px; border: 1px solid transparent;
+}
+.log-row:hover { background: rgba(2, 132, 199, 0.12); border-color: rgba(3, 105, 161, 0.4); }
+.log-row.new { animation: cardIn 0.4s ease; }
+.log-row .ts { font-family: var(--font-mono); font-size: 0.68rem; color: var(--ocean-500); }
+.log-row .sum { color: var(--ocean-100); }
+.log-row .at { font-family: var(--font-mono); font-size: 0.64rem; color: var(--ocean-500); white-space: nowrap; }
+.log-row.fail .sum { color: var(--rose-soft); }
+.role-badge {
+  font-family: var(--font-mono); font-size: 0.64rem; padding: 0.1rem 0.45rem; border-radius: 5px;
+  text-align: center; white-space: nowrap;
+}
+.rb-captain    { background: rgba(56, 189, 248, 0.18); color: var(--ocean-300); border: 1px solid rgba(56, 189, 248, 0.4); }
+.rb-navigator  { background: rgba(165, 180, 252, 0.14); color: var(--indigo); border: 1px solid rgba(165, 180, 252, 0.4); }
+.rb-doctor     { background: rgba(52, 211, 153, 0.12); color: var(--emerald); border: 1px solid rgba(52, 211, 153, 0.4); }
+.rb-shipwright { background: rgba(251, 191, 36, 0.12); color: var(--amber-soft); border: 1px solid rgba(251, 191, 36, 0.4); }
+.rb-helmsman   { background: rgba(103, 232, 249, 0.12); color: var(--cyan); border: 1px solid rgba(103, 232, 249, 0.4); }
+.rb-system     { background: rgba(125, 211, 252, 0.1); color: var(--ocean-400); border: 1px solid rgba(3, 105, 161, 0.5); }
+
+/* Deck footer: interventions + playback */
+.deck-footer {
+  border-top: var(--border-soft); padding: 0.6rem 1rem;
+  display: flex; align-items: center; gap: 0.9rem; flex-wrap: wrap; background: rgba(8, 47, 73, 0.35);
+}
+.iv-btn {
+  font-size: 0.78rem; padding: 0.34rem 0.8rem; border-radius: 8px; cursor: pointer;
+  border: var(--border-soft); background: rgba(12, 74, 110, 0.5); color: var(--ocean-100);
+  font-family: var(--font-sans);
+}
+.iv-btn:hover:not(:disabled) { border-color: var(--ocean-300); color: #fff; }
+.iv-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+.iv-btn.danger { border-color: rgba(251, 113, 133, 0.45); color: var(--rose-soft); }
+.iv-btn.danger:hover:not(:disabled) { border-color: var(--rose); }
+.iv-btn.primary { background: var(--ocean-500); border-color: var(--ocean-500); color: #fff; font-weight: 600; }
+.iv-btn.primary:hover:not(:disabled) { background: var(--ocean-400); }
+.playback { display: flex; align-items: center; gap: 0.55rem; flex: 1; min-width: 220px; }
+.playback input[type="range"] { flex: 1; accent-color: var(--ocean-400); }
+.playback .pt { font-family: var(--font-mono); font-size: 0.66rem; color: var(--ocean-500); white-space: nowrap; }
+.speed-btn { min-width: 44px; }
+
+/* Details drawer */
+.drawer {
+  position: absolute; top: 0; right: 0; bottom: 0; width: 300px; z-index: 30;
+  background: linear-gradient(180deg, #0a3a5c, #07273f);
+  border-left: var(--border); padding: 0.9rem; overflow-y: auto;
+  transform: translateX(105%); transition: transform 0.25s ease;
+}
+.drawer.open { transform: none; }
+.drawer-head { display: flex; justify-content: space-between; align-items: center; margin-bottom: 0.7rem; color: #fff; font-size: 0.9rem; }
+.drawer-tabs { display: flex; gap: 0.3rem; margin-bottom: 0.8rem; }
+.drawer-tab {
+  font-size: 0.72rem; color: var(--ocean-300); background: transparent; border: var(--border-soft);
+  border-radius: 7px; padding: 0.25rem 0.6rem; cursor: pointer; font-family: var(--font-sans);
+}
+.drawer-tab.active { background: rgba(2, 132, 199, 0.3); color: #fff; }
+.kv { display: grid; grid-template-columns: auto 1fr; gap: 0.35rem 0.8rem; font-size: 0.78rem; margin-bottom: 0.9rem; }
+.kv dt { color: var(--ocean-400); }
+.kv dd { color: var(--ocean-100); }
+.kv-table { width: 100%; border-collapse: collapse; font-size: 0.76rem; }
+.kv-table td { padding: 0.3rem 0.4rem; border-bottom: 1px solid rgba(3, 105, 161, 0.2); color: var(--ocean-200); }
+.failure-box {
+  margin-top: 0.8rem; border: 1px solid rgba(251, 113, 133, 0.45); background: rgba(251, 113, 133, 0.08);
+  color: var(--rose-soft); font-size: 0.76rem; padding: 0.6rem 0.7rem; border-radius: 8px;
+}
+.deck-body { position: relative; overflow: hidden; }
+.deck-body.focus .deck-sidebar { display: none; }
+
+/* Modals & toasts */
+.modal-backdrop {
+  position: fixed; inset: 0; background: rgba(2, 8, 23, 0.7); backdrop-filter: blur(3px);
+  display: none; align-items: center; justify-content: center; z-index: 100; padding: 1rem;
+}
+.modal-backdrop.open { display: flex; }
+.modal {
+  background: linear-gradient(180deg, #0a3a5c, var(--ocean-950));
+  border: var(--border); border-radius: var(--radius-lg); padding: 1.4rem; max-width: 460px; width: 100%;
+  box-shadow: var(--shadow);
+}
+.modal h3 { color: #fff; font-size: 1.05rem; margin-bottom: 0.5rem; }
+.modal p { color: var(--ocean-300); font-size: 0.86rem; margin-bottom: 0.9rem; }
+.modal textarea, .modal input[type="text"] {
+  width: 100%; background: rgba(4, 16, 31, 0.7); border: var(--border-soft); border-radius: 8px;
+  color: var(--ocean-100); padding: 0.6rem 0.7rem; font-size: 0.85rem; font-family: var(--font-sans);
+  resize: vertical; margin-bottom: 0.9rem;
+}
+.modal .row { display: flex; gap: 0.6rem; justify-content: flex-end; align-items: center; }
+.modal label { display: flex; gap: 0.45rem; align-items: center; font-size: 0.8rem; color: var(--ocean-200); margin-bottom: 0.9rem; }
+
+.toast-stack { position: fixed; right: 1rem; bottom: 1rem; display: flex; flex-direction: column; gap: 0.5rem; z-index: 120; }
+.toast {
+  background: linear-gradient(180deg, #0a3a5c, #082f49); border: var(--border); border-radius: 10px;
+  padding: 0.6rem 0.9rem; font-size: 0.8rem; color: var(--ocean-100); box-shadow: var(--shadow);
+  max-width: 340px; animation: cardIn 0.3s ease;
+}
+.toast b { color: #fff; }
+.toast .sub { color: var(--ocean-400); font-size: 0.7rem; font-family: var(--font-mono); }
+
+/* Command palette */
+.palette {
+  position: fixed; inset: 0; z-index: 110; display: none; align-items: flex-start; justify-content: center;
+  background: rgba(2, 8, 23, 0.6); padding-top: 14vh;
+}
+.palette.open { display: flex; }
+.palette-box { width: min(520px, 92vw); background: #0a3050; border: var(--border); border-radius: 12px; overflow: hidden; box-shadow: var(--shadow); }
+.palette-box input {
+  width: 100%; background: transparent; border: none; border-bottom: var(--border-soft);
+  padding: 0.85rem 1rem; color: #fff; font-size: 0.95rem; font-family: var(--font-sans); outline: none;
+}
+.palette-list { max-height: 280px; overflow-y: auto; padding: 0.4rem; }
+.palette-item {
+  display: flex; justify-content: space-between; width: 100%; background: none; border: none;
+  padding: 0.55rem 0.7rem; border-radius: 8px; color: var(--ocean-100); font-size: 0.85rem; cursor: pointer;
+  font-family: var(--font-sans); text-align: left;
+}
+.palette-item:hover, .palette-item.sel { background: rgba(2, 132, 199, 0.25); color: #fff; }
+.kbd {
+  font-family: var(--font-mono); font-size: 0.66rem; color: var(--ocean-300);
+  border: 1px solid rgba(125, 211, 252, 0.35); border-bottom-width: 2px; border-radius: 5px; padding: 0.06rem 0.4rem;
+}
+
+/* --------------------------------------------------------------------------
+   Dial System section
+   -------------------------------------------------------------------------- */
+.dial-grid { display: grid; grid-template-columns: 1.25fr 1fr; gap: 1.2rem; align-items: start; }
+.dial-table { width: 100%; border-collapse: collapse; font-size: 0.82rem; }
+.dial-table th {
+  text-align: left; color: var(--ocean-400); font-size: 0.68rem; text-transform: uppercase;
+  letter-spacing: 0.09em; padding: 0.5rem 0.6rem; border-bottom: var(--border-soft);
+}
+.dial-table td { padding: 0.55rem 0.6rem; border-bottom: 1px solid rgba(3, 105, 161, 0.18); vertical-align: middle; }
+.provider-chip {
+  display: inline-flex; align-items: center; gap: 0.35rem; font-family: var(--font-mono); font-size: 0.72rem;
+  padding: 0.18rem 0.55rem; border-radius: 6px; border: 1px solid rgba(3, 105, 161, 0.55);
+  background: rgba(8, 47, 73, 0.6); color: var(--ocean-200);
+}
+.provider-chip .pd { width: 7px; height: 7px; border-radius: 50%; background: var(--emerald); }
+.provider-chip.down .pd { background: var(--rose); }
+.provider-chip.down { color: var(--rose-soft); border-color: rgba(251, 113, 133, 0.45); text-decoration: line-through; }
+.fallback-arrow { color: var(--ocean-600); margin: 0 0.25rem; }
+.dial-events { display: flex; flex-direction: column; gap: 0.45rem; max-height: 280px; overflow-y: auto; }
+.dial-event {
+  font-family: var(--font-mono); font-size: 0.72rem; color: var(--ocean-200);
+  border-left: 3px solid var(--ocean-600); padding: 0.35rem 0.6rem; background: rgba(8, 47, 73, 0.4);
+  border-radius: 0 7px 7px 0; animation: cardIn 0.3s ease;
+}
+.dial-event.warn { border-left-color: var(--amber); }
+.dial-event.ok { border-left-color: var(--emerald); }
+
+/* --------------------------------------------------------------------------
+   Architecture / internals
+   -------------------------------------------------------------------------- */
+.arch-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(255px, 1fr)); gap: 1rem; }
+.arch-card h3 { color: #fff; font-size: 1rem; display: flex; align-items: center; gap: 0.5rem; margin-bottom: 0.45rem; }
+.arch-card p { color: var(--ocean-200); font-size: 0.85rem; }
+.arch-card .chips { margin-top: 0.7rem; display: flex; flex-wrap: wrap; gap: 0.3rem; }
+
+.tiers { display: grid; grid-template-columns: repeat(auto-fit, minmax(230px, 1fr)); gap: 1rem; margin-top: 1.6rem; }
+.tier h4 { color: #fff; font-size: 0.95rem; margin-bottom: 0.3rem; }
+.tier .trig { font-size: 0.76rem; color: var(--ocean-300); }
+.tier .gate { margin-top: 0.55rem; font-size: 0.72rem; color: var(--amber-soft); font-family: var(--font-mono); }
+
+/* API table */
+.api-table { width: 100%; border-collapse: collapse; font-size: 0.8rem; }
+.api-table td { padding: 0.42rem 0.6rem; border-bottom: 1px solid rgba(3, 105, 161, 0.18); }
+.api-table .m { font-family: var(--font-mono); font-weight: 700; width: 70px; }
+.m-GET { color: var(--emerald); } .m-POST { color: var(--ocean-400); } .m-PUT { color: var(--amber); }
+.m-WS { color: var(--violet); } .m-SSE { color: var(--cyan); }
+.api-table .p { font-family: var(--font-mono); color: var(--ocean-100); }
+.api-table .d { color: var(--ocean-400); font-size: 0.74rem; }
+.api-cols { display: grid; grid-template-columns: 1fr 1fr; gap: 1.2rem; align-items: start; }
+
+/* Footer */
+footer { border-top: var(--border-soft); padding: 2.6rem 0 3rem; text-align: center; }
+footer .tag { color: var(--ocean-300); font-size: 1rem; margin-bottom: 0.8rem; font-weight: 600; }
+footer .links { display: flex; gap: 1.2rem; justify-content: center; flex-wrap: wrap; font-size: 0.85rem; margin-bottom: 0.9rem; }
+footer .fine { color: var(--ocean-600); font-size: 0.76rem; }
+
+/* Responsive */
+@media (max-width: 980px) {
+  .dial-grid, .api-cols { grid-template-columns: 1fr; }
+}
+@media (max-width: 760px) {
+  .deck-sidebar { display: none; }
+  .nav-links a:not(.nav-cta) { display: none; }
+  .deck-mobile-note { display: block; }
+}
+.deck-mobile-note {
+  display: none; background: rgba(251, 191, 36, 0.08); border: 1px solid rgba(251, 191, 36, 0.35);
+  color: var(--amber-soft); font-size: 0.74rem; padding: 0.5rem 0.8rem; border-radius: 8px; margin-bottom: 0.8rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after { animation-duration: 0.001ms !important; transition-duration: 0.001ms !important; }
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -8,6 +8,8 @@
   <meta property="og:title" content="GrandLine — Multi-Agent Orchestration Platform">
   <meta property="og:description" content="Watch an AI crew plan, test, build, validate and deploy software — live on the Observation Deck. Interactive mockup with simulated data.">
   <meta property="og:type" content="website">
+  <meta property="og:url" content="https://harshal2802.github.io/GrandLine/">
+  <link rel="canonical" href="https://harshal2802.github.io/GrandLine/">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>⚓</text></svg>">
   <link rel="stylesheet" href="./assets/styles.css">
 </head>

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,106 +3,600 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>GrandLine Documentation</title>
-  <style>
-    :root {
-      --ocean-50: #f0f9ff;
-      --ocean-100: #e0f2fe;
-      --ocean-300: #7dd3fc;
-      --ocean-400: #38bdf8;
-      --ocean-700: #0369a1;
-      --ocean-800: #075985;
-      --ocean-900: #0c4a6e;
-      --ocean-950: #082f49;
-    }
-    * { margin: 0; padding: 0; box-sizing: border-box; }
-    body {
-      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-      background: var(--ocean-950);
-      color: var(--ocean-100);
-      min-height: 100vh;
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      padding: 4rem 1rem;
-    }
-    h1 { font-size: 2.5rem; margin-bottom: 0.5rem; }
-    .subtitle { color: var(--ocean-300); font-size: 1.1rem; margin-bottom: 3rem; }
-    .sections {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-      gap: 1.5rem;
-      max-width: 800px;
-      width: 100%;
-    }
-    .card {
-      background: var(--ocean-900);
-      border: 1px solid var(--ocean-700);
-      border-radius: 8px;
-      padding: 1.5rem;
-    }
-    .card h2 { font-size: 1.2rem; margin-bottom: 0.5rem; color: var(--ocean-50); }
-    .card p { color: var(--ocean-300); font-size: 0.9rem; line-height: 1.5; }
-    .badge {
-      display: inline-block;
-      background: var(--ocean-800);
-      color: var(--ocean-300);
-      padding: 0.2rem 0.6rem;
-      border-radius: 4px;
-      font-size: 0.75rem;
-      margin-top: 0.75rem;
-    }
-    footer {
-      margin-top: 4rem;
-      color: var(--ocean-700);
-      font-size: 0.85rem;
-    }
-  </style>
+  <title>GrandLine — Assemble your crew. Navigate the GrandLine.</title>
+  <meta name="description" content="GrandLine is a multi-agent orchestration platform where a crew of persona-based AI agents — Captain, Navigator, Doctor, Shipwrights, Helmsman — voyage through a disciplined PDD → TDD → Build → Review → Deploy pipeline. Interactive product mockup.">
+  <meta property="og:title" content="GrandLine — Multi-Agent Orchestration Platform">
+  <meta property="og:description" content="Watch an AI crew plan, test, build, validate and deploy software — live on the Observation Deck. Interactive mockup with simulated data.">
+  <meta property="og:type" content="website">
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>⚓</text></svg>">
+  <link rel="stylesheet" href="./assets/styles.css">
 </head>
 <body>
-  <h1>GrandLine</h1>
-  <p class="subtitle">Multi-Agent Orchestration Platform Documentation</p>
 
-  <div class="sections">
-    <div class="card">
-      <h2>The Crew</h2>
-      <p>Captain (PM), Navigator (Architect), Shipwrights (Devs), Doctor (QA), Helmsman (DevOps) — persona-based AI agents that voyage together.</p>
-      <span class="badge">Coming soon</span>
+  <!-- ================= NAV ================= -->
+  <nav class="nav">
+    <div class="nav-inner">
+      <a class="brand" href="#top"><span class="anchor">⚓</span> GrandLine</a>
+      <span class="mock-tag">Interactive mockup</span>
+      <div class="nav-links">
+        <a href="#crew">The Crew</a>
+        <a href="#pipeline">Pipeline</a>
+        <a href="#deck">Observation Deck</a>
+        <a href="#dial">Dial System</a>
+        <a href="#platform">Platform</a>
+        <a href="#api">API</a>
+        <a href="https://github.com/harshal2802/GrandLine" target="_blank" rel="noopener">GitHub</a>
+        <a class="nav-cta" href="#deck">Launch the demo</a>
+      </div>
     </div>
+  </nav>
 
-    <div class="card">
-      <h2>Observation Deck</h2>
-      <p>Real-time war room UI with Sea Chart (board), Crew Map (DAG), and Ship's Log (timeline) views.</p>
-      <span class="badge">Coming soon</span>
+  <!-- ================= HERO ================= -->
+  <header class="hero" id="top">
+    <div class="container">
+      <h1>Assemble your crew.<br><span class="accent">Navigate the GrandLine.</span></h1>
+      <p class="sub">A multi-agent orchestration platform where persona-based AI agents voyage through a disciplined
+        pipeline to build, test, and deploy software — observable end-to-end, interruptible at any moment.</p>
+      <div class="hero-ctas">
+        <a class="btn btn-primary" href="#deck">▶ Watch a voyage run</a>
+        <a class="btn btn-ghost" href="https://github.com/harshal2802/GrandLine" target="_blank" rel="noopener">View on GitHub</a>
+      </div>
+      <div class="hero-badges">
+        <span class="pill">PDD → TDD → Build → Review → Deploy</span>
+        <span class="pill">5 persona agents</span>
+        <span class="pill">Provider-agnostic LLM gateway</span>
+        <span class="pill">Real git branches per agent</span>
+        <span class="pill">Sandboxed execution</span>
+        <span class="pill">No work lost — Vivre Cards</span>
+      </div>
     </div>
+    <svg class="hero-waves" viewBox="0 0 1440 110" preserveAspectRatio="none" aria-hidden="true">
+      <path d="M0,60 C240,110 480,10 720,55 C960,100 1200,20 1440,60 L1440,110 L0,110 Z" fill="rgba(14,165,233,0.10)"/>
+      <path d="M0,80 C260,30 520,105 780,70 C1040,35 1240,95 1440,75 L1440,110 L0,110 Z" fill="rgba(2,132,199,0.14)"/>
+    </svg>
+  </header>
 
-    <div class="card">
-      <h2>Dial System</h2>
-      <p>Provider-agnostic LLM gateway with config-driven role mapping and automatic failover via Vivre Card checkpoints.</p>
-      <span class="badge">Coming soon</span>
+  <!-- ================= CREW ================= -->
+  <section id="crew">
+    <div class="container">
+      <div class="section-head">
+        <div class="kicker">The Crew</div>
+        <h2>Five specialists. Zero god agents.</h2>
+        <p>Each crew member has one job in the voyage pipeline — and every action they take is logged,
+          checkpointed, and observable. No freestyle.</p>
+      </div>
+      <div class="crew-grid">
+        <div class="card crew-card">
+          <div class="crew-emoji">⚓</div>
+          <h3>Captain</h3>
+          <div class="crew-role">Project Manager</div>
+          <p>Decomposes your mission into a voyage plan — ordered phases with dependencies, crew assignments, and artifacts. Validates the dependency graph (cycle detection included).</p>
+          <div class="crew-meta"><span class="chip">voyage_plan_created</span></div>
+        </div>
+        <div class="card crew-card">
+          <div class="crew-emoji">🧭</div>
+          <h3>Navigator</h3>
+          <div class="crew-role">Architect</div>
+          <p>Drafts the Poneglyphs — encoded PDD prompt artifacts with constraints, file paths, and test criteria that guide every downstream step.</p>
+          <div class="crew-meta"><span class="chip">poneglyph_drafted</span></div>
+        </div>
+        <div class="card crew-card">
+          <div class="crew-emoji">🩺</div>
+          <h3>Doctor</h3>
+          <div class="crew-role">QA Engineer</div>
+          <p>Writes failing health checks <em>before</em> any code exists (TDD), then re-validates the whole build in a clean sandbox afterwards.</p>
+          <div class="crew-meta"><span class="chip">health_check_written</span> <span class="chip">validation_passed</span></div>
+        </div>
+        <div class="card crew-card">
+          <div class="crew-emoji">🔨</div>
+          <h3>Shipwrights</h3>
+          <div class="crew-role">Developers</div>
+          <p>Build the code, following Poneglyphs precisely. Iterate against the Doctor's tests until green — in parallel across independent phases, each on its own git branch.</p>
+          <div class="crew-meta"><span class="chip">code_generated</span> <span class="chip">tests_passed</span></div>
+        </div>
+        <div class="card crew-card">
+          <div class="crew-emoji">⚙️</div>
+          <h3>Helmsman</h3>
+          <div class="crew-role">DevOps Engineer</div>
+          <p>Deploys across three tiers — auto preview, semi-auto staging, approval-gated production — with rollback per tier and root-cause diagnosis on failure.</p>
+          <div class="crew-meta"><span class="chip">deployment_completed</span></div>
+        </div>
+      </div>
     </div>
+  </section>
 
-    <div class="card">
-      <h2>API Reference</h2>
-      <p>REST + SSE + WebSocket API documentation. Auto-generated from FastAPI OpenAPI spec.</p>
-      <span class="badge">Coming soon</span>
+  <!-- ================= PIPELINE ================= -->
+  <section id="pipeline">
+    <div class="container">
+      <div class="section-head">
+        <div class="kicker">The Voyage Pipeline</div>
+        <h2>One state machine. No shortcuts.</h2>
+        <p>Every voyage moves through enforced stage transitions with guards — you can't enter BUILDING until the Doctor's tests exist.</p>
+      </div>
+      <div class="pipeline-flow" id="pipeline-flow">
+        <div class="stage"><span class="glyph st-CHARTED">○</span><span class="name">CHARTED</span><span class="who">you</span></div>
+        <span class="flow-arrow">→</span>
+        <div class="stage"><span class="glyph st-PLANNING">◔</span><span class="name">PLANNING</span><span class="who">⚓ Captain</span></div>
+        <span class="flow-arrow">→</span>
+        <div class="stage"><span class="glyph st-PDD">◑</span><span class="name">PDD</span><span class="who">🧭 Navigator</span></div>
+        <span class="flow-arrow">→</span>
+        <div class="stage"><span class="glyph st-TDD">◑</span><span class="name">TDD</span><span class="who">🩺 Doctor</span></div>
+        <span class="flow-arrow">→</span>
+        <div class="stage"><span class="glyph st-BUILDING">◕</span><span class="name">BUILDING</span><span class="who">🔨 Shipwrights</span></div>
+        <span class="flow-arrow">→</span>
+        <div class="stage"><span class="glyph st-REVIEWING">◕</span><span class="name">REVIEWING</span><span class="who">🩺 Doctor</span></div>
+        <span class="flow-arrow">→</span>
+        <div class="stage"><span class="glyph st-DEPLOYING">◕</span><span class="name">DEPLOYING</span><span class="who">⚙️ Helmsman</span></div>
+        <span class="flow-arrow">→</span>
+        <div class="stage"><span class="glyph st-COMPLETED">●</span><span class="name">COMPLETED</span><span class="who">🏴‍☠️</span></div>
+      </div>
+      <div class="side-states">
+        <span class="badge st-PAUSED"><span class="g">❚❚</span>PAUSED — resumable from any stage</span>
+        <span class="badge st-FAILED"><span class="g">✕</span>FAILED — Vivre Card preserved</span>
+        <span class="badge st-CANCELLED"><span class="g">⊘</span>CANCELLED — graceful shutdown</span>
+      </div>
+      <p class="pipeline-quote">“PDD and TDD aren't optional — they're the Log Pose. Without them, the crew doesn't sail.”</p>
     </div>
+  </section>
 
-    <div class="card">
-      <h2>Deployment</h2>
-      <p>Docker Compose (local-first) and Kubernetes + Helm (production) deployment guides.</p>
-      <span class="badge">Coming soon</span>
+  <!-- ================= OBSERVATION DECK (interactive demo) ================= -->
+  <section id="deck">
+    <div class="container">
+      <div class="section-head">
+        <div class="kicker">The Observation Deck</div>
+        <h2>Your real-time war room</h2>
+        <p>Watch the voyage unfold across three live views — then step in like a fleet admiral.
+          This demo runs a scripted voyage entirely in your browser.</p>
+      </div>
+
+      <div class="deck-mobile-note">⚓ The Observation Deck is desktop-optimized — rotate or widen your screen for the full war room.</div>
+
+      <div class="deck-frame">
+        <!-- top bar -->
+        <div class="deck-topbar">
+          <span class="deck-title">⚓ Observation Deck</span>
+          <div class="deck-tabs" role="tablist">
+            <button class="deck-tab active" data-view="sea">Sea Chart</button>
+            <button class="deck-tab" data-view="map">Crew Map</button>
+            <button class="deck-tab" data-view="log">Ship's Log</button>
+          </div>
+          <div class="deck-top-right">
+            <span class="conn live" id="conn-chip"><span class="dot"></span><span id="conn-label">Idle</span><span class="transport" id="conn-transport">· ws</span></span>
+            <button class="iv-btn" id="palette-open" title="Command palette">⌘K</button>
+            <button class="iv-btn" id="speed-btn" title="Demo speed">1×</button>
+            <button class="iv-btn primary" id="sail-btn">⛵ Set Sail</button>
+          </div>
+        </div>
+
+        <div class="deck-body" id="deck-body">
+          <!-- sidebar -->
+          <aside class="deck-sidebar">
+            <h4>Voyages <button class="chart-btn" id="chart-open">+ Chart</button></h4>
+            <div id="voyage-list"></div>
+            <button class="show-more">Show more voyages…</button>
+          </aside>
+
+          <!-- main -->
+          <div class="deck-main">
+            <!-- Sea Chart -->
+            <div class="deck-view active" id="view-sea">
+              <div class="sea-columns">
+                <div class="sea-col" id="col-planning"><h5>Planning <span class="count">0</span></h5><div class="cards"></div></div>
+                <div class="sea-col" id="col-pdd"><h5>PDD <span class="count">0</span></h5><div class="cards"></div></div>
+                <div class="sea-col" id="col-tdd"><h5>TDD <span class="count">0</span></h5><div class="cards"></div></div>
+                <div class="sea-col" id="col-building"><h5>Building <span class="count">0</span></h5><div class="cards"></div></div>
+                <div class="sea-col" id="col-reviewing"><h5>Reviewing <span class="count">0</span></h5><div class="cards"></div></div>
+                <div class="sea-col" id="col-deploying"><h5>Deploying <span class="count">0</span></h5><div class="cards"></div></div>
+              </div>
+              <details class="terminal-strip" open>
+                <summary>Completed &amp; Failed (<span id="terminal-count">0</span>)</summary>
+                <div class="terminal-cards" id="terminal-cards"></div>
+              </details>
+            </div>
+
+            <!-- Crew Map -->
+            <div class="deck-view" id="view-map">
+              <div class="crewmap-wrap">
+                <svg class="crewmap" viewBox="0 0 900 240" aria-label="Live DAG of crew agents communicating via Den Den Mushi">
+                  <!-- edges -->
+                  <path class="cm-edge" data-edge="captain-navigator"   d="M 90 110 Q 180 84 270 110"/>
+                  <path class="cm-edge" data-edge="navigator-doctor"    d="M 270 110 Q 360 84 450 110"/>
+                  <path class="cm-edge" data-edge="doctor-shipwright"   d="M 450 110 Q 540 84 630 110"/>
+                  <path class="cm-edge" data-edge="shipwright-helmsman" d="M 630 110 Q 720 84 810 110"/>
+                  <path class="cm-edge" data-edge="helmsman-captain"    d="M 810 110 Q 450 225 90 110"/>
+                  <circle id="cm-dot" class="cm-dot" r="5" cx="90" cy="110" opacity="0"/>
+                  <!-- activity label -->
+                  <text id="cm-activity" class="cm-activity" x="90" y="52" text-anchor="middle" opacity="0"></text>
+                  <!-- nodes -->
+                  <g class="cm-node" data-role="captain">
+                    <circle cx="90" cy="110" r="34"/>
+                    <text class="emoji" x="90" y="118" text-anchor="middle">⚓</text>
+                    <text class="label" x="90" y="166" text-anchor="middle">captain</text>
+                    <circle class="cm-count-bg" data-role="captain" cx="116" cy="86" r="11" opacity="0"/>
+                    <text class="cm-count" data-role="captain" x="116" y="90" text-anchor="middle" opacity="0">0</text>
+                  </g>
+                  <g class="cm-node" data-role="navigator">
+                    <circle cx="270" cy="110" r="34"/>
+                    <text class="emoji" x="270" y="118" text-anchor="middle">🧭</text>
+                    <text class="label" x="270" y="166" text-anchor="middle">navigator</text>
+                    <circle class="cm-count-bg" data-role="navigator" cx="296" cy="86" r="11" opacity="0"/>
+                    <text class="cm-count" data-role="navigator" x="296" y="90" text-anchor="middle" opacity="0">0</text>
+                  </g>
+                  <g class="cm-node" data-role="doctor">
+                    <circle cx="450" cy="110" r="34"/>
+                    <text class="emoji" x="450" y="118" text-anchor="middle">🩺</text>
+                    <text class="label" x="450" y="166" text-anchor="middle">doctor</text>
+                    <circle class="cm-count-bg" data-role="doctor" cx="476" cy="86" r="11" opacity="0"/>
+                    <text class="cm-count" data-role="doctor" x="476" y="90" text-anchor="middle" opacity="0">0</text>
+                  </g>
+                  <g class="cm-node" data-role="shipwright">
+                    <circle cx="630" cy="110" r="34"/>
+                    <text class="emoji" x="630" y="118" text-anchor="middle">🔨</text>
+                    <text class="label" x="630" y="166" text-anchor="middle">shipwright</text>
+                    <circle class="cm-count-bg" data-role="shipwright" cx="656" cy="86" r="11" opacity="0"/>
+                    <text class="cm-count" data-role="shipwright" x="656" y="90" text-anchor="middle" opacity="0">0</text>
+                  </g>
+                  <g class="cm-node" data-role="helmsman">
+                    <circle cx="810" cy="110" r="34"/>
+                    <text class="emoji" x="810" y="118" text-anchor="middle">⚙️</text>
+                    <text class="label" x="810" y="166" text-anchor="middle">helmsman</text>
+                    <circle class="cm-count-bg" data-role="helmsman" cx="836" cy="86" r="11" opacity="0"/>
+                    <text class="cm-count" data-role="helmsman" x="836" y="90" text-anchor="middle" opacity="0">0</text>
+                  </g>
+                </svg>
+                <div class="cm-legend">
+                  <span>⚓ captain <b id="count-captain">0</b></span>
+                  <span>🧭 navigator <b id="count-navigator">0</b></span>
+                  <span>🩺 doctor <b id="count-doctor">0</b></span>
+                  <span>🔨 shipwright <b id="count-shipwright">0</b></span>
+                  <span>⚙️ helmsman <b id="count-helmsman">0</b></span>
+                  <span style="margin-left:auto">events on <code>grandline:events:vg-7f3a2c91</code>: <b id="cm-total">0</b></span>
+                </div>
+              </div>
+            </div>
+
+            <!-- Ship's Log -->
+            <div class="deck-view" id="view-log">
+              <div class="log-toolbar">
+                <input class="log-search" id="log-search" type="text" placeholder="Search the log…  ( / )">
+                <button class="filter-chip" data-role="captain">⚓ captain</button>
+                <button class="filter-chip" data-role="navigator">🧭 navigator</button>
+                <button class="filter-chip" data-role="doctor">🩺 doctor</button>
+                <button class="filter-chip" data-role="shipwright">🔨 shipwright</button>
+                <button class="filter-chip" data-role="helmsman">⚙️ helmsman</button>
+                <button class="filter-chip" id="fail-only">✕ failures only</button>
+                <button class="filter-chip" id="clear-filters">clear</button>
+              </div>
+              <div class="log-rows" id="log-rows"></div>
+            </div>
+          </div>
+
+          <!-- details drawer -->
+          <aside class="drawer" id="drawer" aria-label="Voyage details">
+            <div class="drawer-head">
+              <b id="drawer-title">Voyage</b>
+              <button class="iv-btn" id="drawer-close">✕</button>
+            </div>
+            <div class="drawer-tabs">
+              <button class="drawer-tab active" data-pane="overview">Overview</button>
+              <button class="drawer-tab" data-pane="events">Events</button>
+              <button class="drawer-tab" data-pane="timestamps">Timestamps</button>
+            </div>
+            <div class="drawer-pane" id="pane-overview">
+              <dl class="kv">
+                <dt>Status</dt><dd id="d-status"></dd>
+                <dt>Active crew</dt><dd id="d-crew" class="mono"></dd>
+                <dt>Completed phases</dt><dd id="d-phases-done" class="mono"></dd>
+              </dl>
+              <table class="kv-table"><tbody id="d-phase-table"></tbody></table>
+              <div class="failure-box" id="d-failure" style="display:none"></div>
+            </div>
+            <div class="drawer-pane" id="pane-events" style="display:none">
+              <div class="dial-events" id="d-events"></div>
+            </div>
+            <div class="drawer-pane" id="pane-timestamps" style="display:none">
+              <dl class="kv">
+                <dt>First event</dt><dd id="d-first" class="mono"></dd>
+                <dt>Last activity</dt><dd id="d-last" class="mono"></dd>
+                <dt>Events buffered</dt><dd id="d-buffered" class="mono"></dd>
+              </dl>
+            </div>
+          </aside>
+        </div>
+
+        <!-- footer: interventions + playback -->
+        <div class="deck-footer">
+          <button class="iv-btn" id="iv-pause">❚❚ Pause</button>
+          <button class="iv-btn" id="iv-resume" style="display:none">▶ Resume</button>
+          <button class="iv-btn" id="iv-inject">✎ Inject context</button>
+          <button class="iv-btn danger" id="iv-cancel">✕ Cancel</button>
+          <div class="playback">
+            <span class="pt" id="pt-start">—</span>
+            <input type="range" id="scrubber" min="0" max="100" value="100" disabled aria-label="Playback scrubber">
+            <span class="pt" id="pt-end">live</span>
+            <button class="iv-btn" id="return-live" style="display:none">▶ Return to live</button>
+          </div>
+        </div>
+      </div>
+      <p class="deck-note">Interactive mockup — every event is simulated in your browser using the platform's real
+        <code>event_type</code> strings, voyage statuses, and intervention semantics. No backend, no API keys.</p>
+
+      <!-- three views explained -->
+      <div class="arch-grid" style="margin-top:2rem">
+        <div class="card arch-card">
+          <h3>🗺️ Sea Chart <span class="chip">board</span></h3>
+          <p>Voyages flow left-to-right through pipeline columns. Cards show live status, per-phase build state, and progress. Terminal voyages collapse into Completed &amp; Failed.</p>
+        </div>
+        <div class="card arch-card">
+          <h3>🕸️ Crew Map <span class="chip">graph</span></h3>
+          <p>A live DAG of the crew. Nodes pulse while an agent works; edges flash as Den Den Mushi messages travel between agents; badges count recent events.</p>
+        </div>
+        <div class="card arch-card">
+          <h3>📜 Ship's Log <span class="chip">timeline</span></h3>
+          <p>The durable record of every crew action — searchable, filterable by crew member, failures-only mode, with cursor pagination over <code>(created_at, id)</code>.</p>
+        </div>
+        <div class="card arch-card">
+          <h3>🎛️ Fleet admiral controls <span class="chip">interventions</span></h3>
+          <p>Pause, resume, inject context, redirect a phase, or cancel — every intervention triggers a Vivre Card checkpoint so no work is ever lost. Try the buttons during the demo.</p>
+        </div>
+      </div>
     </div>
+  </section>
 
-    <div class="card">
-      <h2>PDD Guide</h2>
-      <p>How GrandLine uses Prompt Driven Development and Test Driven Development — the Log Pose.</p>
-      <span class="badge">Coming soon</span>
+  <!-- ================= DIAL SYSTEM ================= -->
+  <section id="dial">
+    <div class="container">
+      <div class="section-head">
+        <div class="kicker">The Dial System</div>
+        <h2>Every role dials its own model</h2>
+        <p>A provider-agnostic LLM gateway: per-role provider/model mapping, sliding-window rate limiting,
+          and automatic failover chains — with a Vivre Card checkpoint before every switch.</p>
+      </div>
+      <div class="dial-grid">
+        <div class="card">
+          <table class="dial-table">
+            <thead><tr><th>Crew role</th><th>Active provider · model</th><th>Fallback chain</th></tr></thead>
+            <tbody>
+              <tr>
+                <td>⚓ captain</td>
+                <td data-active-provider><span class="provider-chip"><span class="pd"></span>anthropic</span> <span class="mono" style="color:var(--ocean-500)">claude-sonnet-4</span></td>
+                <td><span class="provider-chip" data-p="anthropic"><span class="pd"></span>anthropic</span><span class="fallback-arrow">→</span><span class="provider-chip"><span class="pd"></span>openai</span><span class="fallback-arrow">→</span><span class="provider-chip"><span class="pd"></span>ollama</span></td>
+              </tr>
+              <tr>
+                <td>🧭 navigator</td>
+                <td><span class="provider-chip"><span class="pd"></span>claude_code</span> <span class="mono" style="color:var(--ocean-500)">sonnet</span></td>
+                <td><span class="provider-chip" data-p="anthropic"><span class="pd"></span>anthropic</span></td>
+              </tr>
+              <tr>
+                <td>🩺 doctor</td>
+                <td><span class="provider-chip"><span class="pd"></span>ollama</span> <span class="mono" style="color:var(--ocean-500)">llama3</span></td>
+                <td><span class="mono" style="color:var(--ocean-600)">none</span></td>
+              </tr>
+              <tr>
+                <td>🔨 shipwright</td>
+                <td><span class="provider-chip"><span class="pd"></span>openai</span> <span class="mono" style="color:var(--ocean-500)">gpt-4o</span></td>
+                <td><span class="provider-chip"><span class="pd"></span>ollama</span></td>
+              </tr>
+              <tr>
+                <td>⚙️ helmsman</td>
+                <td><span class="provider-chip"><span class="pd"></span>claude_code</span> <span class="mono" style="color:var(--ocean-500)">claude-sonnet-4</span></td>
+                <td><span class="provider-chip" data-p="anthropic"><span class="pd"></span>anthropic</span></td>
+              </tr>
+            </tbody>
+          </table>
+          <p style="font-size:0.76rem;color:var(--ocean-400);margin-top:0.8rem">
+            Configured per-voyage via <code>PUT /api/v1/voyages/{id}/dial-config</code> — JSONB role mapping, no restart needed.
+            Providers: <code>anthropic</code>, <code>openai</code>, <code>ollama</code>, <code>claude_code</code> (runs your local Claude Code CLI — subscription auth, no key stored).
+          </p>
+        </div>
+        <div class="card">
+          <h3 style="color:#fff;font-size:1rem;margin-bottom:0.6rem">Failover, live</h3>
+          <p style="font-size:0.82rem;color:var(--ocean-300);margin-bottom:0.8rem">
+            Rate limiter trips (100k tokens / 100 req per 60s window) → Vivre Card checkpoint → switch to the
+            next provider in the chain → <code>provider_switched</code> event on the Den Den Mushi.
+          </p>
+          <button class="btn btn-primary" id="dial-sim" style="margin-bottom:0.9rem">⚡ Simulate anthropic rate-limit</button>
+          <div class="dial-events" id="dial-events">
+            <div class="dial-event">dial system idle · all providers healthy</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ================= PLATFORM INTERNALS ================= -->
+  <section id="platform">
+    <div class="container">
+      <div class="section-head">
+        <div class="kicker">Below Deck</div>
+        <h2>The machinery of the voyage</h2>
+        <p>Everything an agent does is evented, checkpointed, sandboxed, and committed to real git history.</p>
+      </div>
+      <div class="arch-grid">
+        <div class="card arch-card">
+          <h3>🐌 Den Den Mushi <span class="chip">Redis Streams</span></h3>
+          <p>Typed inter-agent events with consumer groups, dead-letter stream, and replay-from-offset. Per-voyage stream <code>grandline:events:{voyage_id}</code>.</p>
+          <div class="chips"><span class="chip">voyage_plan_created</span><span class="chip">tests_passed</span><span class="chip">provider_switched</span><span class="chip">+17 more</span></div>
+        </div>
+        <div class="card arch-card">
+          <h3>🃏 Vivre Cards <span class="chip">PostgreSQL JSONB</span></h3>
+          <p>Agent state snapshots at every stage, iteration, pause, and failover. Restore, diff two checkpoints, or clean up old ones — resumable voyages, no work lost.</p>
+          <div class="chips"><span class="chip">checkpoint</span><span class="chip">restore</span><span class="chip">diff</span><span class="chip">cleanup</span></div>
+        </div>
+        <div class="card arch-card">
+          <h3>📦 Execution Service <span class="chip">gVisor sandbox</span></h3>
+          <p>All agent code runs in isolated containers — per-user sandboxes, resource limits, path-traversal guards, auto-recreate on death. Never on the host.</p>
+          <div class="chips"><span class="chip">ExecutionBackend ABC</span><span class="chip">swappable</span></div>
+        </div>
+        <div class="card arch-card">
+          <h3>🌿 Git Integration <span class="chip">real repos</span></h3>
+          <p>Each agent works on its own branch — <code>agent/{crew}/{voyage}</code> — with commits, pushes, PR creation, and conflict detection. Host allowlist prevents token exfiltration.</p>
+          <div class="chips"><span class="chip">clone</span><span class="chip">branch</span><span class="chip">commit</span><span class="chip">pr</span><span class="chip">conflicts</span></div>
+        </div>
+        <div class="card arch-card">
+          <h3>🔐 Auth <span class="chip">default-deny</span></h3>
+          <p>JWT with refresh rotation; every route closed unless explicitly allowed. WebSocket auth rides the <code>grandline-bearer</code> subprotocol — no tokens in URLs.</p>
+          <div class="chips"><span class="chip">register</span><span class="chip">login</span><span class="chip">refresh</span><span class="chip">me</span></div>
+        </div>
+        <div class="card arch-card">
+          <h3>🧰 Stack <span class="chip">local-first</span></h3>
+          <p>Next.js 14 + Tailwind · FastAPI + SQLAlchemy · LangGraph · PostgreSQL · Redis Streams · Docker Compose locally, Kubernetes + Helm in production.</p>
+          <div class="chips"><span class="chip">REST</span><span class="chip">SSE</span><span class="chip">WebSocket</span></div>
+        </div>
+      </div>
+
+      <div class="tiers">
+        <div class="card tier">
+          <h4>🛶 Preview</h4>
+          <div class="trig">Auto-deploy on branch push. Containerized preview per voyage.</div>
+          <div class="gate">approval: none</div>
+        </div>
+        <div class="card tier">
+          <h4>⛵ Staging</h4>
+          <div class="trig">Deploys on PR merge with lightweight validation. Rollback = redeploy previous.</div>
+          <div class="gate">approval: lightweight review</div>
+        </div>
+        <div class="card tier">
+          <h4>🚢 Production</h4>
+          <div class="trig">PR to main only. The Helmsman refuses to sail without an explicit approver.</div>
+          <div class="gate">approval: fleet admiral required</div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ================= API ================= -->
+  <section id="api">
+    <div class="container">
+      <div class="section-head">
+        <div class="kicker">API Surface</div>
+        <h2>REST + SSE + WebSocket, versioned at <code>/api/v1</code></h2>
+        <p>OpenAPI auto-generated by FastAPI. A condensed map of the surface:</p>
+      </div>
+      <div class="api-cols">
+        <div class="card">
+          <table class="api-table">
+            <tr><td class="m m-POST">POST</td><td class="p">/voyages</td><td class="d">chart a course</td></tr>
+            <tr><td class="m m-POST">POST</td><td class="p">/voyages/{id}/start</td><td class="d">set sail (202)</td></tr>
+            <tr><td class="m m-POST">POST</td><td class="p">/voyages/{id}/pause · /resume · /cancel</td><td class="d">fleet admiral controls</td></tr>
+            <tr><td class="m m-POST">POST</td><td class="p">/voyages/{id}/inject · /redirect</td><td class="d">mid-voyage interventions</td></tr>
+            <tr><td class="m m-GET">GET</td><td class="p">/voyages/{id}/status</td><td class="d">pipeline snapshot</td></tr>
+            <tr><td class="m m-SSE">SSE</td><td class="p">/voyages/{id}/stream</td><td class="d">live pipeline events</td></tr>
+            <tr><td class="m m-WS">WS</td><td class="p">/voyages/{id}/events</td><td class="d">Observation Deck stream</td></tr>
+            <tr><td class="m m-GET">GET</td><td class="p">/voyages/{id}/crew-actions</td><td class="d">Ship's Log, cursor paged</td></tr>
+            <tr><td class="m m-POST">POST</td><td class="p">/voyages/{id}/plan</td><td class="d">⚓ Captain decomposes</td></tr>
+            <tr><td class="m m-POST">POST</td><td class="p">/voyages/{id}/poneglyphs</td><td class="d">🧭 Navigator drafts PDD</td></tr>
+            <tr><td class="m m-POST">POST</td><td class="p">/voyages/{id}/health-checks</td><td class="d">🩺 Doctor writes TDD</td></tr>
+            <tr><td class="m m-POST">POST</td><td class="p">/voyages/{id}/phases/{n}/build</td><td class="d">🔨 Shipwright iterates</td></tr>
+            <tr><td class="m m-POST">POST</td><td class="p">/voyages/{id}/validation</td><td class="d">🩺 Doctor validates</td></tr>
+            <tr><td class="m m-POST">POST</td><td class="p">/voyages/{id}/deploy · /rollback</td><td class="d">⚙️ Helmsman, 3 tiers</td></tr>
+          </table>
+        </div>
+        <div class="card">
+          <table class="api-table">
+            <tr><td class="m m-GET">GET</td><td class="p">/voyages/{id}/dial-config</td><td class="d">role→provider map</td></tr>
+            <tr><td class="m m-PUT">PUT</td><td class="p">/voyages/{id}/dial-config</td><td class="d">hot-swap models</td></tr>
+            <tr><td class="m m-SSE">SSE</td><td class="p">/voyages/{id}/completions/stream</td><td class="d">token streaming</td></tr>
+            <tr><td class="m m-POST">POST</td><td class="p">/voyages/{id}/vivre-cards</td><td class="d">checkpoint state</td></tr>
+            <tr><td class="m m-GET">GET</td><td class="p">/voyages/{id}/vivre-cards/{c}/diff</td><td class="d">compare checkpoints</td></tr>
+            <tr><td class="m m-POST">POST</td><td class="p">/voyages/{id}/vivre-cards/{c}/restore</td><td class="d">resume from snapshot</td></tr>
+            <tr><td class="m m-POST">POST</td><td class="p">/voyages/{id}/execute</td><td class="d">sandboxed run</td></tr>
+            <tr><td class="m m-POST">POST</td><td class="p">/voyages/{id}/git/clone · /commit · /pr</td><td class="d">agent git ops</td></tr>
+            <tr><td class="m m-POST">POST</td><td class="p">/auth/register · /login · /refresh</td><td class="d">JWT pair</td></tr>
+            <tr><td class="m m-GET">GET</td><td class="p">/auth/me</td><td class="d">fleet admiral profile</td></tr>
+            <tr><td class="m m-GET">GET</td><td class="p">/health</td><td class="d">service heartbeat</td></tr>
+          </table>
+          <p style="font-size:0.76rem;color:var(--ocean-400);margin-top:0.8rem">
+            Full reference: run the stack and open <code>/docs</code> (Swagger UI) — see the
+            <a href="https://github.com/harshal2802/GrandLine/blob/main/docs/DEPLOYMENT.md" target="_blank" rel="noopener">deployment runbook</a>.
+          </p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ================= FOOTER ================= -->
+  <footer>
+    <div class="container">
+      <div class="tag">Assemble your crew. Navigate the GrandLine. 🏴‍☠️</div>
+      <div class="links">
+        <a href="https://github.com/harshal2802/GrandLine" target="_blank" rel="noopener">GitHub</a>
+        <a href="https://github.com/harshal2802/GrandLine#readme" target="_blank" rel="noopener">README</a>
+        <a href="https://github.com/harshal2802/GrandLine/blob/main/docs/DEPLOYMENT.md" target="_blank" rel="noopener">Deployment runbook</a>
+        <a href="https://github.com/harshal2802/GrandLine/blob/main/docs/RELEASE_READINESS.md" target="_blank" rel="noopener">Release readiness</a>
+      </div>
+      <div class="fine">Interactive product mockup — all voyages, events, and providers on this page are simulated in your browser.<br>© 2026 GrandLine · MIT License</div>
+    </div>
+  </footer>
+
+  <!-- ================= MODALS ================= -->
+  <div class="modal-backdrop" id="chart-modal">
+    <div class="modal">
+      <h3>Chart a course</h3>
+      <p>Give the crew a mission. The Captain will decompose it into a voyage plan.</p>
+      <input type="text" id="chart-title" placeholder="Voyage title (max 255 chars)" maxlength="255">
+      <textarea id="chart-task" rows="4" placeholder="Mission for the crew — e.g. “Build a REST endpoint that aggregates fleet telemetry and exposes p95 latency per vessel.” (min 10 chars to set sail)"></textarea>
+      <label><input type="checkbox" id="chart-sail" checked> Set sail immediately (<code>POST /voyages/{id}/start</code>)</label>
+      <div class="row">
+        <button class="iv-btn" id="chart-cancel">Cancel</button>
+        <button class="iv-btn primary" id="chart-create">⚓ Chart &amp; set sail</button>
+      </div>
     </div>
   </div>
 
-  <footer>
-    Assemble your crew. Navigate the GrandLine.
-  </footer>
+  <div class="modal-backdrop" id="inject-modal">
+    <div class="modal">
+      <h3>Inject context</h3>
+      <p>Add instructions to the running agent's context window — delivered mid-voyage via <code>POST /voyages/{id}/inject</code>, logged to the Ship's Log.</p>
+      <textarea id="inject-text" rows="4" placeholder="e.g. “Prefer cursor pagination over offset for the telemetry list endpoint.” (min 10 chars)"></textarea>
+      <div class="row">
+        <button class="iv-btn" id="inject-cancel">Cancel</button>
+        <button class="iv-btn primary" id="inject-send">✎ Inject</button>
+      </div>
+    </div>
+  </div>
+
+  <div class="modal-backdrop" id="cancel-modal">
+    <div class="modal">
+      <h3>Cancel voyage?</h3>
+      <p>The crew stops gracefully and the voyage moves to <span class="badge st-CANCELLED"><span class="g">⊘</span>CANCELLED</span>.
+        A final Vivre Card preserves all state — cancelled voyages are not resumable.</p>
+      <div class="row">
+        <button class="iv-btn" id="cancel-keep">Keep sailing</button>
+        <button class="iv-btn danger" id="cancel-confirm">✕ Cancel voyage</button>
+      </div>
+    </div>
+  </div>
+
+  <div class="modal-backdrop" id="help-modal">
+    <div class="modal">
+      <h3>Keyboard shortcuts</h3>
+      <table class="kv-table shortcuts">
+        <tr><td><span class="kbd">⌘/Ctrl K</span></td><td>Command palette</td></tr>
+        <tr><td><span class="kbd">g</span> <span class="kbd">s</span></td><td>Go to Sea Chart</td></tr>
+        <tr><td><span class="kbd">g</span> <span class="kbd">c</span></td><td>Go to Crew Map</td></tr>
+        <tr><td><span class="kbd">g</span> <span class="kbd">l</span></td><td>Go to Ship's Log</td></tr>
+        <tr><td><span class="kbd">/</span></td><td>Focus log search</td></tr>
+        <tr><td><span class="kbd">f</span></td><td>Toggle focus mode</td></tr>
+        <tr><td><span class="kbd">?</span></td><td>Show this help</td></tr>
+        <tr><td><span class="kbd">Esc</span></td><td>Close overlays</td></tr>
+      </table>
+      <div class="row" style="margin-top:0.9rem">
+        <button class="iv-btn" id="help-close">Close</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- command palette -->
+  <div class="palette" id="palette">
+    <div class="palette-box">
+      <input type="text" id="palette-input" placeholder="Type a command…">
+      <div class="palette-list" id="palette-list"></div>
+    </div>
+  </div>
+
+  <div class="toast-stack" id="toasts"></div>
+
+  <script src="./assets/deck.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
The GitHub Pages site was a "Coming soon" placeholder. This PR replaces it with a full interactive mockup of GrandLine, built from a deep dive of the actual frontend (`SeaChart.tsx`, `CrewMap.tsx`, `ShipsLog.tsx`, Phase 16 contracts) and backend (pipeline graph, Den Den Mushi events, Dial System, Vivre Cards) — so everything on the page uses the platform's real enums, event types, and endpoint paths.

## What's on the new site
- **Hero / Crew / Pipeline** — the five personas and the voyage state machine (`CHARTED → PLANNING → PDD → TDD → BUILDING → REVIEWING → DEPLOYING → COMPLETED`, with PAUSED/FAILED/CANCELLED side states)
- **Interactive Observation Deck demo** — a scripted voyage plays through all three views (Sea Chart board, Crew Map DAG, Ship's Log timeline) using the real `event_type` strings; working fleet-admiral interventions (pause / resume / inject context / cancel), details drawer, playback scrubber, command palette (⌘K) and `g s` / `g c` / `g l` / `/` / `f` / `?` shortcuts
- **Dial System** — role→provider table plus a rate-limit failover simulation (`checkpoint_created` → `provider_switched`)
- **Platform internals** — Den Den Mushi, Vivre Cards, gVisor sandbox, per-agent git branches, auth, three deploy tiers
- **API surface** — condensed `/api/v1` map (REST + SSE + WS)

All data is simulated in-browser and the page is labelled as a mockup. Plain HTML/CSS/JS, no build step — served by the existing `docs.yml` Pages workflow.

## Workflow change
`docs.yml` gains a `workflow_dispatch` trigger so the Pages deploy can be re-run manually. (Note: the `github-pages` environment restricts deployments to `main`, so the site goes live when this merges — the workflow path-triggers on `docs/**`.)

## Verification
- Rendered headlessly (Playwright/Chromium): zero console errors; full scripted voyage runs to COMPLETED; interventions, dial failover sim, tabs, palette, and shortcuts all exercised
- `node --check` on the JS; all 61 DOM ids referenced by the script verified present

## Related
UX-review issues filed from the same deep dive: #50 #51 #52 #53 #54 #55 #56

https://claude.ai/code/session_01GC6ekfqN4PxAXEu6nyJG32

---
_Generated by [Claude Code](https://claude.ai/code/session_01GC6ekfqN4PxAXEu6nyJG32)_