### PR TITLE
fix(dial): carry per-fallback model so cross-vendor failover works (#50)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,10 +64,18 @@ providers:
     "helmsman":   {"provider": "claude_code", "model": "claude-sonnet-4-20250514"}
   },
   "fallback_chain": {
-    "captain": ["openai", "ollama"]
+    "captain": [
+      {"provider": "openai", "model": "gpt-4o"},
+      {"provider": "ollama", "model": "llama3"}
+    ]
   }
 }
 ```
+
+Each fallback entry carries its **own** provider *and* model so cross-vendor
+failover works (a Claude model id can't be sent to OpenAI). A bare string —
+`"captain": ["openai"]` — still works and resolves to that provider's default
+model, but the object form above is recommended.
 
 Supported providers:
 

--- a/src/backend/app/dial_system/factory.py
+++ b/src/backend/app/dial_system/factory.py
@@ -18,6 +18,56 @@ from app.dial_system.router import DialSystemRouter
 from app.models.dial_config import DialConfig
 from app.models.enums import CrewRole
 
+# Sensible per-provider default models, used when a fallback_chain entry is a
+# bare provider string with no explicit model. The primary role's model is never
+# reused for a fallback on a different vendor — that sends e.g. a Claude model id
+# to OpenAI and 404s (see #50). Prefer the object form to be explicit.
+_PROVIDER_DEFAULT_MODELS: dict[str, str] = {
+    "anthropic": "claude-sonnet-4-20250514",
+    "openai": "gpt-4o",
+    "ollama": "llama3",
+    "claude_code": "sonnet",
+    "claude-code": "sonnet",
+}
+
+
+def _default_model_for(provider: str, settings: Settings) -> str:
+    """Resolve a default model for a bare-string fallback entry.
+
+    Uses the configured default model for the deployment's default provider so a
+    custom ``GRANDLINE_DIAL_DEFAULT_MODEL`` is honored; otherwise a known-good
+    per-provider default. Unknown providers raise (they have no valid model).
+    """
+    if provider == settings.dial_default_provider and settings.dial_default_model:
+        return settings.dial_default_model
+    model = _PROVIDER_DEFAULT_MODELS.get(provider)
+    if model is None:
+        raise ValueError(
+            f"No default model known for fallback provider {provider!r}; "
+            "specify it explicitly as {'provider': ..., 'model': ...}"
+        )
+    return model
+
+
+def _resolve_fallback_entry(entry: Any, settings: Settings) -> tuple[str, str]:
+    """Return ``(provider, model)`` for one ``fallback_chain`` entry.
+
+    Accepts two shapes:
+      * bare string ``"openai"`` — back-compat; resolves to the provider's
+        default model rather than the primary role's model.
+      * object ``{"provider": "openai", "model": "gpt-4o"}`` — explicit and
+        recommended; ``model`` may be omitted to use the provider default.
+    """
+    if isinstance(entry, str):
+        return entry, _default_model_for(entry, settings)
+    if isinstance(entry, dict):
+        provider = entry.get("provider")
+        if not provider:
+            raise ValueError(f"Fallback entry missing 'provider': {entry!r}")
+        model = entry.get("model") or _default_model_for(provider, settings)
+        return provider, model
+    raise ValueError(f"Invalid fallback entry (expected string or object): {entry!r}")
+
 
 def create_adapter(provider: str, model: str, settings: Settings) -> ProviderAdapter:
     if provider == "anthropic":
@@ -66,12 +116,12 @@ def build_router_from_config(
         role_mapping[role] = create_adapter(provider, model, settings)
 
     chains: dict[str, Any] = config.fallback_chain or {}
-    for role_str, fallback_providers in chains.items():
+    for role_str, fallback_entries in chains.items():
         role = CrewRole(role_str)
         adapters: list[ProviderAdapter] = []
-        default_model = mapping.get(role_str, {}).get("model", "default")
-        for fb_provider in fallback_providers:
-            adapters.append(create_adapter(fb_provider, default_model, settings))
+        for entry in fallback_entries:
+            provider, model = _resolve_fallback_entry(entry, settings)
+            adapters.append(create_adapter(provider, model, settings))
         fallback_chains[role] = adapters
 
     return DialSystemRouter(

--- a/src/backend/app/dial_system/router.py
+++ b/src/backend/app/dial_system/router.py
@@ -86,7 +86,7 @@ class DialSystemRouter:
                     await self._rate_limiter.record_usage(
                         result.provider, result.usage.total_tokens
                     )
-                await self._publish_switch_event(role, result.provider)
+                await self._publish_switch_event(role, result.provider, result.model)
                 return result
             except ProviderError as exc:
                 logger.warning("Fallback provider failed for %s: %s", role.value, exc)
@@ -115,8 +115,9 @@ class DialSystemRouter:
                 continue
             try:
                 fallback_name = self._get_provider_name(fallback)
+                fallback_model = getattr(fallback, "_model", None)
                 await self._call_switch_hook(role, fallback_name)
-                await self._publish_switch_event(role, fallback_name)
+                await self._publish_switch_event(role, fallback_name, fallback_model)
                 async for token in fallback.stream(request):
                     yield token
                 return
@@ -146,11 +147,16 @@ class DialSystemRouter:
         except Exception as exc:
             logger.warning("on_provider_switch hook failed for %s: %s", role.value, exc)
 
-    async def _publish_switch_event(self, role: CrewRole, new_provider: str) -> None:
+    async def _publish_switch_event(
+        self, role: CrewRole, new_provider: str, new_model: str | None = None
+    ) -> None:
+        payload: dict[str, str] = {"new_provider": new_provider}
+        if new_model:
+            payload["new_model"] = new_model
         event = ProviderSwitchedEvent(
             voyage_id=self._voyage_id,
             source_role=role,
-            payload={"new_provider": new_provider},
+            payload=payload,
         )
         stream = stream_key(self._voyage_id)
         await self._mushi.publish(stream, event)

--- a/src/backend/app/schemas/dial_config.py
+++ b/src/backend/app/schemas/dial_config.py
@@ -3,9 +3,50 @@ import uuid
 from datetime import datetime
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field, ValidationError
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
 
 logger = logging.getLogger(__name__)
+
+# Providers the Dial System can build adapters for (mirrors factory.create_adapter).
+SUPPORTED_PROVIDERS = frozenset(
+    {"anthropic", "openai", "ollama", "claude_code", "claude-code"}
+)
+
+
+def validate_fallback_chain(value: dict[str, Any] | None) -> dict[str, Any] | None:
+    """Validate the shape of a ``fallback_chain`` mapping.
+
+    Each role maps to a list of entries; an entry is either a bare provider
+    string or a ``{"provider": ..., "model": ...}`` object. The provider must be
+    supported. Model strings can't be validated against a provider's catalog, so
+    only the shape and provider name are checked here.
+    """
+    if value is None:
+        return value
+    for role, entries in value.items():
+        if not isinstance(entries, list):
+            raise ValueError(f"fallback_chain[{role!r}] must be a list of providers")
+        for entry in entries:
+            provider: str | None
+            if isinstance(entry, str):
+                provider = entry
+            elif isinstance(entry, dict):
+                provider = entry.get("provider")
+                if not provider:
+                    raise ValueError(
+                        f"fallback_chain[{role!r}] entry missing 'provider': {entry!r}"
+                    )
+            else:
+                raise ValueError(
+                    f"fallback_chain[{role!r}] entry must be a provider string or "
+                    f"a {{'provider', 'model'}} object, got: {entry!r}"
+                )
+            if provider not in SUPPORTED_PROVIDERS:
+                raise ValueError(
+                    f"Unsupported provider {provider!r} in fallback_chain[{role!r}]; "
+                    f"choose one of {sorted(SUPPORTED_PROVIDERS)}"
+                )
+    return value
 
 
 class DialConfigCreate(BaseModel):
@@ -13,10 +54,20 @@ class DialConfigCreate(BaseModel):
     role_mapping: dict[str, Any]
     fallback_chain: dict[str, Any] | None = None
 
+    @field_validator("fallback_chain")
+    @classmethod
+    def _check_fallback_chain(cls, v: dict[str, Any] | None) -> dict[str, Any] | None:
+        return validate_fallback_chain(v)
+
 
 class DialConfigUpdate(BaseModel):
     role_mapping: dict[str, Any] | None = None
     fallback_chain: dict[str, Any] | None = None
+
+    @field_validator("fallback_chain")
+    @classmethod
+    def _check_fallback_chain(cls, v: dict[str, Any] | None) -> dict[str, Any] | None:
+        return validate_fallback_chain(v)
 
 
 class DialConfigRead(BaseModel):

--- a/src/backend/tests/test_dial_config_schemas.py
+++ b/src/backend/tests/test_dial_config_schemas.py
@@ -8,8 +8,11 @@ import pytest
 from pydantic import ValidationError
 
 from app.schemas.dial_config import (
+    DialConfigCreate,
+    DialConfigUpdate,
     ShipwrightRoleConfig,
     resolve_shipwright_max_concurrency,
+    validate_fallback_chain,
 )
 
 
@@ -87,3 +90,64 @@ class TestResolveShipwrightMaxConcurrency:
             "shipwright": {"max_concurrency": 5, "model": "claude-sonnet-4"}
         }
         assert resolve_shipwright_max_concurrency(role_mapping) == 5
+
+
+class TestValidateFallbackChain:
+    def test_none_passes(self) -> None:
+        assert validate_fallback_chain(None) is None
+
+    def test_bare_string_entries_pass(self) -> None:
+        chain: dict[str, Any] = {"captain": ["openai", "ollama"]}
+        assert validate_fallback_chain(chain) == chain
+
+    def test_object_entries_pass(self) -> None:
+        chain: dict[str, Any] = {
+            "captain": [{"provider": "openai", "model": "gpt-4o"}],
+        }
+        assert validate_fallback_chain(chain) == chain
+
+    def test_mixed_entries_pass(self) -> None:
+        chain: dict[str, Any] = {
+            "captain": ["ollama", {"provider": "openai", "model": "gpt-4o"}],
+        }
+        assert validate_fallback_chain(chain) == chain
+
+    def test_unknown_provider_string_rejected(self) -> None:
+        with pytest.raises(ValueError, match="Unsupported provider 'gemini'"):
+            validate_fallback_chain({"captain": ["gemini"]})
+
+    def test_unknown_provider_object_rejected(self) -> None:
+        with pytest.raises(ValueError, match="Unsupported provider 'gemini'"):
+            validate_fallback_chain({"captain": [{"provider": "gemini", "model": "x"}]})
+
+    def test_object_missing_provider_rejected(self) -> None:
+        with pytest.raises(ValueError, match="missing 'provider'"):
+            validate_fallback_chain({"captain": [{"model": "gpt-4o"}]})
+
+    def test_non_list_entries_rejected(self) -> None:
+        with pytest.raises(ValueError, match="must be a list"):
+            validate_fallback_chain({"captain": "openai"})
+
+    def test_invalid_entry_type_rejected(self) -> None:
+        with pytest.raises(ValueError, match="must be a provider string"):
+            validate_fallback_chain({"captain": [123]})
+
+    def test_dial_config_create_validates_fallback_chain(self) -> None:
+        import uuid
+
+        with pytest.raises(ValidationError):
+            DialConfigCreate(
+                voyage_id=uuid.uuid4(),
+                role_mapping={"captain": {"provider": "anthropic", "model": "x"}},
+                fallback_chain={"captain": ["gemini"]},
+            )
+
+    def test_dial_config_update_validates_fallback_chain(self) -> None:
+        with pytest.raises(ValidationError):
+            DialConfigUpdate(fallback_chain={"captain": ["gemini"]})
+
+    def test_dial_config_update_accepts_object_form(self) -> None:
+        cfg = DialConfigUpdate(
+            fallback_chain={"captain": [{"provider": "openai", "model": "gpt-4o"}]}
+        )
+        assert cfg.fallback_chain == {"captain": [{"provider": "openai", "model": "gpt-4o"}]}

--- a/src/backend/tests/test_dial_factory.py
+++ b/src/backend/tests/test_dial_factory.py
@@ -12,8 +12,14 @@ from app.dial_system.adapters.anthropic import AnthropicAdapter
 from app.dial_system.adapters.claude_code import ClaudeCodeAdapter
 from app.dial_system.adapters.ollama import OllamaAdapter
 from app.dial_system.adapters.openai import OpenAIAdapter
-from app.dial_system.factory import build_router_from_config, create_adapter
+from app.dial_system.factory import (
+    _default_model_for,
+    _resolve_fallback_entry,
+    build_router_from_config,
+    create_adapter,
+)
 from app.models.dial_config import DialConfig
+from app.models.enums import CrewRole
 
 VOYAGE_ID = uuid.uuid4()
 
@@ -123,3 +129,78 @@ class TestBuildRouterFromConfig:
 
         router = build_router_from_config(config, _make_settings(), MagicMock(), MagicMock())
         assert router is not None
+
+
+class TestResolveFallbackEntry:
+    def test_object_form_uses_explicit_model(self) -> None:
+        provider, model = _resolve_fallback_entry(
+            {"provider": "openai", "model": "gpt-4o-mini"}, _make_settings()
+        )
+        assert (provider, model) == ("openai", "gpt-4o-mini")
+
+    def test_bare_string_resolves_to_provider_default(self) -> None:
+        provider, model = _resolve_fallback_entry("openai", _make_settings())
+        assert provider == "openai"
+        assert model == "gpt-4o"
+
+    def test_object_form_without_model_uses_provider_default(self) -> None:
+        provider, model = _resolve_fallback_entry({"provider": "ollama"}, _make_settings())
+        assert (provider, model) == ("ollama", "llama3")
+
+    def test_default_model_for_configured_provider_uses_settings(self) -> None:
+        settings = Settings(
+            anthropic_api_key="k",
+            openai_api_key="k",
+            dial_default_provider="anthropic",
+            dial_default_model="claude-custom-9",
+        )
+        assert _default_model_for("anthropic", settings) == "claude-custom-9"
+
+    def test_unknown_fallback_provider_raises(self) -> None:
+        with pytest.raises(ValueError, match="No default model known"):
+            _resolve_fallback_entry("gemini", _make_settings())
+
+    def test_invalid_entry_shape_raises(self) -> None:
+        with pytest.raises(ValueError, match="Invalid fallback entry"):
+            _resolve_fallback_entry(123, _make_settings())
+
+    def test_object_form_missing_provider_raises(self) -> None:
+        with pytest.raises(ValueError, match="missing 'provider'"):
+            _resolve_fallback_entry({"model": "gpt-4o"}, _make_settings())
+
+
+class TestCrossVendorFailoverModel:
+    """Regression for #50: fallbacks must not reuse the primary's model id."""
+
+    def test_fallback_adapter_uses_its_own_model_not_primary(self) -> None:
+        config = DialConfig(
+            id=uuid.uuid4(),
+            voyage_id=VOYAGE_ID,
+            role_mapping={
+                "captain": {"provider": "anthropic", "model": "claude-sonnet-4-20250514"},
+            },
+            fallback_chain={"captain": [{"provider": "openai", "model": "gpt-4o"}]},
+        )
+
+        router = build_router_from_config(config, _make_settings(), MagicMock(), MagicMock())
+
+        fallback = router._fallback_chains[CrewRole.CAPTAIN][0]
+        assert isinstance(fallback, OpenAIAdapter)
+        assert fallback._model == "gpt-4o"
+        assert fallback._model != "claude-sonnet-4-20250514"
+
+    def test_bare_string_fallback_does_not_inherit_primary_model(self) -> None:
+        config = DialConfig(
+            id=uuid.uuid4(),
+            voyage_id=VOYAGE_ID,
+            role_mapping={
+                "captain": {"provider": "anthropic", "model": "claude-sonnet-4-20250514"},
+            },
+            fallback_chain={"captain": ["openai"]},
+        )
+
+        router = build_router_from_config(config, _make_settings(), MagicMock(), MagicMock())
+
+        fallback = router._fallback_chains[CrewRole.CAPTAIN][0]
+        assert isinstance(fallback, OpenAIAdapter)
+        assert fallback._model == "gpt-4o"

--- a/src/backend/tests/test_dial_router.py
+++ b/src/backend/tests/test_dial_router.py
@@ -192,6 +192,8 @@ class TestFailover:
         assert event.event_type == "provider_switched"
         assert event.voyage_id == VOYAGE_ID
         assert event.source_role == CrewRole.CAPTAIN
+        assert event.payload["new_provider"] == "openai"
+        assert event.payload["new_model"] == "gpt-4o"
 
     @pytest.mark.asyncio
     async def test_no_event_when_primary_succeeds(self) -> None:


### PR DESCRIPTION
Fixes #50.

## Problem
`build_router_from_config` built every fallback adapter with the **primary role's** model string:

```python
default_model = mapping.get(role_str, {}).get("model", "default")
for fb_provider in fallback_chain[role]:
    adapters.append(create_adapter(fb_provider, default_model, settings))
```

So a captain configured as `anthropic / claude-sonnet-4` with `fallback_chain: ["openai"]` failed over to OpenAI **with a Claude model id** — the call 404s and the router moves on. Cross-vendor failover (the headline README example) could never succeed.

## Fix
- **`factory.py`** — `fallback_chain` entries may now be `{"provider", "model"}` objects (explicit, recommended). Bare provider strings still work and resolve to that provider's **default** model (via `_PROVIDER_DEFAULT_MODELS`, honoring `GRANDLINE_DIAL_DEFAULT_MODEL` for the configured default provider) instead of inheriting the primary's model.
- **`router.py`** — `provider_switched` payload now includes `new_model` alongside `new_provider` (from `result.model` on the completion path, from the adapter on the stream path).
- **`schemas/dial_config.py`** — `DialConfigCreate`/`DialConfigUpdate` validate `fallback_chain` shape and reject unsupported providers.
- **`README.md`** — Dial System example updated to the object form, with a note that bare strings still work.

No adapter changes; routing/failover logic is unchanged.

## Acceptance criteria
- [x] A voyage with `captain: anthropic/claude-sonnet-4` and a fallback to `openai` fails over with a valid OpenAI model.
- [x] `provider_switched` payload includes the fallback **model** as well as the provider.
- [x] Unit tests cover object-form entries, bare-string back-compat, and validation errors for unknown providers.
- [x] README Dial System example updated.

## Tests
`921 passed, 19 skipped`; `ruff` clean; `mypy` clean (modulo a pre-existing `python-jose` stub issue in untouched `security.py`). New tests in `test_dial_factory.py`, `test_dial_config_schemas.py`, `test_dial_router.py`.

https://claude.ai/code/session_01GC6ekfqN4PxAXEu6nyJG32

---
_Generated by [Claude Code](https://claude.ai/code/session_01GC6ekfqN4PxAXEu6nyJG32)_