### PR TITLE
feat(deploy): expose deploy tiers + production approval, URL & rollback in the deck (#52)

### DIFF
--- a/src/backend/app/api/v1/pipeline.py
+++ b/src/backend/app/api/v1/pipeline.py
@@ -107,6 +107,7 @@ def _spawn_pipeline_task(
             body.task,
             body.deploy_tier,
             body.max_parallel_shipwrights,
+            approved_by=body.approved_by,
         )
     )
     registry[voyage_id] = task

--- a/src/backend/app/crew/pipeline_graph.py
+++ b/src/backend/app/crew/pipeline_graph.py
@@ -24,7 +24,7 @@ import time
 import uuid
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from typing import Any, Literal, TypedDict
+from typing import Any, TypedDict
 
 from langgraph.graph import END, StateGraph
 from langgraph.graph.state import CompiledStateGraph
@@ -51,6 +51,7 @@ from app.models.validation_run import ValidationRun
 from app.models.vivre_card import VivreCard
 from app.models.voyage import Voyage, VoyagePlan
 from app.schemas.captain import VoyagePlanSpec
+from app.schemas.deployment import DeploymentTier
 from app.services.captain_service import CaptainError, CaptainService
 from app.services.doctor_service import DoctorError, DoctorService
 from app.services.execution_service import ExecutionService
@@ -87,7 +88,8 @@ StageFn = Callable[["PipelineState"], Awaitable[dict[str, Any]]]
 class PipelineState(TypedDict):
     voyage_id: uuid.UUID
     user_id: uuid.UUID
-    deploy_tier: Literal["preview"]
+    deploy_tier: DeploymentTier
+    approved_by: uuid.UUID | None
     max_parallel_shipwrights: int
     task: str
     start_monotonic: float
@@ -628,7 +630,12 @@ def _make_deploying_node(ctx: PipelineContext) -> StageFn:
             helmsman = HelmsmanService(
                 ctx.dial_router, ctx.mushi, session, ctx.deployment_backend, ctx.git_service
             )
-            deployment = await helmsman.deploy(voyage, state["deploy_tier"], state["user_id"])
+            deployment = await helmsman.deploy(
+                voyage,
+                state["deploy_tier"],
+                state["user_id"],
+                approved_by=state.get("approved_by"),
+            )
             return {"deployment_id": deployment.deployment_id}
 
         return await _run_stage_with_guard(

--- a/src/backend/app/schemas/pipeline.py
+++ b/src/backend/app/schemas/pipeline.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import uuid
-from typing import Any, Literal
+from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field
+
+from app.schemas.deployment import DeploymentTier
 
 
 class PipelineStatusSnapshot(BaseModel):
@@ -31,7 +33,10 @@ class StartVoyageRequest(BaseModel):
     model_config = ConfigDict(strict=True, extra="forbid")
 
     task: str = Field(min_length=10, max_length=5000)
-    deploy_tier: Literal["preview"] = "preview"
+    deploy_tier: DeploymentTier = "preview"
+    # Required when deploy_tier == "production" (the Helmsman refuses to sail to
+    # production without an approver). The deck sends the approving user's id.
+    approved_by: uuid.UUID | None = None
     max_parallel_shipwrights: int | None = Field(default=None, ge=1, le=10)
 
 

--- a/src/backend/app/services/pipeline_service.py
+++ b/src/backend/app/services/pipeline_service.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import logging
 import time
 import uuid
-from typing import Any, Literal
+from typing import Any
 
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
@@ -42,6 +42,7 @@ from app.models.poneglyph import Poneglyph
 from app.models.validation_run import ValidationRun
 from app.models.vivre_card import VivreCard
 from app.models.voyage import Voyage, VoyagePlan
+from app.schemas.deployment import DeploymentTier
 from app.schemas.dial_config import resolve_shipwright_max_concurrency
 from app.schemas.pipeline import PipelineStatusSnapshot
 from app.services.crew_action_helper import (
@@ -103,8 +104,9 @@ class PipelineService:
         voyage: Voyage,
         user_id: uuid.UUID,
         task: str,
-        deploy_tier: Literal["preview"] = "preview",
+        deploy_tier: DeploymentTier = "preview",
         max_parallel_shipwrights: int | None = None,
+        approved_by: uuid.UUID | None = None,
     ) -> None:
         try:
             require_can_enter_planning(voyage)
@@ -152,6 +154,7 @@ class PipelineService:
             "voyage_id": voyage.id,
             "user_id": user_id,
             "deploy_tier": deploy_tier,
+            "approved_by": approved_by,
             "max_parallel_shipwrights": resolved_concurrency,
             "task": task,
             "start_monotonic": run_start,

--- a/src/backend/tests/test_pipeline_api.py
+++ b/src/backend/tests/test_pipeline_api.py
@@ -117,11 +117,29 @@ class TestPipelineSchemas:
         with pytest.raises(Exception):
             StartVoyageRequest.model_validate({"task": "short"})
 
-    def test_start_voyage_request_rejects_bad_tier(self) -> None:
+    def test_start_voyage_request_accepts_all_tiers(self) -> None:
+        for tier in ("preview", "staging", "production"):
+            req = StartVoyageRequest.model_validate(
+                {"task": "build a todo app", "deploy_tier": tier}
+            )
+            assert req.deploy_tier == tier
+
+    def test_start_voyage_request_rejects_unknown_tier(self) -> None:
         with pytest.raises(Exception):
             StartVoyageRequest.model_validate(
-                {"task": "build a todo app", "deploy_tier": "production"}
+                {"task": "build a todo app", "deploy_tier": "mainnet"}
             )
+
+    def test_start_voyage_request_accepts_approved_by(self) -> None:
+        approver = uuid.uuid4()
+        # JSON body path (what FastAPI uses): a string UUID is accepted.
+        req = StartVoyageRequest.model_validate_json(
+            f'{{"task": "ship to prod", "deploy_tier": "production", '
+            f'"approved_by": "{approver}"}}'
+        )
+        assert req.approved_by == approver
+        # approved_by defaults to None for the happy path.
+        assert StartVoyageRequest(task="build a todo app").approved_by is None
 
     def test_start_voyage_request_max_parallel_too_low(self) -> None:
         with pytest.raises(Exception):

--- a/src/backend/tests/test_pipeline_graph.py
+++ b/src/backend/tests/test_pipeline_graph.py
@@ -205,11 +205,14 @@ def _make_state(
     paused: bool = False,
     error: dict | None = None,
     max_parallel: int = 1,
+    deploy_tier: str = "preview",
+    approved_by: uuid.UUID | None = None,
 ) -> PipelineState:
     return {
         "voyage_id": VOYAGE_ID,
         "user_id": USER_ID,
-        "deploy_tier": "preview",
+        "deploy_tier": deploy_tier,  # type: ignore[typeddict-item]
+        "approved_by": approved_by,
         "max_parallel_shipwrights": max_parallel,
         "task": "t",
         "start_monotonic": time.monotonic(),
@@ -732,6 +735,32 @@ class TestDeployingNode:
         result = await node(_make_state())
         helmsman.deploy.assert_awaited_once()
         assert result["deployment_id"] == deployment.deployment_id
+
+    @pytest.mark.asyncio
+    async def test_passes_tier_and_approval_to_helmsman(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        ctx = _mock_ctx()
+        voyage = _mock_voyage()
+        _patch_loads(monkeypatch, voyage=voyage, latest_validation=MagicMock(status="passed"))
+        _mock_guard(monkeypatch, "require_can_enter_deploying")
+
+        deployment = MagicMock()
+        deployment.deployment_id = uuid.uuid4()
+        helmsman = MagicMock()
+        helmsman.deploy = AsyncMock(return_value=deployment)
+        monkeypatch.setattr(
+            "app.crew.pipeline_graph.HelmsmanService", MagicMock(return_value=helmsman)
+        )
+
+        approver = uuid.uuid4()
+        node = _make_deploying_node(ctx)
+        await node(_make_state(deploy_tier="production", approved_by=approver))
+
+        _, kwargs = helmsman.deploy.call_args
+        args = helmsman.deploy.call_args.args
+        assert args[1] == "production"
+        assert kwargs.get("approved_by") == approver
 
     @pytest.mark.asyncio
     async def test_never_skips(self, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/src/backend/tests/test_pipeline_service.py
+++ b/src/backend/tests/test_pipeline_service.py
@@ -486,6 +486,7 @@ class TestPipelineStateShape:
             "voyage_id": VOYAGE_ID,
             "user_id": USER_ID,
             "deploy_tier": "preview",
+            "approved_by": None,
             "max_parallel_shipwrights": 1,
             "task": "t",
             "start_monotonic": time.monotonic(),

--- a/src/frontend/components/observation-deck/ChartCourseDialog.tsx
+++ b/src/frontend/components/observation-deck/ChartCourseDialog.tsx
@@ -4,6 +4,8 @@ import { useState } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useQueryClient } from "@tanstack/react-query";
 import { createVoyage, startVoyage, MIN_TASK_LENGTH } from "@/lib/voyages";
+import { DEPLOY_TIERS, type DeployTier } from "@/lib/types";
+import { useAuthStore } from "@/stores/auth";
 
 // "Chart a course" — create a voyage (and optionally set sail immediately,
 // using the mission text as the pipeline task).
@@ -13,14 +15,22 @@ export function ChartCourseDialog({ onClose }: { onClose: () => void }) {
   const params = useSearchParams();
   const queryClient = useQueryClient();
 
+  const userId = useAuthStore((s) => s.user?.id ?? null);
+
   const [title, setTitle] = useState("");
   const [mission, setMission] = useState("");
   const [setSail, setSetSail] = useState(true);
+  const [deployTier, setDeployTier] = useState<DeployTier>("preview");
+  const [prodApproved, setProdApproved] = useState(false);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const missionTooShort = setSail && mission.trim().length < MIN_TASK_LENGTH;
-  const canSubmit = title.trim().length > 0 && !missionTooShort && !busy;
+  // Production auto-deploy needs an approver (the current user) acknowledged.
+  const needsApproval = setSail && deployTier === "production";
+  const approvalMissing = needsApproval && (!prodApproved || !userId);
+  const canSubmit =
+    title.trim().length > 0 && !missionTooShort && !approvalMissing && !busy;
 
   const submit = async () => {
     if (!canSubmit) return;
@@ -32,7 +42,10 @@ export function ChartCourseDialog({ onClose }: { onClose: () => void }) {
         description: mission.trim() || null,
       });
       if (setSail) {
-        await startVoyage(voyage.id, mission.trim());
+        await startVoyage(voyage.id, mission.trim(), {
+          deployTier,
+          approvedBy: deployTier === "production" ? userId : null,
+        });
       }
       // Refresh every voyage list (sidebar + sea chart lanes).
       void queryClient.invalidateQueries({ queryKey: ["sidebar"] });
@@ -94,6 +107,52 @@ export function ChartCourseDialog({ onClose }: { onClose: () => void }) {
           />
           Set sail immediately (start the pipeline)
         </label>
+
+        {setSail && (
+          <div className="mt-3">
+            <label className="mb-1 block text-xs text-ocean-400" htmlFor="deploy-tier">
+              Deploy tier
+            </label>
+            <select
+              id="deploy-tier"
+              value={deployTier}
+              onChange={(e) => setDeployTier(e.target.value as DeployTier)}
+              className="w-full rounded border border-ocean-700 bg-ocean-950 px-2 py-1.5 text-sm text-ocean-100 outline-none focus:border-ocean-400"
+            >
+              {DEPLOY_TIERS.map((tier) => (
+                <option key={tier} value={tier}>
+                  {tier}
+                </option>
+              ))}
+            </select>
+            <p className="mt-1 text-xs text-ocean-500">
+              The Helmsman deploys here when the crew finishes.
+            </p>
+
+            {needsApproval && (
+              <div className="mt-2 rounded border border-amber-700 bg-amber-500/10 p-2">
+                <label className="flex items-start gap-2 text-xs text-amber-200">
+                  <input
+                    type="checkbox"
+                    checked={prodApproved}
+                    onChange={(e) => setProdApproved(e.target.checked)}
+                    className="mt-0.5 accent-amber-400"
+                  />
+                  <span>
+                    I approve this <strong>production</strong> deployment. My user
+                    id is recorded as the approver.
+                  </span>
+                </label>
+                {!userId && (
+                  <p className="mt-1 text-xs text-rose-400">
+                    Can&apos;t resolve your user — reload before approving production.
+                  </p>
+                )}
+              </div>
+            )}
+          </div>
+        )}
+
         {missionTooShort && (
           <p className="mt-1 text-xs text-amber-400">
             The mission needs at least {MIN_TASK_LENGTH} characters to set sail.

--- a/src/frontend/components/observation-deck/DetailsDrawer.tsx
+++ b/src/frontend/components/observation-deck/DetailsDrawer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { usePlaybackStore } from "@/stores/playback";
 import { useDerivedState } from "@/hooks/useDerivedState";
 import { useActiveVoyageEvents } from "@/hooks/useActiveVoyageEvents";
@@ -20,6 +20,16 @@ export function DetailsDrawer() {
   const [rbError, setRbError] = useState<string | null>(null);
   const [rbDone, setRbDone] = useState(false);
   const [confirmRollback, setConfirmRollback] = useState(false);
+
+  // The drawer is mounted once and reused across voyages, so reset rollback
+  // state when it switches voyages — otherwise voyage A's "Rolled back" leaks
+  // onto voyage B's panel.
+  useEffect(() => {
+    setRbBusy(false);
+    setRbError(null);
+    setRbDone(false);
+    setConfirmRollback(false);
+  }, [drawerVoyageId]);
 
   const rollback = async () => {
     if (!drawerVoyageId || !deployment?.tier) return;

--- a/src/frontend/components/observation-deck/DetailsDrawer.tsx
+++ b/src/frontend/components/observation-deck/DetailsDrawer.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { usePlaybackStore } from "@/stores/playback";
 import { useDerivedState } from "@/hooks/useDerivedState";
 import { useActiveVoyageEvents } from "@/hooks/useActiveVoyageEvents";
+import { latestDeployment, rollbackDeployment } from "@/lib/deployments";
 
 type Tab = "overview" | "events" | "timestamps";
 
@@ -13,6 +14,27 @@ export function DetailsDrawer() {
   const derived = useDerivedState();
   const events = useActiveVoyageEvents();
   const [tab, setTab] = useState<Tab>("overview");
+
+  const deployment = latestDeployment(events);
+  const [rbBusy, setRbBusy] = useState(false);
+  const [rbError, setRbError] = useState<string | null>(null);
+  const [rbDone, setRbDone] = useState(false);
+  const [confirmRollback, setConfirmRollback] = useState(false);
+
+  const rollback = async () => {
+    if (!drawerVoyageId || !deployment?.tier) return;
+    setRbBusy(true);
+    setRbError(null);
+    try {
+      await rollbackDeployment(drawerVoyageId, deployment.tier);
+      setRbDone(true);
+    } catch (e) {
+      setRbError(e instanceof Error ? e.message : "Rollback failed");
+    } finally {
+      setRbBusy(false);
+      setConfirmRollback(false);
+    }
+  };
 
   if (!drawerVoyageId) return null;
 
@@ -54,6 +76,58 @@ export function DetailsDrawer() {
                 <div className="rounded border border-rose-700 bg-rose-500/10 p-2 text-rose-200">
                   <p className="font-medium">Failure at {derived.failure.stage}</p>
                   <p className="text-xs">{derived.failure.code}: {derived.failure.message}</p>
+                </div>
+              )}
+
+              {deployment && (
+                <div className="rounded border border-emerald-800 bg-emerald-500/10 p-2">
+                  <p className="mb-1 text-xs font-medium uppercase tracking-wide text-emerald-300">
+                    Deployment{deployment.tier ? ` · ${deployment.tier}` : ""}
+                  </p>
+                  {deployment.url ? (
+                    <a
+                      href={deployment.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="break-all text-xs text-emerald-200 underline hover:text-emerald-100"
+                    >
+                      {deployment.url} ↗
+                    </a>
+                  ) : (
+                    <p className="text-xs text-emerald-200/70">No URL reported.</p>
+                  )}
+                  <div className="mt-2 flex items-center gap-2">
+                    <button
+                      disabled={rbBusy || rbDone || !deployment.tier}
+                      onClick={() => setConfirmRollback(true)}
+                      className="rounded border border-amber-700 px-2 py-0.5 text-xs text-amber-300 hover:bg-amber-900/40 disabled:opacity-50"
+                    >
+                      {rbDone ? "Rolled back" : rbBusy ? "Rolling back…" : "↩ Rollback"}
+                    </button>
+                    {rbError && <span className="text-xs text-rose-400">{rbError}</span>}
+                  </div>
+                  {confirmRollback && (
+                    <div className="mt-2 rounded border border-amber-700 bg-amber-500/10 p-2">
+                      <p className="text-xs text-amber-200">
+                        Roll back the latest <strong>{deployment.tier}</strong>{" "}
+                        deployment?
+                      </p>
+                      <div className="mt-2 flex justify-end gap-2">
+                        <button
+                          onClick={() => setConfirmRollback(false)}
+                          className="rounded border border-ocean-700 px-2 py-0.5 text-xs text-ocean-300 hover:bg-ocean-800"
+                        >
+                          Cancel
+                        </button>
+                        <button
+                          onClick={() => void rollback()}
+                          className="rounded bg-amber-600 px-2 py-0.5 text-xs text-white hover:bg-amber-500"
+                        >
+                          Roll back
+                        </button>
+                      </div>
+                    </div>
+                  )}
                 </div>
               )}
               <div>

--- a/src/frontend/components/observation-deck/SeaChartCard.tsx
+++ b/src/frontend/components/observation-deck/SeaChartCard.tsx
@@ -1,9 +1,11 @@
 "use client";
 
+import { useMemo } from "react";
 import { useVoyageProgress } from "@/hooks/useVoyageProgress";
 import { useFocusStore } from "@/stores/focus";
 import { useVoyageStore } from "@/stores/voyage";
 import type { VoyageListItem } from "@/lib/types";
+import { latestDeployment } from "@/lib/deployments";
 import { StatusBadge } from "./StatusBadge";
 
 function relativeTime(ts: number | null): string {
@@ -29,6 +31,13 @@ export function SeaChartCard({
   const lastEventTs = useVoyageStore(
     (s) => s.buffers[voyage.id]?.lastEventTs ?? null,
   );
+  // Deployment URL lives only in the event stream (P5). Derive it for completed
+  // voyages so the card can link the live artifact.
+  const eventsMap = useVoyageStore((s) => s.buffers[voyage.id]?.events);
+  const deploymentUrl = useMemo(() => {
+    if (voyage.status !== "COMPLETED" || !eventsMap) return null;
+    return latestDeployment(Array.from(eventsMap.values()))?.url ?? null;
+  }, [voyage.status, eventsMap]);
 
   return (
     <article
@@ -82,6 +91,19 @@ export function SeaChartCard({
             ))}
           </div>
         </div>
+      )}
+
+      {deploymentUrl && (
+        <a
+          href={deploymentUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={(e) => e.stopPropagation()}
+          className="mt-2 block truncate text-[11px] text-emerald-300 underline hover:text-emerald-200"
+          title={deploymentUrl}
+        >
+          🚀 View deployment ↗
+        </a>
       )}
 
       <div className="mt-2 flex items-center justify-between text-[11px] text-ocean-500">

--- a/src/frontend/lib/deployments.test.ts
+++ b/src/frontend/lib/deployments.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { latestDeployment } from "@/lib/deployments";
+import type { EventEnvelope } from "@/lib/types";
+
+function ev(type: string, payload: Record<string, unknown>, msg = "1"): EventEnvelope {
+  return {
+    event_id: `e-${msg}`,
+    msg_id: msg,
+    ts: Number(msg),
+    source_role: "helmsman",
+    type,
+    payload,
+    isReplay: false,
+  };
+}
+
+describe("latestDeployment", () => {
+  it("returns null when there is no deployment_completed event", () => {
+    expect(latestDeployment([])).toBeNull();
+    expect(latestDeployment([ev("phase_build_started", { phase_number: 1 })])).toBeNull();
+  });
+
+  it("reads url and tier from a deployment_completed event", () => {
+    const d = latestDeployment([
+      ev("deployment_completed", { url: "https://preview.example.com", tier: "preview" }),
+    ]);
+    expect(d).toEqual({ url: "https://preview.example.com", tier: "preview" });
+  });
+
+  it("returns the latest deployment when several exist", () => {
+    const d = latestDeployment([
+      ev("deployment_completed", { url: "https://staging.example.com", tier: "staging" }, "1"),
+      ev("deployment_completed", { url: "https://prod.example.com", tier: "production" }, "2"),
+    ]);
+    expect(d).toEqual({ url: "https://prod.example.com", tier: "production" });
+  });
+
+  it("tolerates a missing url", () => {
+    const d = latestDeployment([ev("deployment_completed", { tier: "preview" })]);
+    expect(d).toEqual({ url: null, tier: "preview" });
+  });
+});

--- a/src/frontend/lib/deployments.ts
+++ b/src/frontend/lib/deployments.ts
@@ -1,0 +1,36 @@
+// Deployment API calls (Helmsman) + a helper to read the latest deployment off
+// the event stream. The deployment URL is intentionally NOT carried in the
+// playback reducer (P5 keeps only milestone-derivable state), so views derive
+// it directly from `deployment_completed` events here.
+
+import { apiFetch } from "@/lib/api";
+import type { DeployTier, EventEnvelope } from "@/lib/types";
+
+export type Deployment = {
+  url: string | null;
+  tier: DeployTier | null;
+};
+
+// Roll back the latest deployment for a tier (POST /voyages/{id}/rollback).
+export function rollbackDeployment(voyageId: string, tier: DeployTier) {
+  return apiFetch(`/voyages/${voyageId}/rollback`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ tier }),
+  });
+}
+
+// Most recent successful deployment from a voyage's events, or null. Scans from
+// the end so the latest `deployment_completed` wins.
+export function latestDeployment(events: EventEnvelope[]): Deployment | null {
+  for (let i = events.length - 1; i >= 0; i--) {
+    if (events[i].type === "deployment_completed") {
+      const payload = events[i].payload;
+      const url = typeof payload.url === "string" ? payload.url : null;
+      const tier =
+        typeof payload.tier === "string" ? (payload.tier as DeployTier) : null;
+      return { url, tier };
+    }
+  }
+  return null;
+}

--- a/src/frontend/lib/types.ts
+++ b/src/frontend/lib/types.ts
@@ -21,6 +21,11 @@ export type VoyageStatus =
   | "PAUSED"
   | "CANCELLED";
 
+// Deployment tiers (mirrors app/schemas/deployment.py DeploymentTier).
+export type DeployTier = "preview" | "staging" | "production";
+
+export const DEPLOY_TIERS: readonly DeployTier[] = ["preview", "staging", "production"];
+
 export const TERMINAL_STATUSES: ReadonlySet<VoyageStatus> = new Set<VoyageStatus>([
   "COMPLETED",
   "FAILED",

--- a/src/frontend/lib/voyages.test.ts
+++ b/src/frontend/lib/voyages.test.ts
@@ -49,6 +49,28 @@ describe("voyage lifecycle API", () => {
     expect(JSON.parse(init.body as string)).toEqual({
       task: "Build a URL shortener",
       deploy_tier: "preview",
+      approved_by: null,
+    });
+  });
+
+  it("sends the chosen tier and approver when provided", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ voyage_id: "v2", status: "CHARTED" }), {
+        status: 202,
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await startVoyage("v2", "Ship to production safely", {
+      deployTier: "production",
+      approvedBy: "user-123",
+    });
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(init.body as string)).toEqual({
+      task: "Ship to production safely",
+      deploy_tier: "production",
+      approved_by: "user-123",
     });
   });
 

--- a/src/frontend/lib/voyages.ts
+++ b/src/frontend/lib/voyages.ts
@@ -3,7 +3,7 @@
 // is handled.
 
 import { apiFetch } from "@/lib/api";
-import type { VoyageListItem } from "@/lib/types";
+import type { DeployTier, VoyageListItem } from "@/lib/types";
 
 export type VoyageCreatePayload = {
   title: string;
@@ -22,10 +22,22 @@ export function createVoyage(payload: VoyageCreatePayload) {
   });
 }
 
-export function startVoyage(id: string, task: string) {
+export type StartVoyageOptions = {
+  deployTier?: DeployTier;
+  // The approving user's id; required by the backend when deployTier is
+  // "production" (the Helmsman refuses to sail to production unapproved).
+  approvedBy?: string | null;
+};
+
+export function startVoyage(id: string, task: string, opts: StartVoyageOptions = {}) {
+  const deployTier = opts.deployTier ?? "preview";
   return apiFetch<{ voyage_id: string; status: string }>(`/voyages/${id}/start`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ task, deploy_tier: "preview" }),
+    body: JSON.stringify({
+      task,
+      deploy_tier: deployTier,
+      approved_by: opts.approvedBy ?? null,
+    }),
   });
 }


### PR DESCRIPTION
Fixes #52.

## Problem
The backend Helmsman supports the full three-tier model (`preview | staging | production`, production gated on `approved_by`, per-tier `/rollback`), but the deck hardcoded `deploy_tier="preview"` and surfaced none of it — no tier selector, no production approval, no deployment URL, no rollback.

## Fix
**Backend** — thread the tier + approval through the start path so the chosen tier reaches the pipeline's auto-deploy:
- `StartVoyageRequest.deploy_tier` widened from `Literal["preview"]` to the full `DeploymentTier`; new optional `approved_by` (the Helmsman refuses production without it).
- `PipelineState` + `pipeline_service.start` carry `deploy_tier` + `approved_by`; the deploying node passes `approved_by` to `helmsman.deploy(...)`. The voyage stays CHARTED through the pipeline, so the existing deploy gate + `_require_production_approval` apply unchanged. **Preview stays the default** — the happy path is untouched.

**Frontend:**
- `ChartCourseDialog` gains a **deploy-tier select**; choosing **production** reveals an approval acknowledgment and sends the current user's id as `approved_by`.
- `startVoyage(id, task, { deployTier, approvedBy })` no longer hardcodes preview.
- New `lib/deployments`: `rollbackDeployment()` + `latestDeployment()` — derives the deployment URL/tier from `deployment_completed` events (the playback reducer deliberately omits the URL per the P5 contract).
- `DetailsDrawer` shows the deployment **URL as a link** + a **Rollback** action with confirmation; `SeaChartCard` links the deployment URL for completed voyages.

## Acceptance criteria
- [x] A voyage can be sailed to staging from the deck; production prompts for explicit approval and sends `approved_by`.
- [x] Deployment URL is clickable from the Sea Chart card and the details drawer.
- [x] Rollback action visible for the latest deployment, with confirmation.
- [x] `deploy_tier` no longer hardcoded in the `startVoyage` caller.

## Known follow-up
`resumeVoyage()` still hardcodes `deploy_tier: "preview"` — fixing it correctly means carrying the voyage's original tier, which overlaps with #53's resume-body rework, so it's deferred there. This PR doesn't regress resume (it already used preview).

## Tests
Backend `939 passed, 19 skipped`; `ruff`/`mypy` clean (modulo the pre-existing `python-jose` stub). Frontend `tsc`/`next lint` clean, `61` vitest tests pass. New: tier/approval acceptance in `test_pipeline_api.py`, deploy-node forwarding in `test_pipeline_graph.py`, `lib/deployments.test.ts`, `lib/voyages.test.ts`.

https://claude.ai/code/session_01GC6ekfqN4PxAXEu6nyJG32

---
_Generated by [Claude Code](https://claude.ai/code/session_01GC6ekfqN4PxAXEu6nyJG32)_