### PR TITLE
feat(dial): surface the Dial System in the deck — config panel, failover toast, usage (#54)

### DIFF
--- a/src/backend/app/api/v1/dial.py
+++ b/src/backend/app/api/v1/dial.py
@@ -2,21 +2,46 @@ from __future__ import annotations
 
 import uuid
 from collections.abc import AsyncIterator
+from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import StreamingResponse
+from redis.asyncio import Redis
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.api.v1.dependencies import get_authorized_voyage, get_dial_router
+from app.api.v1.dependencies import get_authorized_voyage, get_dial_router, get_redis
+from app.dial_system.rate_limiter import WINDOW_SECONDS, RateLimiter
 from app.dial_system.router import DialSystemRouter
 from app.models import get_db
 from app.models.dial_config import DialConfig
 from app.models.voyage import Voyage
 from app.schemas.dial_config import DialConfigRead, DialConfigUpdate
-from app.schemas.dial_system import CompletionRequest, CompletionResult
+from app.schemas.dial_system import (
+    CompletionRequest,
+    CompletionResult,
+    DialStatusResponse,
+    ProviderWindowUsage,
+)
 
 router = APIRouter(prefix="/voyages", tags=["dial-system"])
+
+
+def _providers_in_config(
+    role_mapping: dict[str, Any] | None, fallback_chain: dict[str, Any] | None
+) -> list[str]:
+    """Distinct provider names referenced by a dial config (mapping + fallbacks)."""
+    providers: set[str] = set()
+    for cfg in (role_mapping or {}).values():
+        if isinstance(cfg, dict) and cfg.get("provider"):
+            providers.add(str(cfg["provider"]))
+    for entries in (fallback_chain or {}).values():
+        for entry in entries or []:
+            if isinstance(entry, str):
+                providers.add(entry)
+            elif isinstance(entry, dict) and entry.get("provider"):
+                providers.add(str(entry["provider"]))
+    return sorted(providers)
 
 
 @router.get("/{voyage_id}/dial-config", response_model=DialConfigRead)
@@ -52,6 +77,44 @@ async def update_dial_config(
     await session.commit()
     await session.refresh(config)
     return config
+
+
+@router.get("/{voyage_id}/dial-status", response_model=DialStatusResponse)
+async def get_dial_status(
+    voyage_id: uuid.UUID,
+    session: AsyncSession = Depends(get_db),
+    redis: Redis = Depends(get_redis),
+    _voyage: Voyage = Depends(get_authorized_voyage),
+) -> DialStatusResponse:
+    """Per-provider rate-limit headroom for the current sliding window (read-only).
+
+    Lets the deck show how much request/token budget each configured provider
+    has left, and pre-warn before a trip. Reuses the same RateLimiter the router
+    consults; no routing/failover logic is touched.
+    """
+    result = await session.execute(select(DialConfig).where(DialConfig.voyage_id == voyage_id))
+    config = result.scalar_one_or_none()
+    if config is None:
+        raise HTTPException(status_code=404, detail="Dial config not found for this voyage")
+
+    limiter = RateLimiter(redis)
+    providers: list[ProviderWindowUsage] = []
+    for provider in _providers_in_config(config.role_mapping, config.fallback_chain):
+        st = await limiter.check(provider)
+        providers.append(
+            ProviderWindowUsage(
+                provider=provider,
+                is_limited=st.is_limited,
+                remaining_requests=st.remaining_requests,
+                remaining_tokens=st.remaining_tokens,
+                max_requests=limiter.max_requests,
+                max_tokens=limiter.max_tokens,
+            )
+        )
+
+    return DialStatusResponse(
+        voyage_id=voyage_id, window_seconds=WINDOW_SECONDS, providers=providers
+    )
 
 
 @router.post(

--- a/src/backend/app/api/v1/dial.py
+++ b/src/backend/app/api/v1/dial.py
@@ -27,6 +27,15 @@ from app.schemas.dial_system import (
 router = APIRouter(prefix="/voyages", tags=["dial-system"])
 
 
+def _canonical_provider(provider: str) -> str:
+    """Match DialSystemRouter._get_provider_name so rate-limit keys line up.
+
+    The factory accepts the ``claude-code`` alias, but the router records and
+    enforces usage under ``claude_code`` — report headroom under the same name.
+    """
+    return "claude_code" if provider in ("claude_code", "claude-code") else provider
+
+
 def _providers_in_config(
     role_mapping: dict[str, Any] | None, fallback_chain: dict[str, Any] | None
 ) -> list[str]:
@@ -34,13 +43,13 @@ def _providers_in_config(
     providers: set[str] = set()
     for cfg in (role_mapping or {}).values():
         if isinstance(cfg, dict) and cfg.get("provider"):
-            providers.add(str(cfg["provider"]))
+            providers.add(_canonical_provider(str(cfg["provider"])))
     for entries in (fallback_chain or {}).values():
         for entry in entries or []:
             if isinstance(entry, str):
-                providers.add(entry)
+                providers.add(_canonical_provider(entry))
             elif isinstance(entry, dict) and entry.get("provider"):
-                providers.add(str(entry["provider"]))
+                providers.add(_canonical_provider(str(entry["provider"])))
     return sorted(providers)
 
 

--- a/src/backend/app/dial_system/rate_limiter.py
+++ b/src/backend/app/dial_system/rate_limiter.py
@@ -21,6 +21,14 @@ class RateLimiter:
         self._max_tokens = max_tokens_per_minute
         self._max_requests = max_requests_per_minute
 
+    @property
+    def max_tokens(self) -> int:
+        return self._max_tokens
+
+    @property
+    def max_requests(self) -> int:
+        return self._max_requests
+
     def _key(self, provider: str) -> str:
         return f"{KEY_PREFIX}:{provider}"
 

--- a/src/backend/app/schemas/dial_system.py
+++ b/src/backend/app/schemas/dial_system.py
@@ -42,3 +42,22 @@ class RateLimitStatus(BaseModel):
     remaining_tokens: int | None = None
     remaining_requests: int | None = None
     reset_at: datetime | None = None
+
+
+class ProviderWindowUsage(BaseModel):
+    """Per-provider sliding-window usage for the current voyage's dial config."""
+
+    provider: str
+    is_limited: bool
+    remaining_requests: int | None
+    remaining_tokens: int | None
+    max_requests: int
+    max_tokens: int
+
+
+class DialStatusResponse(BaseModel):
+    """Read-only headroom snapshot surfaced by GET /voyages/{id}/dial-status."""
+
+    voyage_id: uuid.UUID
+    window_seconds: int
+    providers: list[ProviderWindowUsage]

--- a/src/backend/tests/test_dial_api.py
+++ b/src/backend/tests/test_dial_api.py
@@ -118,6 +118,17 @@ class TestProvidersInConfig:
 
         assert _providers_in_config(None, None) == []
 
+    def test_canonicalizes_claude_code_alias(self) -> None:
+        from app.api.v1.dial import _providers_in_config
+
+        # The hyphen alias must collapse to claude_code (the router's rate-limit
+        # key), and dedupe with the underscore form.
+        providers = _providers_in_config(
+            {"captain": {"provider": "claude-code", "model": "sonnet"}},
+            {"captain": ["claude_code"]},
+        )
+        assert providers == ["claude_code"]
+
 
 class TestGetDialStatus:
     @staticmethod

--- a/src/backend/tests/test_dial_api.py
+++ b/src/backend/tests/test_dial_api.py
@@ -101,3 +101,83 @@ class TestUpdateDialConfig:
             await update_dial_config(VOYAGE_ID, update, session, user)
 
         assert exc_info.value.status_code == 404
+
+
+class TestProvidersInConfig:
+    def test_collects_mapping_and_fallback_providers(self) -> None:
+        from app.api.v1.dial import _providers_in_config
+
+        providers = _providers_in_config(
+            {"captain": {"provider": "anthropic", "model": "x"}},
+            {"captain": ["openai", {"provider": "ollama", "model": "llama3"}]},
+        )
+        assert providers == ["anthropic", "ollama", "openai"]  # sorted, deduped
+
+    def test_handles_none(self) -> None:
+        from app.api.v1.dial import _providers_in_config
+
+        assert _providers_in_config(None, None) == []
+
+
+class TestGetDialStatus:
+    @staticmethod
+    def _redis(requests: int = 0, entries: list[tuple[str, float]] | None = None) -> AsyncMock:
+        redis = AsyncMock()
+        redis.zrangebyscore = AsyncMock(return_value=entries or [])
+        redis.zcount = AsyncMock(return_value=requests)
+        return redis
+
+    @pytest.mark.asyncio
+    async def test_returns_usage_for_each_provider(self) -> None:
+        from app.api.v1.dial import get_dial_status
+
+        config = DialConfig(
+            id=CONFIG_ID,
+            voyage_id=VOYAGE_ID,
+            role_mapping=ROLE_MAPPING,
+            fallback_chain=FALLBACK_CHAIN,
+        )
+        session = _mock_session_with_config(config)
+
+        result = await get_dial_status(VOYAGE_ID, session, self._redis(), MagicMock())
+
+        assert result.window_seconds == 60
+        names = {p.provider for p in result.providers}
+        assert names == {"anthropic", "openai", "ollama"}
+        for p in result.providers:
+            assert p.is_limited is False
+            assert p.remaining_requests == 100
+            assert p.remaining_tokens == 100_000
+            assert p.max_requests == 100
+            assert p.max_tokens == 100_000
+
+    @pytest.mark.asyncio
+    async def test_reflects_consumed_window(self) -> None:
+        from app.api.v1.dial import get_dial_status
+
+        config = DialConfig(
+            id=CONFIG_ID,
+            voyage_id=VOYAGE_ID,
+            role_mapping={"captain": {"provider": "anthropic", "model": "x"}},
+            fallback_chain=None,
+        )
+        session = _mock_session_with_config(config)
+        # 3 requests, 1500 tokens consumed this window.
+        redis = self._redis(requests=3, entries=[("1.0:1000", 1.0), ("2.0:500", 2.0)])
+
+        result = await get_dial_status(VOYAGE_ID, session, redis, MagicMock())
+
+        anthropic = next(p for p in result.providers if p.provider == "anthropic")
+        assert anthropic.remaining_requests == 97
+        assert anthropic.remaining_tokens == 98_500
+
+    @pytest.mark.asyncio
+    async def test_404_when_no_config(self) -> None:
+        from app.api.v1.dial import get_dial_status
+
+        session = _mock_session_with_config(None)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await get_dial_status(VOYAGE_ID, session, self._redis(), MagicMock())
+
+        assert exc_info.value.status_code == 404

--- a/src/frontend/components/observation-deck/CrewMap.tsx
+++ b/src/frontend/components/observation-deck/CrewMap.tsx
@@ -39,6 +39,7 @@ const ACTIVITY_LABEL: Record<string, string> = {
   deployment_completed: "Deployed ✓",
   deployment_failed: "Deploy failed ✕",
   pipeline_stage_entered: "Entering stage…",
+  provider_switched: "Switched provider ⚡",
 };
 
 function nodeOf(role: CrewRole): Node | undefined {

--- a/src/frontend/components/observation-deck/DeckShell.tsx
+++ b/src/frontend/components/observation-deck/DeckShell.tsx
@@ -15,6 +15,8 @@ import { DetailsDrawer } from "./DetailsDrawer";
 import { CommandPalette } from "./CommandPalette";
 import { HelpDialog } from "./HelpDialog";
 import { InterventionControls } from "./InterventionControls";
+import { Toaster } from "./Toaster";
+import { useFailoverToasts } from "@/hooks/useFailoverToasts";
 
 const TABS = [
   { href: "/app/sea-chart", label: "Sea Chart" },
@@ -38,6 +40,7 @@ export function DeckShell({ children }: { children: React.ReactNode }) {
   useVoyageStatus(voyageId);
   const { reconnect } = useVoyageStream(voyageId);
   const focusMode = useUiStore((s) => s.focusMode);
+  useFailoverToasts();
 
   return (
     <div className="flex h-screen flex-col bg-ocean-950 text-ocean-100">
@@ -86,6 +89,7 @@ export function DeckShell({ children }: { children: React.ReactNode }) {
       <DetailsDrawer />
       <CommandPalette />
       <HelpDialog />
+      <Toaster />
     </div>
   );
 }

--- a/src/frontend/components/observation-deck/DetailsDrawer.tsx
+++ b/src/frontend/components/observation-deck/DetailsDrawer.tsx
@@ -5,8 +5,9 @@ import { usePlaybackStore } from "@/stores/playback";
 import { useDerivedState } from "@/hooks/useDerivedState";
 import { useActiveVoyageEvents } from "@/hooks/useActiveVoyageEvents";
 import { latestDeployment, rollbackDeployment } from "@/lib/deployments";
+import { DialPanel } from "./DialPanel";
 
-type Tab = "overview" | "events" | "timestamps";
+type Tab = "overview" | "events" | "dial" | "timestamps";
 
 export function DetailsDrawer() {
   const drawerVoyageId = usePlaybackStore((s) => s.drawerVoyageId);
@@ -63,7 +64,7 @@ export function DetailsDrawer() {
         </header>
 
         <nav className="flex gap-1 border-b border-ocean-800 px-2 py-2 text-xs">
-          {(["overview", "events", "timestamps"] as Tab[]).map((t) => (
+          {(["overview", "events", "dial", "timestamps"] as Tab[]).map((t) => (
             <button
               key={t}
               onClick={() => setTab(t)}
@@ -174,6 +175,8 @@ export function DetailsDrawer() {
               {events.length === 0 && <li className="text-ocean-500">No events yet.</li>}
             </ul>
           )}
+
+          {tab === "dial" && <DialPanel voyageId={drawerVoyageId} />}
 
           {tab === "timestamps" && (
             <div className="space-y-3">

--- a/src/frontend/components/observation-deck/DialPanel.tsx
+++ b/src/frontend/components/observation-deck/DialPanel.tsx
@@ -1,0 +1,197 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  DIAL_PROVIDERS,
+  DIAL_ROLES,
+  fallbackLabel,
+  getDialConfig,
+  getDialStatus,
+  updateDialConfig,
+  type DialProvider,
+  type ProviderWindowUsage,
+  type RoleProviderConfig,
+} from "@/lib/dial";
+
+// Per-voyage Dial System panel: view/edit role→provider mapping (writes through
+// PUT /dial-config, taking effect on the next LLM call), see fallback chains,
+// and watch per-provider rate-limit headroom (#54).
+export function DialPanel({ voyageId }: { voyageId: string }) {
+  const queryClient = useQueryClient();
+
+  const configQuery = useQuery({
+    queryKey: ["dial-config", voyageId],
+    queryFn: () => getDialConfig(voyageId),
+    retry: false,
+  });
+  const statusQuery = useQuery({
+    queryKey: ["dial-status", voyageId],
+    queryFn: () => getDialStatus(voyageId),
+    refetchInterval: 15000,
+    retry: false,
+  });
+
+  const [draft, setDraft] = useState<Record<string, RoleProviderConfig>>({});
+  const [saved, setSaved] = useState(false);
+
+  useEffect(() => {
+    if (configQuery.data) setDraft({ ...configQuery.data.role_mapping });
+  }, [configQuery.data]);
+
+  const mutation = useMutation({
+    mutationFn: (mapping: Record<string, RoleProviderConfig>) =>
+      updateDialConfig(voyageId, { role_mapping: mapping }),
+    onSuccess: () => {
+      setSaved(true);
+      void queryClient.invalidateQueries({ queryKey: ["dial-config", voyageId] });
+      setTimeout(() => setSaved(false), 2500);
+    },
+  });
+
+  if (configQuery.isLoading) {
+    return <p className="text-xs text-ocean-400">Loading dial config…</p>;
+  }
+  if (configQuery.isError || !configQuery.data) {
+    return (
+      <p className="text-xs text-ocean-400">
+        No dial config for this voyage yet. It is created when the voyage is charted.
+      </p>
+    );
+  }
+
+  const config = configQuery.data;
+  const dirty = JSON.stringify(draft) !== JSON.stringify(config.role_mapping);
+  const usageByProvider = new Map<string, ProviderWindowUsage>(
+    (statusQuery.data?.providers ?? []).map((p) => [p.provider, p]),
+  );
+
+  const setRole = (role: string, patch: Partial<RoleProviderConfig>) => {
+    setDraft((d) => {
+      const base = d[role] ?? { provider: "anthropic", model: "" };
+      return { ...d, [role]: { ...base, ...patch } };
+    });
+  };
+
+  return (
+    <div className="space-y-4">
+      <section>
+        <h4 className="mb-2 text-xs font-medium uppercase tracking-wide text-ocean-400">
+          Role → provider
+        </h4>
+        <div className="space-y-2">
+          {DIAL_ROLES.map((role) => {
+            const cfg = draft[role];
+            return (
+              <div key={role} className="flex items-center gap-2">
+                <span className="w-20 shrink-0 text-xs capitalize text-ocean-300">{role}</span>
+                <select
+                  value={cfg?.provider ?? ""}
+                  onChange={(e) => setRole(role, { provider: e.target.value as DialProvider })}
+                  className="w-28 shrink-0 rounded border border-ocean-700 bg-ocean-950 px-1.5 py-1 text-xs text-ocean-100 outline-none focus:border-ocean-400"
+                >
+                  <option value="" disabled>
+                    —
+                  </option>
+                  {DIAL_PROVIDERS.map((p) => (
+                    <option key={p} value={p}>
+                      {p}
+                    </option>
+                  ))}
+                </select>
+                <input
+                  value={cfg?.model ?? ""}
+                  onChange={(e) => setRole(role, { model: e.target.value })}
+                  placeholder="model"
+                  className="min-w-0 flex-1 rounded border border-ocean-700 bg-ocean-950 px-1.5 py-1 text-xs text-ocean-100 outline-none focus:border-ocean-400"
+                />
+              </div>
+            );
+          })}
+        </div>
+        <div className="mt-2 flex items-center gap-2">
+          <button
+            disabled={!dirty || mutation.isPending}
+            onClick={() => mutation.mutate(draft)}
+            className="rounded bg-ocean-500 px-3 py-1 text-xs text-ocean-950 hover:bg-ocean-400 disabled:opacity-50"
+          >
+            {mutation.isPending ? "Saving…" : "Save mapping"}
+          </button>
+          {dirty && <span className="text-xs text-amber-400">Unsaved changes</span>}
+          {saved && !dirty && <span className="text-xs text-emerald-400">Saved ✓</span>}
+          {mutation.isError && (
+            <span className="text-xs text-rose-400">
+              {mutation.error instanceof Error ? mutation.error.message : "Save failed"}
+            </span>
+          )}
+        </div>
+        <p className="mt-1 text-[11px] text-ocean-500">Takes effect on the next LLM call.</p>
+      </section>
+
+      {config.fallback_chain && Object.keys(config.fallback_chain).length > 0 && (
+        <section>
+          <h4 className="mb-2 text-xs font-medium uppercase tracking-wide text-ocean-400">
+            Fallback chains
+          </h4>
+          <div className="space-y-1 text-xs">
+            {Object.entries(config.fallback_chain).map(([role, entries]) => (
+              <div key={role} className="flex items-baseline gap-2">
+                <span className="w-20 shrink-0 capitalize text-ocean-300">{role}</span>
+                <span className="text-ocean-200">
+                  {entries.map(fallbackLabel).join(" → ") || "—"}
+                </span>
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+
+      <section>
+        <h4 className="mb-2 text-xs font-medium uppercase tracking-wide text-ocean-400">
+          Rate-limit headroom
+          {statusQuery.data && (
+            <span className="ml-1 normal-case text-ocean-500">
+              · {statusQuery.data.window_seconds}s window
+            </span>
+          )}
+        </h4>
+        {statusQuery.isError ? (
+          <p className="text-xs text-ocean-500">Usage unavailable.</p>
+        ) : usageByProvider.size === 0 ? (
+          <p className="text-xs text-ocean-500">No providers configured.</p>
+        ) : (
+          <div className="space-y-2">
+            {Array.from(usageByProvider.values()).map((u) => (
+              <ProviderUsage key={u.provider} usage={u} />
+            ))}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}
+
+function ProviderUsage({ usage }: { usage: ProviderWindowUsage }) {
+  const usedRequests = usage.max_requests - (usage.remaining_requests ?? usage.max_requests);
+  const pct = usage.max_requests > 0 ? Math.round((usedRequests / usage.max_requests) * 100) : 0;
+  return (
+    <div>
+      <div className="mb-0.5 flex items-center justify-between text-xs">
+        <span className="text-ocean-200">{usage.provider}</span>
+        {usage.is_limited ? (
+          <span className="text-rose-400">rate limited</span>
+        ) : (
+          <span className="text-ocean-400">
+            {usage.remaining_requests ?? "?"} req · {usage.remaining_tokens ?? "?"} tok left
+          </span>
+        )}
+      </div>
+      <div className="h-1.5 w-full overflow-hidden rounded-full bg-ocean-800">
+        <div
+          className={`h-full rounded-full ${usage.is_limited ? "bg-rose-500" : "bg-emerald-400"}`}
+          style={{ width: `${Math.min(100, pct)}%` }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/frontend/components/observation-deck/DialPanel.tsx
+++ b/src/frontend/components/observation-deck/DialPanel.tsx
@@ -62,6 +62,11 @@ export function DialPanel({ voyageId }: { voyageId: string }) {
 
   const config = configQuery.data;
   const dirty = JSON.stringify(draft) !== JSON.stringify(config.role_mapping);
+  // PUT replaces role_mapping wholesale and the router rejects any role missing
+  // a provider or model — block the save instead of bricking the voyage's routing.
+  const incomplete = Object.values(draft).some(
+    (c) => !c.provider || !c.model.trim(),
+  );
   const usageByProvider = new Map<string, ProviderWindowUsage>(
     (statusQuery.data?.providers ?? []).map((p) => [p.provider, p]),
   );
@@ -111,13 +116,17 @@ export function DialPanel({ voyageId }: { voyageId: string }) {
         </div>
         <div className="mt-2 flex items-center gap-2">
           <button
-            disabled={!dirty || mutation.isPending}
+            disabled={!dirty || incomplete || mutation.isPending}
             onClick={() => mutation.mutate(draft)}
             className="rounded bg-ocean-500 px-3 py-1 text-xs text-ocean-950 hover:bg-ocean-400 disabled:opacity-50"
           >
             {mutation.isPending ? "Saving…" : "Save mapping"}
           </button>
-          {dirty && <span className="text-xs text-amber-400">Unsaved changes</span>}
+          {incomplete ? (
+            <span className="text-xs text-rose-400">Every role needs a provider and model</span>
+          ) : (
+            dirty && <span className="text-xs text-amber-400">Unsaved changes</span>
+          )}
           {saved && !dirty && <span className="text-xs text-emerald-400">Saved ✓</span>}
           {mutation.isError && (
             <span className="text-xs text-rose-400">

--- a/src/frontend/components/observation-deck/ShipsLog.tsx
+++ b/src/frontend/components/observation-deck/ShipsLog.tsx
@@ -122,6 +122,7 @@ export function ShipsLog() {
           <ul className="divide-y divide-ocean-800/60">
             {filtered.slice(0, MAX_RENDER).map((row) => {
               const failure = /fail/i.test(row.actionType);
+              const switched = row.actionType === "provider_switched";
               const highlighted =
                 (hoveredPhase !== null && row.phaseNumber === hoveredPhase) ||
                 (hoveredCrew !== null && row.crewMember === hoveredCrew);
@@ -139,13 +140,22 @@ export function ShipsLog() {
                   </span>
                   <span
                     className={`shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium ${
-                      failure ? "bg-rose-500/20 text-rose-300" : "bg-ocean-800 text-ocean-300"
+                      failure
+                        ? "bg-rose-500/20 text-rose-300"
+                        : switched
+                          ? "bg-amber-500/20 text-amber-300"
+                          : "bg-ocean-800 text-ocean-300"
                     }`}
                   >
                     {row.crewMember}
                   </span>
                   <div className="min-w-0 flex-1">
-                    <p className="truncate text-ocean-100">{row.summary}</p>
+                    <p
+                      className={`truncate ${switched ? "text-amber-200" : "text-ocean-100"}`}
+                    >
+                      {switched && "⚡ "}
+                      {row.summary}
+                    </p>
                     <p className="text-[11px] text-ocean-500">
                       {row.actionType}
                       {row.phaseNumber !== null && ` · phase ${row.phaseNumber}`}

--- a/src/frontend/components/observation-deck/Toaster.tsx
+++ b/src/frontend/components/observation-deck/Toaster.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useToastStore } from "@/stores/toast";
+
+const TONE_CLASS: Record<string, string> = {
+  info: "border-ocean-600 bg-ocean-800",
+  warn: "border-amber-600 bg-amber-900/70",
+  success: "border-emerald-600 bg-emerald-900/70",
+  error: "border-rose-600 bg-rose-900/70",
+};
+
+export function Toaster() {
+  const toasts = useToastStore((s) => s.toasts);
+  const dismiss = useToastStore((s) => s.dismiss);
+
+  if (toasts.length === 0) return null;
+
+  return (
+    <div
+      className="pointer-events-none fixed bottom-4 right-4 z-[60] flex w-80 max-w-[calc(100vw-2rem)] flex-col gap-2"
+      aria-live="polite"
+    >
+      {toasts.map((t) => (
+        <div
+          key={t.id}
+          role="status"
+          className={`pointer-events-auto rounded-lg border px-3 py-2 text-sm shadow-lg ${
+            TONE_CLASS[t.tone] ?? TONE_CLASS.info
+          }`}
+        >
+          <div className="flex items-start justify-between gap-2">
+            <p className="font-medium text-ocean-50">{t.title}</p>
+            <button
+              onClick={() => dismiss(t.id)}
+              className="text-ocean-300 hover:text-ocean-100"
+              aria-label="Dismiss notification"
+            >
+              ✕
+            </button>
+          </div>
+          {t.body && <p className="mt-0.5 text-xs text-ocean-200">{t.body}</p>}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/frontend/hooks/useFailoverToasts.ts
+++ b/src/frontend/hooks/useFailoverToasts.ts
@@ -1,0 +1,37 @@
+// Watches the active voyage's live events for Dial System failovers
+// (provider_switched) and raises a toast so a mid-voyage switch isn't silent
+// in the deck (#54). Replays don't toast (P2), mirroring CrewMap's animation.
+
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useActiveVoyageEvents } from "@/hooks/useActiveVoyageEvents";
+import { useToastStore } from "@/stores/toast";
+
+export function useFailoverToasts(): void {
+  const events = useActiveVoyageEvents();
+  const push = useToastStore((s) => s.push);
+  const seen = useRef(0);
+
+  useEffect(() => {
+    if (events.length <= seen.current) {
+      seen.current = events.length;
+      return;
+    }
+    const fresh = events.slice(seen.current);
+    seen.current = events.length;
+
+    for (const e of fresh) {
+      if (e.isReplay || e.type !== "provider_switched") continue;
+      const payload = e.payload as Record<string, unknown>;
+      const provider =
+        typeof payload.new_provider === "string" ? payload.new_provider : "another provider";
+      const model = typeof payload.new_model === "string" ? payload.new_model : null;
+      push({
+        tone: "warn",
+        title: `⚡ ${e.source_role} switched provider`,
+        body: model ? `Now routing through ${provider}/${model}` : `Now routing through ${provider}`,
+      });
+    }
+  }, [events, push]);
+}

--- a/src/frontend/hooks/useFailoverToasts.ts
+++ b/src/frontend/hooks/useFailoverToasts.ts
@@ -6,14 +6,25 @@
 
 import { useEffect, useRef } from "react";
 import { useActiveVoyageEvents } from "@/hooks/useActiveVoyageEvents";
+import { useVoyageStore } from "@/stores/voyage";
 import { useToastStore } from "@/stores/toast";
 
 export function useFailoverToasts(): void {
   const events = useActiveVoyageEvents();
+  const activeId = useVoyageStore((s) => s.activeVoyageId);
   const push = useToastStore((s) => s.push);
   const seen = useRef(0);
+  const lastVoyage = useRef<string | null>(null);
 
   useEffect(() => {
+    // On voyage switch, treat the freshly-loaded (replayed) batch as already
+    // seen so we don't re-toast a prior voyage's failovers (high-water mark is
+    // per-voyage, not global).
+    if (activeId !== lastVoyage.current) {
+      lastVoyage.current = activeId;
+      seen.current = events.length;
+      return;
+    }
     if (events.length <= seen.current) {
       seen.current = events.length;
       return;
@@ -33,5 +44,5 @@ export function useFailoverToasts(): void {
         body: model ? `Now routing through ${provider}/${model}` : `Now routing through ${provider}`,
       });
     }
-  }, [events, push]);
+  }, [events, push, activeId]);
 }

--- a/src/frontend/lib/dial.test.ts
+++ b/src/frontend/lib/dial.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { DIAL_PROVIDERS, fallbackLabel } from "@/lib/dial";
+
+describe("fallbackLabel", () => {
+  it("renders a bare provider string", () => {
+    expect(fallbackLabel("openai")).toBe("openai");
+  });
+  it("renders provider/model for an object entry", () => {
+    expect(fallbackLabel({ provider: "openai", model: "gpt-4o" })).toBe("openai/gpt-4o");
+  });
+  it("renders just the provider when an object omits the model", () => {
+    expect(fallbackLabel({ provider: "ollama" })).toBe("ollama");
+  });
+});
+
+describe("DIAL_PROVIDERS", () => {
+  it("matches the backend supported provider list", () => {
+    expect([...DIAL_PROVIDERS]).toEqual(["anthropic", "openai", "ollama", "claude_code"]);
+  });
+});

--- a/src/frontend/lib/dial.ts
+++ b/src/frontend/lib/dial.ts
@@ -1,0 +1,76 @@
+// Dial System API client + types (mirrors app/schemas/dial_config.py and
+// app/schemas/dial_system.py). The deck reads/writes a voyage's role→provider
+// mapping and reads per-provider rate-limit headroom.
+
+import { apiFetch } from "@/lib/api";
+import type { CrewRole } from "@/lib/types";
+
+export const DIAL_PROVIDERS = [
+  "anthropic",
+  "openai",
+  "ollama",
+  "claude_code",
+] as const;
+export type DialProvider = (typeof DIAL_PROVIDERS)[number];
+
+export const DIAL_ROLES: readonly CrewRole[] = [
+  "captain",
+  "navigator",
+  "doctor",
+  "shipwright",
+  "helmsman",
+];
+
+export type RoleProviderConfig = { provider: string; model: string };
+export type FallbackEntry = string | { provider: string; model?: string };
+
+export type DialConfig = {
+  id: string;
+  voyage_id: string;
+  role_mapping: Record<string, RoleProviderConfig>;
+  fallback_chain: Record<string, FallbackEntry[]> | null;
+  created_at: string;
+  updated_at: string;
+};
+
+export type DialConfigUpdate = {
+  role_mapping?: Record<string, RoleProviderConfig>;
+  fallback_chain?: Record<string, FallbackEntry[]> | null;
+};
+
+export type ProviderWindowUsage = {
+  provider: string;
+  is_limited: boolean;
+  remaining_requests: number | null;
+  remaining_tokens: number | null;
+  max_requests: number;
+  max_tokens: number;
+};
+
+export type DialStatus = {
+  voyage_id: string;
+  window_seconds: number;
+  providers: ProviderWindowUsage[];
+};
+
+export function getDialConfig(voyageId: string) {
+  return apiFetch<DialConfig>(`/voyages/${voyageId}/dial-config`);
+}
+
+export function updateDialConfig(voyageId: string, body: DialConfigUpdate) {
+  return apiFetch<DialConfig>(`/voyages/${voyageId}/dial-config`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+export function getDialStatus(voyageId: string) {
+  return apiFetch<DialStatus>(`/voyages/${voyageId}/dial-status`);
+}
+
+// Render a fallback entry compactly (provider or provider/model).
+export function fallbackLabel(entry: FallbackEntry): string {
+  if (typeof entry === "string") return entry;
+  return entry.model ? `${entry.provider}/${entry.model}` : entry.provider;
+}

--- a/src/frontend/lib/shipsLog.test.ts
+++ b/src/frontend/lib/shipsLog.test.ts
@@ -52,6 +52,24 @@ describe("rowFromEvent (P3)", () => {
     expect(row.actionType).toBe("validation_passed");
     expect(row.phaseNumber).toBe(2);
   });
+  it("synthesizes a row from a provider_switched event (failover visibility)", () => {
+    const row = rowFromEvent(
+      liveEvent({
+        type: "provider_switched",
+        source_role: "captain",
+        payload: { new_provider: "openai", new_model: "gpt-4o" },
+      }),
+    )!;
+    expect(row.actionType).toBe("provider_switched");
+    expect(row.crewMember).toBe("captain");
+    expect(row.summary).toBe("Switched provider → openai/gpt-4o");
+  });
+  it("handles provider_switched without a model", () => {
+    const row = rowFromEvent(
+      liveEvent({ type: "provider_switched", payload: { new_provider: "ollama" } }),
+    )!;
+    expect(row.summary).toBe("Switched provider → ollama");
+  });
 });
 
 describe("mergeLog (P3, P13)", () => {

--- a/src/frontend/lib/shipsLog.ts
+++ b/src/frontend/lib/shipsLog.ts
@@ -40,6 +40,26 @@ export function rowFromCrewAction(a: CrewActionRead): LogRow {
 }
 
 export function rowFromEvent(e: EventEnvelope): LogRow | null {
+  // Dial System failover isn't a crew_action_recorded, but users should see it
+  // in the log — synthesize a row directly from the provider_switched event.
+  if (e.type === "provider_switched") {
+    const payload = e.payload as Record<string, unknown>;
+    const provider =
+      typeof payload.new_provider === "string" ? payload.new_provider : "another provider";
+    const model = typeof payload.new_model === "string" ? payload.new_model : null;
+    return {
+      event_id: e.event_id,
+      id: e.event_id,
+      createdAt: e.ts,
+      crewMember: e.source_role,
+      actionType: "provider_switched",
+      summary: model
+        ? `Switched provider → ${provider}/${model}`
+        : `Switched provider → ${provider}`,
+      details: payload,
+      phaseNumber: null,
+    };
+  }
   if (e.type !== "crew_action_recorded") return null;
   const p = e.payload as Record<string, unknown>;
   const details = (p.details as Record<string, unknown> | null) ?? null;

--- a/src/frontend/stores/toast.ts
+++ b/src/frontend/stores/toast.ts
@@ -1,0 +1,34 @@
+// Minimal toast store (Zustand). Transient notifications surfaced bottom-right
+// by <Toaster />. Used for Dial System failover alerts (#54).
+
+import { create } from "zustand";
+
+export type ToastTone = "info" | "warn" | "success" | "error";
+
+export type Toast = {
+  id: string;
+  title: string;
+  body?: string;
+  tone: ToastTone;
+};
+
+const AUTO_DISMISS_MS = 6000;
+
+type ToastState = {
+  toasts: Toast[];
+  push: (toast: Omit<Toast, "id">) => string;
+  dismiss: (id: string) => void;
+};
+
+export const useToastStore = create<ToastState>((set) => ({
+  toasts: [],
+  push: (toast) => {
+    const id = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    set((s) => ({ toasts: [...s.toasts, { ...toast, id }] }));
+    setTimeout(() => {
+      set((s) => ({ toasts: s.toasts.filter((t) => t.id !== id) }));
+    }, AUTO_DISMISS_MS);
+    return id;
+  },
+  dismiss: (id) => set((s) => ({ toasts: s.toasts.filter((t) => t.id !== id) })),
+}));


### PR DESCRIPTION
Fixes #54.

## Problem
The Dial System (per-role provider/model mapping, fallback chains, hot-swap via `PUT /dial-config`) is a headline differentiator with **zero UI presence**: role remapping was curl-only, `provider_switched` failovers were silent in the deck, and rate-limit headroom was never exposed.

## Fix
**Backend** (one small read-only endpoint; no routing/failover logic touched):
- **`GET /voyages/{id}/dial-status`** returns per-provider sliding-window usage (remaining requests/tokens + the limits), reusing the same `RateLimiter` the router consults. `RateLimiter` gains read-only `max_tokens`/`max_requests` accessors.

**Frontend:**
1. **Dial config panel** — a new **"Dial" tab** in the details drawer (`DialPanel`): view/edit the role→provider/model rows and write through `PUT /dial-config` (effective on the next LLM call, per the Phase 6 contract), see the fallback chains, and watch live per-provider rate-limit headroom (15s refresh).
2. **Failover visibility** — a **toast** on `provider_switched` (new minimal toast store + `<Toaster/>` + `useFailoverToasts`), a **Ship's Log row** synthesized directly from the event (it isn't a `crew_action_recorded`) with ⚡ emphasis, and a **`"Switched provider ⚡"`** entry in the Crew Map's `ACTIVITY_LABEL`.
3. **Rate-limit surface** — the panel renders each provider's remaining request/token budget with a usage bar, flagging rate-limited providers.

## Acceptance criteria
- [x] A user can view and edit the active voyage's role mapping from the deck; changes take effect on the next LLM call (no restart).
- [x] A simulated rate-limit failover produces a visible toast and a log entry (both driven off the `provider_switched` event, so within ~1s of arrival).
- [x] Dial panel shows per-provider request/token usage for the current window.

## Scope
Frontend panel + one small read-only backend endpoint. No changes to routing/failover logic (that was #50). The fallback chains are displayed read-only; editing the mapping is the primary write path.

## Tests
Backend `948 passed, 19 skipped`; `ruff`/`mypy` clean (modulo the pre-existing `python-jose` stub). Frontend `tsc`/`next lint` clean, `67` vitest tests pass. New: dial-status endpoint + provider extraction (`test_dial_api.py`), the `provider_switched` log row (`shipsLog.test.ts`), and dial helpers (`dial.test.ts`).

https://claude.ai/code/session_01GC6ekfqN4PxAXEu6nyJG32

---
_Generated by [Claude Code](https://claude.ai/code/session_01GC6ekfqN4PxAXEu6nyJG32)_