### PR TITLE
feat(interventions): drain inject/redirect into the running pipeline + Redirect UI (#51)

### DIFF
--- a/src/backend/app/crew/shipwright_graph.py
+++ b/src/backend/app/crew/shipwright_graph.py
@@ -55,6 +55,8 @@ class ShipwrightState(TypedDict):
     health_checks: list[dict[str, str]]
     iteration: int
     last_test_output: str | None
+    injected_context: list[str]
+    redirect_instruction: str | None
     raw_output: str
     generated_files: list[BuildArtifactSpec] | None
     exit_code: int | None
@@ -75,6 +77,22 @@ def _build_user_message(state: ShipwrightState) -> str:
         f"## Poneglyph (phase {state['phase_number']})\n{poneglyph_block}",
         f"## Tests you must make pass\n{tests_block}",
     ]
+    redirect = state.get("redirect_instruction")
+    if redirect:
+        sections.append(
+            "## Phase redirected by the fleet admiral\n"
+            "Your approach for this phase has been changed. Follow this instruction, "
+            "overriding the Poneglyph where they conflict:\n"
+            f"{redirect}"
+        )
+    injected = state.get("injected_context") or []
+    if injected:
+        joined = "\n\n".join(injected)
+        sections.append(
+            "## Injected context from the fleet admiral\n"
+            "Honor these instructions added mid-voyage:\n"
+            f"{joined}"
+        )
     if state["iteration"] > 1 and state.get("last_test_output"):
         output = state["last_test_output"] or ""
         sections.append(

--- a/src/backend/app/schemas/pipeline.py
+++ b/src/backend/app/schemas/pipeline.py
@@ -41,7 +41,9 @@ class InjectContextRequest(BaseModel):
     model_config = ConfigDict(strict=True, extra="forbid")
 
     context: str = Field(min_length=1, max_length=5000)
-    phase_number: int | None = Field(default=None, ge=0)
+    # Phases are 1-indexed (VoyagePlanSpec/Poneglyph use ge=1); a phase-0 target
+    # would never match a built phase and be silently dropped. None = global.
+    phase_number: int | None = Field(default=None, ge=1)
 
 
 class RedirectPhaseRequest(BaseModel):
@@ -49,7 +51,7 @@ class RedirectPhaseRequest(BaseModel):
 
     model_config = ConfigDict(strict=True, extra="forbid")
 
-    phase_number: int = Field(ge=0)
+    phase_number: int = Field(ge=1)
     instruction: str = Field(min_length=1, max_length=5000)
 
 

--- a/src/backend/app/services/intervention_service.py
+++ b/src/backend/app/services/intervention_service.py
@@ -1,0 +1,112 @@
+"""Intervention drain — feeds pending user interventions into the running pipeline.
+
+Phase 17 follow-up (#51). `POST /voyages/{id}/inject` and `/redirect` persist a
+durable `CrewAction` (CONTEXT_INJECTED / PHASE_REDIRECTED) but, until now, nothing
+consumed those rows — the active agent's next LLM call never saw the injected
+context and a redirected phase kept its original Poneglyph instruction.
+
+A crew node calls `drain_pending_interventions(...)` before composing its prompt.
+Each consumed intervention is stamped (`details.applied_phases` gains the phase
+number, `details.applied_at` records first consumption) so it is applied to a
+given phase exactly once — even across the Shipwright's retry iterations.
+
+Targeting:
+  * CONTEXT_INJECTED with `phase_number == N` reaches phase N; a global inject
+    (`phase_number is None`) reaches every phase, once each.
+  * PHASE_REDIRECTED with `phase_number == N` reaches phase N only.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.crew_action import CrewAction
+from app.services.crew_action_helper import CrewActionType
+
+_INTERVENTION_TYPES = (
+    CrewActionType.CONTEXT_INJECTED.value,
+    CrewActionType.PHASE_REDIRECTED.value,
+)
+
+
+@dataclass
+class DrainedInterventions:
+    """Interventions consumed for one phase on one drain."""
+
+    injected_context: list[str] = field(default_factory=list)
+    redirect_instruction: str | None = None
+    applied_actions: list[CrewAction] = field(default_factory=list)
+
+    @property
+    def is_empty(self) -> bool:
+        return not self.injected_context and self.redirect_instruction is None
+
+
+async def drain_pending_interventions(
+    session: AsyncSession, voyage_id: uuid.UUID, phase_number: int
+) -> DrainedInterventions:
+    """Consume interventions targeting `phase_number` not yet applied to it.
+
+    Marks each consumed CrewAction so it is not re-applied to the same phase,
+    then flushes (durability is the caller's commit). Returns the injected
+    context strings in record order and the latest redirect instruction.
+    """
+    rows = (
+        (
+            await session.execute(
+                select(CrewAction)
+                .where(
+                    CrewAction.voyage_id == voyage_id,
+                    CrewAction.action_type.in_(_INTERVENTION_TYPES),
+                )
+                .order_by(CrewAction.created_at.asc(), CrewAction.id.asc())
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+    drained = DrainedInterventions()
+    now = datetime.now(UTC).isoformat()
+
+    for action in rows:
+        details = dict(action.details or {})
+        applied_phases = list(details.get("applied_phases") or [])
+        if phase_number in applied_phases:
+            continue
+
+        target = details.get("phase_number")
+        if action.action_type == CrewActionType.CONTEXT_INJECTED.value:
+            if target is not None and target != phase_number:
+                continue
+            context = details.get("context")
+            if context:
+                drained.injected_context.append(str(context))
+        elif action.action_type == CrewActionType.PHASE_REDIRECTED.value:
+            if target != phase_number:
+                continue
+            instruction = details.get("instruction")
+            if instruction:
+                drained.redirect_instruction = str(instruction)
+        else:  # pragma: no cover - query is filtered to the two types above
+            continue
+
+        applied_phases.append(phase_number)
+        details["applied_phases"] = applied_phases
+        details.setdefault("applied_at", now)
+        # Reassign (not mutate) so SQLAlchemy marks the JSONB column dirty.
+        action.details = details
+        drained.applied_actions.append(action)
+
+    if drained.applied_actions:
+        await session.flush()
+
+    return drained
+
+
+__all__ = ["DrainedInterventions", "drain_pending_interventions"]

--- a/src/backend/app/services/pipeline_service.py
+++ b/src/backend/app/services/pipeline_service.py
@@ -327,7 +327,11 @@ class PipelineService:
 
         Records the redirect and resets the targeted phase to PENDING so a
         subsequent resume re-builds it with the new instruction in context.
-        Rejected on a terminal voyage.
+        While the phase is actively building, the Shipwright drains the redirect
+        on its next iteration (intervention_service). A redirect landing in the
+        narrow window after the build's final iteration but before it commits
+        BUILT is honored only on the next resume (the PENDING reset is the
+        durable signal). Rejected on a terminal voyage.
         """
         if voyage.status in _TERMINAL_STATUSES:
             raise PipelineError(

--- a/src/backend/app/services/shipwright_service.py
+++ b/src/backend/app/services/shipwright_service.py
@@ -46,6 +46,7 @@ from app.services.crew_action_helper import (
 )
 from app.services.execution_service import ExecutionService
 from app.services.git_service import GitService
+from app.services.intervention_service import drain_pending_interventions
 
 logger = logging.getLogger(__name__)
 
@@ -180,6 +181,8 @@ class ShipwrightService:
             ],
             "iteration": 1,
             "last_test_output": None,
+            "injected_context": [],
+            "redirect_instruction": None,
             "raw_output": "",
             "generated_files": None,
             "exit_code": None,
@@ -192,10 +195,26 @@ class ShipwrightService:
 
         iteration_count = 0
         final_parse_error: str | None = None
+        injected_context: list[str] = []
+        redirect_instruction: str | None = None
         try:
             for i in range(1, SHIPWRIGHT_MAX_ITERATIONS + 1):
                 iteration_count = i
                 state["iteration"] = i
+
+                # Drain any pending interventions (inject/redirect) for this phase
+                # so the agent's NEXT LLM call sees them. Each is applied once per
+                # phase, so a new intervention recorded between iterations is
+                # picked up on the following iteration (#51).
+                drained = await drain_pending_interventions(
+                    self._session, voyage.id, phase_number
+                )
+                injected_context.extend(drained.injected_context)
+                if drained.redirect_instruction:
+                    redirect_instruction = drained.redirect_instruction
+                state["injected_context"] = injected_context
+                state["redirect_instruction"] = redirect_instruction
+
                 state = await self._graph.ainvoke(state)
                 await self._checkpoint_iteration(voyage, state)
 

--- a/src/backend/tests/test_intervention_service.py
+++ b/src/backend/tests/test_intervention_service.py
@@ -1,0 +1,143 @@
+"""Tests for the intervention drain (#51)."""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.models.crew_action import CrewAction
+from app.services.crew_action_helper import CrewActionType
+from app.services.intervention_service import drain_pending_interventions
+
+VOYAGE_ID = uuid.uuid4()
+
+
+def _action(action_type: CrewActionType, details: dict[str, Any]) -> CrewAction:
+    return CrewAction(
+        id=uuid.uuid4(),
+        voyage_id=VOYAGE_ID,
+        crew_member="captain",
+        action_type=action_type.value,
+        summary="x",
+        details=details,
+    )
+
+
+def _session(actions: list[CrewAction]) -> AsyncMock:
+    session = AsyncMock()
+    session.add = MagicMock()
+    session.flush = AsyncMock()
+    result = MagicMock()
+    result.scalars.return_value.all.return_value = actions
+    session.execute = AsyncMock(return_value=result)
+    return session
+
+
+@pytest.mark.asyncio
+async def test_empty_when_no_interventions() -> None:
+    session = _session([])
+    drained = await drain_pending_interventions(session, VOYAGE_ID, 1)
+    assert drained.is_empty
+    session.flush.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_phase_targeted_inject_reaches_matching_phase() -> None:
+    action = _action(CrewActionType.CONTEXT_INJECTED, {"context": "use redis", "phase_number": 1})
+    session = _session([action])
+
+    drained = await drain_pending_interventions(session, VOYAGE_ID, 1)
+
+    assert drained.injected_context == ["use redis"]
+    assert 1 in action.details["applied_phases"]
+    assert "applied_at" in action.details
+    session.flush.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_phase_targeted_inject_skipped_for_other_phase() -> None:
+    action = _action(CrewActionType.CONTEXT_INJECTED, {"context": "use redis", "phase_number": 2})
+    session = _session([action])
+
+    drained = await drain_pending_interventions(session, VOYAGE_ID, 1)
+
+    assert drained.injected_context == []
+    assert "applied_phases" not in action.details
+
+
+@pytest.mark.asyncio
+async def test_global_inject_reaches_any_phase() -> None:
+    action = _action(
+        CrewActionType.CONTEXT_INJECTED, {"context": "prefer postgres", "phase_number": None}
+    )
+    session = _session([action])
+
+    drained = await drain_pending_interventions(session, VOYAGE_ID, 7)
+
+    assert drained.injected_context == ["prefer postgres"]
+    assert action.details["applied_phases"] == [7]
+
+
+@pytest.mark.asyncio
+async def test_global_inject_applied_once_per_phase() -> None:
+    action = _action(
+        CrewActionType.CONTEXT_INJECTED, {"context": "global note", "phase_number": None}
+    )
+    session = _session([action])
+
+    first = await drain_pending_interventions(session, VOYAGE_ID, 1)
+    # Same row, now marked applied for phase 1; draining phase 1 again is a no-op.
+    second = await drain_pending_interventions(session, VOYAGE_ID, 1)
+    # A different phase still sees it.
+    third = await drain_pending_interventions(session, VOYAGE_ID, 2)
+
+    assert first.injected_context == ["global note"]
+    assert second.injected_context == []
+    assert third.injected_context == ["global note"]
+    assert action.details["applied_phases"] == [1, 2]
+
+
+@pytest.mark.asyncio
+async def test_redirect_reaches_matching_phase_only() -> None:
+    action = _action(
+        CrewActionType.PHASE_REDIRECTED, {"instruction": "use a state machine", "phase_number": 3}
+    )
+    session = _session([action])
+
+    match = await drain_pending_interventions(session, VOYAGE_ID, 3)
+    other = await drain_pending_interventions(_session([action]), VOYAGE_ID, 4)
+
+    assert match.redirect_instruction == "use a state machine"
+    assert other.redirect_instruction is None
+
+
+@pytest.mark.asyncio
+async def test_latest_redirect_wins() -> None:
+    first = _action(
+        CrewActionType.PHASE_REDIRECTED, {"instruction": "approach A", "phase_number": 1}
+    )
+    second = _action(
+        CrewActionType.PHASE_REDIRECTED, {"instruction": "approach B", "phase_number": 1}
+    )
+    session = _session([first, second])
+
+    drained = await drain_pending_interventions(session, VOYAGE_ID, 1)
+
+    assert drained.redirect_instruction == "approach B"
+
+
+@pytest.mark.asyncio
+async def test_already_applied_not_redrained() -> None:
+    action = _action(
+        CrewActionType.CONTEXT_INJECTED,
+        {"context": "old", "phase_number": 1, "applied_phases": [1], "applied_at": "t"},
+    )
+    session = _session([action])
+
+    drained = await drain_pending_interventions(session, VOYAGE_ID, 1)
+
+    assert drained.is_empty
+    session.flush.assert_not_awaited()

--- a/src/backend/tests/test_pipeline_api.py
+++ b/src/backend/tests/test_pipeline_api.py
@@ -715,6 +715,25 @@ class TestIntervention:
         assert result.crew_action_id == action.id
         svc.redirect.assert_awaited_once_with(voyage, 3, "try again")
 
+    def test_redirect_rejects_phase_zero(self) -> None:
+        # Phases are 1-indexed; a phase-0 target could never be built/drained.
+        from pydantic import ValidationError
+
+        from app.schemas.pipeline import RedirectPhaseRequest
+
+        with pytest.raises(ValidationError):
+            RedirectPhaseRequest(phase_number=0, instruction="x")
+
+    def test_inject_rejects_phase_zero_but_allows_global(self) -> None:
+        from pydantic import ValidationError
+
+        from app.schemas.pipeline import InjectContextRequest
+
+        with pytest.raises(ValidationError):
+            InjectContextRequest(context="x", phase_number=0)
+        # None (global inject) remains valid.
+        assert InjectContextRequest(context="x").phase_number is None
+
 
 # ---------------------------------------------------------------------------
 # GET /status

--- a/src/backend/tests/test_shipwright_graph.py
+++ b/src/backend/tests/test_shipwright_graph.py
@@ -145,6 +145,47 @@ class TestGenerateNode:
         assert "Previous attempt" not in user_msg["content"]
 
     @pytest.mark.asyncio
+    async def test_injected_context_appears_verbatim(self) -> None:
+        mock_router = AsyncMock()
+        mock_router.route = AsyncMock(return_value=_llm_result(VALID_OUTPUT_JSON))
+
+        await generate(
+            _base_state(injected_context=["Use PostgreSQL, not SQLite"]),
+            mock_router,  # type: ignore[arg-type]
+        )
+
+        request = mock_router.route.call_args.args[1]
+        user_msg = next(m for m in request.messages if m["role"] == "user")
+        assert "Injected context from the fleet admiral" in user_msg["content"]
+        assert "Use PostgreSQL, not SQLite" in user_msg["content"]
+
+    @pytest.mark.asyncio
+    async def test_redirect_instruction_appears_verbatim(self) -> None:
+        mock_router = AsyncMock()
+        mock_router.route = AsyncMock(return_value=_llm_result(VALID_OUTPUT_JSON))
+
+        await generate(
+            _base_state(redirect_instruction="Rewrite using async generators"),
+            mock_router,  # type: ignore[arg-type]
+        )
+
+        request = mock_router.route.call_args.args[1]
+        user_msg = next(m for m in request.messages if m["role"] == "user")
+        assert "Phase redirected by the fleet admiral" in user_msg["content"]
+        assert "Rewrite using async generators" in user_msg["content"]
+
+    @pytest.mark.asyncio
+    async def test_no_intervention_blocks_without_interventions(self) -> None:
+        mock_router = AsyncMock()
+        mock_router.route = AsyncMock(return_value=_llm_result(VALID_OUTPUT_JSON))
+
+        await generate(_base_state(), mock_router)  # type: ignore[arg-type]
+
+        request = mock_router.route.call_args.args[1]
+        user_msg = next(m for m in request.messages if m["role"] == "user")
+        assert "fleet admiral" not in user_msg["content"]
+
+    @pytest.mark.asyncio
     async def test_valid_json_populates_generated_files(self) -> None:
         mock_router = AsyncMock()
         mock_router.route = AsyncMock(return_value=_llm_result(VALID_OUTPUT_JSON))

--- a/src/backend/tests/test_shipwright_service.py
+++ b/src/backend/tests/test_shipwright_service.py
@@ -168,6 +168,63 @@ def service(
     return svc
 
 
+class TestBuildCodeInterventionDrain:
+    @pytest.mark.asyncio
+    async def test_drained_interventions_feed_into_graph_state(
+        self, service: ShipwrightService, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from app.services import shipwright_service as ss
+        from app.services.intervention_service import DrainedInterventions
+
+        drained = DrainedInterventions(
+            injected_context=["use redis"], redirect_instruction="use a queue"
+        )
+        monkeypatch.setattr(
+            ss, "drain_pending_interventions", AsyncMock(return_value=drained)
+        )
+
+        voyage = _mock_voyage(phase_status={"1": PHASE_STATUS_PENDING})
+        await service.build_code(voyage, 1, _mock_poneglyph(), [_mock_health_check()], USER_ID)
+
+        state_arg = service._graph.ainvoke.call_args_list[0].args[0]  # type: ignore[attr-defined]
+        assert state_arg["injected_context"] == ["use redis"]
+        assert state_arg["redirect_instruction"] == "use a queue"
+
+    @pytest.mark.asyncio
+    async def test_redirect_between_iterations_reaches_next_iteration(
+        self, service: ShipwrightService, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from app.services import shipwright_service as ss
+        from app.services.intervention_service import DrainedInterventions
+
+        # Iteration 1 drains an inject; a redirect arrives and is drained on
+        # iteration 2 (the prior inject persists via accumulation).
+        monkeypatch.setattr(
+            ss,
+            "drain_pending_interventions",
+            AsyncMock(
+                side_effect=[
+                    DrainedInterventions(injected_context=["ctx1"]),
+                    DrainedInterventions(redirect_instruction="switch approach"),
+                ]
+            ),
+        )
+        # Iteration 1 fails (keep looping); iteration 2 passes.
+        service._graph.ainvoke = AsyncMock(  # type: ignore[attr-defined]
+            side_effect=[
+                _graph_state(exit_code=1, passed=0, failed=1, stdout="boom"),
+                _graph_state(exit_code=0),
+            ]
+        )
+
+        voyage = _mock_voyage(phase_status={"1": PHASE_STATUS_PENDING})
+        await service.build_code(voyage, 1, _mock_poneglyph(), [_mock_health_check()], USER_ID)
+
+        second = service._graph.ainvoke.call_args_list[1].args[0]  # type: ignore[attr-defined]
+        assert second["redirect_instruction"] == "switch approach"
+        assert second["injected_context"] == ["ctx1"]
+
+
 class TestPhaseStatusConstants:
     def test_constants_have_expected_values(self) -> None:
         assert PHASE_STATUS_PENDING == "PENDING"

--- a/src/frontend/components/observation-deck/InterventionControls.tsx
+++ b/src/frontend/components/observation-deck/InterventionControls.tsx
@@ -170,7 +170,7 @@ export function InterventionControls({ voyageId }: { voyageId: string }) {
           <label className="mb-1 block text-xs text-ocean-400">Phase number</label>
           <input
             type="number"
-            min={0}
+            min={1}
             value={redirectPhaseNum}
             onChange={(e) => setRedirectPhaseNum(e.target.value)}
             className="mb-3 w-28 rounded border border-ocean-700 bg-ocean-950 px-2 py-1 text-sm text-ocean-100 outline-none focus:border-ocean-400"
@@ -195,8 +195,8 @@ export function InterventionControls({ voyageId }: { voyageId: string }) {
               disabled={
                 !redirectText.trim() ||
                 redirectPhaseNum.trim() === "" ||
-                Number.isNaN(Number(redirectPhaseNum)) ||
-                Number(redirectPhaseNum) < 0
+                !Number.isInteger(Number(redirectPhaseNum)) ||
+                Number(redirectPhaseNum) < 1
               }
               onClick={() => {
                 const phase = Number(redirectPhaseNum);

--- a/src/frontend/components/observation-deck/InterventionControls.tsx
+++ b/src/frontend/components/observation-deck/InterventionControls.tsx
@@ -8,11 +8,12 @@ import {
   cancelVoyage,
   injectContext,
   pauseVoyage,
+  redirectPhase,
   resumeVoyage,
 } from "@/lib/intervention";
 
-// Fleet-admiral control bar (Phase 17). Pause/Resume/Cancel + Inject context,
-// with confirmation for the destructive Cancel.
+// Fleet-admiral control bar (Phase 17). Pause/Resume/Cancel + Inject + Redirect,
+// with confirmation for the destructive Cancel and phase-replanning Redirect.
 export function InterventionControls({ voyageId }: { voyageId: string }) {
   const status = useVoyageStore((s) => s.buffers[voyageId]?.status);
   const queryClient = useQueryClient();
@@ -22,6 +23,9 @@ export function InterventionControls({ voyageId }: { voyageId: string }) {
   const [confirmCancel, setConfirmCancel] = useState(false);
   const [showInject, setShowInject] = useState(false);
   const [injectText, setInjectText] = useState("");
+  const [showRedirect, setShowRedirect] = useState(false);
+  const [redirectPhaseNum, setRedirectPhaseNum] = useState("");
+  const [redirectText, setRedirectText] = useState("");
 
   const paused = status === "PAUSED";
   const terminal = isTerminal(status);
@@ -72,6 +76,14 @@ export function InterventionControls({ voyageId }: { voyageId: string }) {
         className="rounded border border-ocean-700 px-2 py-1 text-ocean-300 hover:bg-ocean-800 disabled:opacity-50"
       >
         ✎ Inject
+      </button>
+
+      <button
+        disabled={busy}
+        onClick={() => setShowRedirect(true)}
+        className="rounded border border-amber-700 px-2 py-1 text-amber-300 hover:bg-amber-900/40 disabled:opacity-50"
+      >
+        ⤳ Redirect
       </button>
 
       <button
@@ -142,6 +154,61 @@ export function InterventionControls({ voyageId }: { voyageId: string }) {
               className="rounded bg-ocean-500 px-3 py-1 text-sm text-ocean-950 hover:bg-ocean-400 disabled:opacity-50"
             >
               Inject
+            </button>
+          </div>
+        </Modal>
+      )}
+
+      {/* Redirect a phase (re-plans — destructive) */}
+      {showRedirect && (
+        <Modal title="Redirect a phase" onClose={() => setShowRedirect(false)}>
+          <p className="mb-3 text-sm text-amber-300/90">
+            This re-plans the targeted phase: the Shipwright rebuilds it from the
+            next iteration using your new instruction, overriding the original
+            Poneglyph where they conflict.
+          </p>
+          <label className="mb-1 block text-xs text-ocean-400">Phase number</label>
+          <input
+            type="number"
+            min={0}
+            value={redirectPhaseNum}
+            onChange={(e) => setRedirectPhaseNum(e.target.value)}
+            className="mb-3 w-28 rounded border border-ocean-700 bg-ocean-950 px-2 py-1 text-sm text-ocean-100 outline-none focus:border-ocean-400"
+            placeholder="e.g. 1"
+          />
+          <label className="mb-1 block text-xs text-ocean-400">New instruction</label>
+          <textarea
+            value={redirectText}
+            onChange={(e) => setRedirectText(e.target.value)}
+            rows={4}
+            className="w-full rounded border border-ocean-700 bg-ocean-950 px-2 py-1 text-sm text-ocean-100 outline-none focus:border-ocean-400"
+            placeholder="e.g. use a state machine instead of nested callbacks"
+          />
+          <div className="mt-3 flex justify-end gap-2">
+            <button
+              onClick={() => setShowRedirect(false)}
+              className="rounded border border-ocean-700 px-3 py-1 text-sm text-ocean-300 hover:bg-ocean-800"
+            >
+              Cancel
+            </button>
+            <button
+              disabled={
+                !redirectText.trim() ||
+                redirectPhaseNum.trim() === "" ||
+                Number.isNaN(Number(redirectPhaseNum)) ||
+                Number(redirectPhaseNum) < 0
+              }
+              onClick={() => {
+                const phase = Number(redirectPhaseNum);
+                const instruction = redirectText.trim();
+                setShowRedirect(false);
+                setRedirectPhaseNum("");
+                setRedirectText("");
+                run(() => redirectPhase(voyageId, phase, instruction));
+              }}
+              className="rounded bg-amber-600 px-3 py-1 text-sm text-white hover:bg-amber-500 disabled:opacity-50"
+            >
+              Redirect phase
             </button>
           </div>
         </Modal>


### PR DESCRIPTION
Fixes #51.

## Problem
Phase 17 promised pause/resume/redirect/inject, but two of the four were **records-only**:
- `/inject` and `/redirect` recorded a `CrewAction` and returned 200, but the payload was **never propagated into the running LangGraph** — the active agent's next LLM call didn't see injected context, and a redirected phase kept its original Poneglyph instruction.
- The deck had **no Redirect UI** even though the `/redirect` endpoint and the `redirectPhase()` client both existed.

## Fix
**Backend**
- New `app/services/intervention_service.py` → `drain_pending_interventions(session, voyage_id, phase_number)`: consumes un-applied `CONTEXT_INJECTED` / `PHASE_REDIRECTED` CrewActions targeting a phase and stamps `details.applied_phases` so each is applied **once per phase**. A global inject (`phase_number=None`) reaches every phase once; a phase-targeted inject/redirect reaches only its phase.
- `ShipwrightService.build_code` drains **before each iteration** and feeds the accumulated injected context + latest redirect instruction into the graph state. A redirect arriving mid-build is therefore honored on the **next iteration**.
- The Shipwright prompt (`shipwright_graph._build_user_message`) renders an injected-context block and a redirect block (instructed to override the Poneglyph where they conflict).

**Frontend**
- `InterventionControls.tsx` gains a **Redirect dialog** (phase number + instruction textarea) with a re-plan warning and a destructive-styled confirm button, wired to the existing `redirectPhase()` client — mirroring the Inject modal.

Terminal voyages: `/inject` and `/redirect` already reject with a clear `VOYAGE_TERMINAL` error, and the deck hides the control bar for terminal voyages.

## Acceptance criteria
- [x] Injected context appears verbatim in the next LLM request for the targeted phase (asserted via the recorded prompt).
- [x] Redirecting a phase mid-BUILDING causes the next iteration to use the new instruction (asserted via the drain-per-iteration wiring test).
- [x] Redirect UI exists with a destructive-action confirmation.
- [x] Interventions on terminal voyages rejected with a clear error.

## Scope
Phase 17 follow-up. LLM propagation is wired for the Shipwright (phase build) path — where redirect applies and where phase-targeted/global inject lands during BUILDING. The pipeline graph is not refactored beyond the drain hook. Other stages (Captain/Navigator/Doctor/Helmsman) can adopt the same `drain_pending_interventions` helper later.

## Tests
Backend `933 passed, 19 skipped`; `ruff`/`mypy` clean (modulo the pre-existing `python-jose` stub issue). Frontend `tsc`/`next lint` clean, `56` vitest tests pass. New: `test_intervention_service.py`, plus additions to `test_shipwright_graph.py` and `test_shipwright_service.py`.

https://claude.ai/code/session_01GC6ekfqN4PxAXEu6nyJG32

---
_Generated by [Claude Code](https://claude.ai/code/session_01GC6ekfqN4PxAXEu6nyJG32)_