### PR TITLE
feat(resume): make /resume task optional, reuse the stored mission (#53)

### DIFF
--- a/src/backend/app/api/v1/pipeline.py
+++ b/src/backend/app/api/v1/pipeline.py
@@ -34,12 +34,14 @@ from app.models import get_db
 from app.models.enums import VoyageStatus
 from app.models.user import User
 from app.models.voyage import Voyage
+from app.schemas.deployment import DeploymentTier
 from app.schemas.pipeline import (
     InjectContextRequest,
     InterventionResponse,
     PipelineEventEnvelope,
     PipelineStatusSnapshot,
     RedirectPhaseRequest,
+    ResumeVoyageRequest,
     StartVoyageRequest,
     StartVoyageResponse,
 )
@@ -88,8 +90,12 @@ def _spawn_pipeline_task(
     request: Request,
     voyage: Voyage,
     user: User,
-    body: StartVoyageRequest,
     pipeline_service: PipelineService,
+    *,
+    task: str,
+    deploy_tier: DeploymentTier,
+    max_parallel_shipwrights: int | None,
+    approved_by: uuid.UUID | None,
 ) -> StartVoyageResponse:
     """Register a background pipeline task in `app.state.pipeline_tasks`.
 
@@ -100,22 +106,22 @@ def _spawn_pipeline_task(
     registry: dict[uuid.UUID, asyncio.Task[None]] = request.app.state.pipeline_tasks
     voyage_id = voyage.id
 
-    task = asyncio.create_task(
+    pipeline_task = asyncio.create_task(
         pipeline_service.start(
             voyage,
             user.id,
-            body.task,
-            body.deploy_tier,
-            body.max_parallel_shipwrights,
-            approved_by=body.approved_by,
+            task,
+            deploy_tier,
+            max_parallel_shipwrights,
+            approved_by=approved_by,
         )
     )
-    registry[voyage_id] = task
+    registry[voyage_id] = pipeline_task
 
     def _cleanup(_t: asyncio.Task[None]) -> None:
         registry.pop(voyage_id, None)
 
-    task.add_done_callback(_cleanup)
+    pipeline_task.add_done_callback(_cleanup)
 
     return StartVoyageResponse(voyage_id=voyage_id, status=voyage.status)
 
@@ -161,7 +167,16 @@ async def start_voyage(
             )
         )
 
-    return _spawn_pipeline_task(request, voyage, user, body, pipeline_service)
+    return _spawn_pipeline_task(
+        request,
+        voyage,
+        user,
+        pipeline_service,
+        task=body.task,
+        deploy_tier=body.deploy_tier,
+        max_parallel_shipwrights=body.max_parallel_shipwrights,
+        approved_by=body.approved_by,
+    )
 
 
 @router.post(
@@ -171,7 +186,7 @@ async def start_voyage(
 )
 async def resume_voyage(
     voyage_id: uuid.UUID,
-    body: StartVoyageRequest,
+    body: ResumeVoyageRequest,
     request: Request,
     user: User = Depends(get_current_user),
     voyage: Voyage = Depends(get_authorized_voyage),
@@ -194,10 +209,11 @@ async def resume_voyage(
     | COMPLETED / CANCELLED                                   | reject            | 409  |
     | (running task already in registry)                      | reject            | 409  |
 
-    The request body is `StartVoyageRequest` (same shape as `/start`). The
-    `task` field is required by validation but is unused on resume because
-    the Captain stage is skip-already-satisfied (the plan already exists).
-    Callers may supply a placeholder string of >= 10 chars.
+    The request body is optional (`ResumeVoyageRequest`). Resume reuses the
+    voyage's stored mission (`description`); planning is skip-already-satisfied,
+    so no fresh task is needed. Pass a `task` only to update the mission for this
+    run. Rejected with `VOYAGE_NO_TASK` (422) when no task is given and the
+    voyage has no stored mission.
     """
     if _already_running(request, voyage_id):
         raise _pipeline_http_exception(
@@ -207,12 +223,32 @@ async def resume_voyage(
             )
         )
 
+    # Reuse the stored mission when no task is supplied. Resolve before flipping
+    # status so a task-less voyage with no stored mission is rejected cleanly.
+    effective_task = body.task or voyage.description
+    if not effective_task:
+        raise _pipeline_http_exception(
+            PipelineError(
+                "VOYAGE_NO_TASK",
+                "Voyage has no stored mission to resume; provide a task",
+            )
+        )
+
     try:
         await pipeline_service.resume(voyage)
     except PipelineError as exc:
         raise _pipeline_http_exception(exc) from exc
 
-    return _spawn_pipeline_task(request, voyage, user, body, pipeline_service)
+    return _spawn_pipeline_task(
+        request,
+        voyage,
+        user,
+        pipeline_service,
+        task=effective_task,
+        deploy_tier=body.deploy_tier,
+        max_parallel_shipwrights=body.max_parallel_shipwrights,
+        approved_by=body.approved_by,
+    )
 
 
 @router.post("/pause", status_code=status.HTTP_200_OK)

--- a/src/backend/app/schemas/pipeline.py
+++ b/src/backend/app/schemas/pipeline.py
@@ -40,6 +40,23 @@ class StartVoyageRequest(BaseModel):
     max_parallel_shipwrights: int | None = Field(default=None, ge=1, le=10)
 
 
+class ResumeVoyageRequest(BaseModel):
+    """POST /voyages/{id}/resume request body.
+
+    All fields are optional: an empty body (`{}`) resumes a PAUSED/FAILED voyage
+    using the voyage's stored mission (`description`). Planning is skip-already-
+    satisfied on resume, so no fresh task is needed. A `task`, when supplied,
+    updates the mission for this run.
+    """
+
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    task: str | None = Field(default=None, min_length=10, max_length=5000)
+    deploy_tier: DeploymentTier = "preview"
+    approved_by: uuid.UUID | None = None
+    max_parallel_shipwrights: int | None = Field(default=None, ge=1, le=10)
+
+
 class InjectContextRequest(BaseModel):
     """POST /voyages/{id}/inject request body (Phase 17)."""
 

--- a/src/backend/tests/test_pipeline_api.py
+++ b/src/backend/tests/test_pipeline_api.py
@@ -27,6 +27,7 @@ from app.models.enums import CrewRole, VoyageStatus
 from app.schemas.pipeline import (
     PipelineEventEnvelope,
     PipelineStatusSnapshot,
+    ResumeVoyageRequest,
     StartVoyageRequest,
     StartVoyageResponse,
 )
@@ -42,11 +43,15 @@ def _mock_user() -> MagicMock:
     return user
 
 
-def _mock_voyage(status: str = VoyageStatus.CHARTED.value) -> MagicMock:
+def _mock_voyage(
+    status: str = VoyageStatus.CHARTED.value,
+    description: str | None = "Build a URL shortener with auth",
+) -> MagicMock:
     voyage = MagicMock()
     voyage.id = VOYAGE_ID
     voyage.user_id = USER_ID
     voyage.status = status
+    voyage.description = description
     voyage.phase_status = {}
     return voyage
 
@@ -353,7 +358,7 @@ class TestResumeVoyage:
             v.status = VoyageStatus.CHARTED.value
 
         svc.resume = AsyncMock(side_effect=_resume)
-        body = StartVoyageRequest(task="resume placeholder task")
+        body = ResumeVoyageRequest(task="resume placeholder task")
         registry: dict[uuid.UUID, asyncio.Task[None]] = {}
         request = _mock_request(pipeline_tasks=registry)
 
@@ -381,7 +386,7 @@ class TestResumeVoyage:
             v.status = VoyageStatus.CHARTED.value
 
         svc.resume = AsyncMock(side_effect=_resume)
-        body = StartVoyageRequest(task="resume after failure")
+        body = ResumeVoyageRequest(task="resume after failure")
         request = _mock_request()
 
         result = await resume_voyage(VOYAGE_ID, body, request, _mock_user(), voyage, svc)
@@ -400,7 +405,7 @@ class TestResumeVoyage:
         svc = _mock_pipeline_service()
         voyage = _mock_voyage(status=VoyageStatus.CHARTED.value)
         svc.resume = AsyncMock(return_value=None)
-        body = StartVoyageRequest(task="resume already charted")
+        body = ResumeVoyageRequest(task="resume already charted")
         request = _mock_request()
 
         result = await resume_voyage(VOYAGE_ID, body, request, _mock_user(), voyage, svc)
@@ -413,6 +418,80 @@ class TestResumeVoyage:
         await asyncio.sleep(0)
 
     @pytest.mark.asyncio
+    async def test_resume_with_empty_body_uses_stored_mission(self) -> None:
+        from app.api.v1.pipeline import resume_voyage
+
+        svc = _mock_pipeline_service()
+        voyage = _mock_voyage(
+            status=VoyageStatus.PAUSED.value, description="Ship the URL shortener"
+        )
+
+        async def _resume(v: Any) -> None:
+            v.status = VoyageStatus.CHARTED.value
+
+        svc.resume = AsyncMock(side_effect=_resume)
+        body = ResumeVoyageRequest()  # empty body — no fabricated task
+        request = _mock_request()
+
+        await resume_voyage(VOYAGE_ID, body, request, _mock_user(), voyage, svc)
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+        # start() received the stored mission as the task — never a placeholder.
+        svc.start.assert_called_once()
+        assert svc.start.call_args.args[2] == "Ship the URL shortener"
+        assert svc.start.call_args.args[2] != "resume-voyage"
+
+    @pytest.mark.asyncio
+    async def test_resume_with_explicit_task_overrides_mission(self) -> None:
+        from app.api.v1.pipeline import resume_voyage
+
+        svc = _mock_pipeline_service()
+        voyage = _mock_voyage(status=VoyageStatus.PAUSED.value, description="old mission")
+
+        async def _resume(v: Any) -> None:
+            v.status = VoyageStatus.CHARTED.value
+
+        svc.resume = AsyncMock(side_effect=_resume)
+        body = ResumeVoyageRequest(task="updated mission for this run")
+        request = _mock_request()
+
+        await resume_voyage(VOYAGE_ID, body, request, _mock_user(), voyage, svc)
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+        svc.start.assert_called_once()
+        assert svc.start.call_args.args[2] == "updated mission for this run"
+
+    @pytest.mark.asyncio
+    async def test_resume_rejects_when_no_task_and_no_mission(self) -> None:
+        from app.api.v1.pipeline import resume_voyage
+
+        svc = _mock_pipeline_service()
+        voyage = _mock_voyage(status=VoyageStatus.PAUSED.value, description=None)
+        body = ResumeVoyageRequest()
+        request = _mock_request()
+
+        with pytest.raises(HTTPException) as exc_info:
+            await resume_voyage(VOYAGE_ID, body, request, _mock_user(), voyage, svc)
+
+        assert exc_info.value.status_code == 422
+        assert exc_info.value.detail["error"]["code"] == "VOYAGE_NO_TASK"
+        # Rejected before flipping status or spawning.
+        svc.resume.assert_not_called()
+        svc.start.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_resume_request_schema_defaults(self) -> None:
+        body = ResumeVoyageRequest()
+        assert body.task is None
+        assert body.deploy_tier == "preview"
+        assert body.approved_by is None
+        # Too-short task still rejected when one is supplied.
+        with pytest.raises(Exception):
+            ResumeVoyageRequest.model_validate({"task": "short"})
+
+    @pytest.mark.asyncio
     async def test_returns_409_when_voyage_completed(self) -> None:
         from app.api.v1.pipeline import resume_voyage
 
@@ -423,7 +502,7 @@ class TestResumeVoyage:
                 "Voyage status is COMPLETED; cannot resume a completed voyage",
             )
         )
-        body = StartVoyageRequest(task="resume completed placeholder")
+        body = ResumeVoyageRequest(task="resume completed placeholder")
         request = _mock_request()
 
         with pytest.raises(HTTPException) as exc_info:
@@ -451,7 +530,7 @@ class TestResumeVoyage:
                 "Voyage status is CANCELLED; cannot resume a cancelled voyage",
             )
         )
-        body = StartVoyageRequest(task="resume cancelled placeholder")
+        body = ResumeVoyageRequest(task="resume cancelled placeholder")
         request = _mock_request()
 
         with pytest.raises(HTTPException) as exc_info:
@@ -477,7 +556,7 @@ class TestResumeVoyage:
         try:
             registry: dict[uuid.UUID, asyncio.Task[None]] = {VOYAGE_ID: running}
             request = _mock_request(pipeline_tasks=registry)
-            body = StartVoyageRequest(task="resume running placeholder")
+            body = ResumeVoyageRequest(task="resume running placeholder")
 
             with pytest.raises(HTTPException) as exc_info:
                 await resume_voyage(
@@ -514,7 +593,7 @@ class TestResumeVoyage:
                 "or wait for the current run to reach a resumable state",
             )
         )
-        body = StartVoyageRequest(task="resume mid-stage placeholder")
+        body = ResumeVoyageRequest(task="resume mid-stage placeholder")
         request = _mock_request()
 
         with pytest.raises(HTTPException) as exc_info:
@@ -556,7 +635,7 @@ class TestResumeVoyage:
         # Voyage owner-mismatch is a dependency-layer concern; the dependency
         # would short-circuit with 404. Inside the endpoint, we should accept
         # whatever voyage the dependency injected.
-        body = StartVoyageRequest(task="resume placeholder body")
+        body = ResumeVoyageRequest(task="resume placeholder body")
         request = _mock_request()
 
         async def _resume(v: Any) -> None:

--- a/src/frontend/lib/intervention.ts
+++ b/src/frontend/lib/intervention.ts
@@ -8,12 +8,12 @@ export function pauseVoyage(id: string) {
 }
 
 export function resumeVoyage(id: string) {
-  // `task` is required by validation but unused on resume (the plan already
-  // exists); a >=10-char placeholder satisfies the schema.
+  // Empty body: the server reuses the voyage's stored mission and skips
+  // already-satisfied stages. No fabricated task or tier needed.
   return apiFetch(`/voyages/${id}/resume`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ task: "resume-voyage", deploy_tier: "preview" }),
+    body: JSON.stringify({}),
   });
 }
 


### PR DESCRIPTION
Fixes #53.

## Problem
`POST /voyages/{id}/resume` required a `task` (min 10 chars), so the deck sent a literal placeholder `"resume-voyage"` (padded to pass validation). That placeholder leaked into pipeline state and the Ship's Log as if it were the mission — even though resume semantics are "continue the stored mission from the last checkpoint; stage guards skip already-satisfied phases."

## Fix
- New **`ResumeVoyageRequest`** with all fields optional. The endpoint resolves the effective task from `body.task or voyage.description` (the stored mission), rejecting with **`VOYAGE_NO_TASK` (422)** only when neither exists. The check runs **before** flipping status, so a task-less, mission-less voyage isn't left half-resumed.
- `_spawn_pipeline_task` now takes explicit `task` / `deploy_tier` / `max_parallel_shipwrights` / `approved_by` args (shared cleanly by `/start` and `/resume`).
- Frontend `resumeVoyage()` sends an **empty body** (`{}`) — no fabricated task, and no hardcoded `deploy_tier` (this also removes the `lib/intervention.ts` hardcoding noted as follow-up in #52).

## Acceptance criteria
- [x] `POST /resume` with an empty body resumes a PAUSED/FAILED voyage using the stored mission.
- [x] Ship's Log / pipeline state never contain `"resume-voyage"` (the task is the real mission).
- [x] Existing behavior preserved when a caller passes a task (treated as an updated mission for the run, documented in the endpoint docstring).
- [x] Frontend `resumeVoyage()` no longer fabricates a task.

## Note
Resume still defaults `deploy_tier` to `preview` (the voyage has no persisted tier column). Carrying the original tier across resume would need a schema migration and is out of scope here; this PR removes the frontend hardcoding and stops fabricating the task, which is what #53 asks.

## Tests
Backend `943 passed, 19 skipped`; `ruff`/`mypy` clean (modulo the pre-existing `python-jose` stub). Frontend `tsc`/`next lint` clean, `61` vitest tests pass. New resume tests cover empty-body mission reuse, explicit-task override, the no-task/no-mission rejection, and schema defaults.

https://claude.ai/code/session_01GC6ekfqN4PxAXEu6nyJG32

---
_Generated by [Claude Code](https://claude.ai/code/session_01GC6ekfqN4PxAXEu6nyJG32)_