### PR TITLE
feat(deck): polish pack — PAUSED column, live phase chips, terminal affordances (#55)

### DIFF
--- a/src/frontend/components/observation-deck/InterventionControls.tsx
+++ b/src/frontend/components/observation-deck/InterventionControls.tsx
@@ -48,13 +48,17 @@ export function InterventionControls({ voyageId }: { voyageId: string }) {
     }
   };
 
-  if (terminal) return null;
+  // Terminal voyages are read-only: keep the controls visible but disabled with
+  // a tooltip (rather than hiding them or firing requests that 409 server-side).
+  const terminalTip = terminal ? "Voyage is in a terminal state" : undefined;
+  const locked = busy || terminal;
 
   return (
     <div className="flex items-center gap-2 text-xs">
       {paused ? (
         <button
-          disabled={busy}
+          disabled={locked}
+          title={terminalTip}
           onClick={() => run(() => resumeVoyage(voyageId))}
           className="rounded border border-emerald-700 px-2 py-1 text-emerald-300 hover:bg-emerald-900/40 disabled:opacity-50"
         >
@@ -62,7 +66,8 @@ export function InterventionControls({ voyageId }: { voyageId: string }) {
         </button>
       ) : (
         <button
-          disabled={busy}
+          disabled={locked}
+          title={terminalTip}
           onClick={() => run(() => pauseVoyage(voyageId))}
           className="rounded border border-amber-700 px-2 py-1 text-amber-300 hover:bg-amber-900/40 disabled:opacity-50"
         >
@@ -71,7 +76,8 @@ export function InterventionControls({ voyageId }: { voyageId: string }) {
       )}
 
       <button
-        disabled={busy}
+        disabled={locked}
+        title={terminalTip}
         onClick={() => setShowInject(true)}
         className="rounded border border-ocean-700 px-2 py-1 text-ocean-300 hover:bg-ocean-800 disabled:opacity-50"
       >
@@ -79,7 +85,8 @@ export function InterventionControls({ voyageId }: { voyageId: string }) {
       </button>
 
       <button
-        disabled={busy}
+        disabled={locked}
+        title={terminalTip}
         onClick={() => setShowRedirect(true)}
         className="rounded border border-amber-700 px-2 py-1 text-amber-300 hover:bg-amber-900/40 disabled:opacity-50"
       >
@@ -87,12 +94,15 @@ export function InterventionControls({ voyageId }: { voyageId: string }) {
       </button>
 
       <button
-        disabled={busy}
+        disabled={locked}
+        title={terminalTip}
         onClick={() => setConfirmCancel(true)}
         className="rounded border border-rose-700 px-2 py-1 text-rose-300 hover:bg-rose-900/40 disabled:opacity-50"
       >
         ✕ Cancel
       </button>
+
+      {terminal && <span className="text-ocean-500">(read-only)</span>}
 
       {error && <span className="text-rose-400">{error}</span>}
 

--- a/src/frontend/components/observation-deck/SeaChart.test.ts
+++ b/src/frontend/components/observation-deck/SeaChart.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { columnFor, columnForVoyage } from "./SeaChart";
+
+const ACTIVE = "v-active";
+
+describe("columnFor", () => {
+  it("maps stages to their columns", () => {
+    expect(columnFor("PDD")).toBe("pdd");
+    expect(columnFor("TDD")).toBe("tdd");
+    expect(columnFor("BUILDING")).toBe("building");
+    expect(columnFor("CHARTED")).toBe("planning");
+  });
+});
+
+describe("columnForVoyage (PAUSED placement)", () => {
+  it("keeps the active paused voyage in its pre-pause stage column", () => {
+    const v = { id: ACTIVE, status: "PAUSED" as const };
+    // Paused during PDD → stays in the PDD column, not Building.
+    expect(columnForVoyage(v, ACTIVE, "PDD")).toBe("pdd");
+    expect(columnForVoyage(v, ACTIVE, "TDD")).toBe("tdd");
+  });
+
+  it("falls back to the polled status when there is no live stage", () => {
+    const v = { id: ACTIVE, status: "PAUSED" as const };
+    // No reducer status (e.g. non-active or no events) → Building fallback.
+    expect(columnForVoyage(v, ACTIVE, null)).toBe("building");
+  });
+
+  it("does not override a non-active paused voyage", () => {
+    const v = { id: "v-other", status: "PAUSED" as const };
+    expect(columnForVoyage(v, ACTIVE, "PDD")).toBe("building");
+  });
+
+  it("ignores the live status for a non-paused voyage", () => {
+    const v = { id: ACTIVE, status: "BUILDING" as const };
+    expect(columnForVoyage(v, ACTIVE, "PDD")).toBe("building");
+  });
+});

--- a/src/frontend/components/observation-deck/SeaChart.tsx
+++ b/src/frontend/components/observation-deck/SeaChart.tsx
@@ -3,13 +3,16 @@
 import { useRouter, useSearchParams } from "next/navigation";
 import { useVoyages } from "@/hooks/useVoyages";
 import { usePlaybackStore } from "@/stores/playback";
+import { useVoyageStore } from "@/stores/voyage";
+import { useDerivedState } from "@/hooks/useDerivedState";
 import type { VoyageListItem, VoyageStatus } from "@/lib/types";
 import { SeaChartCard } from "./SeaChartCard";
 import { EmptyState } from "./EmptyState";
 
 // Pipeline columns (PLAN Phase 2). CHARTED/PLANNING collapse into "Planning";
-// PDD/TDD/BUILDING/REVIEWING/DEPLOYING each get a column; PAUSED rides with its
-// stage via the BUILDING column fallback.
+// PDD/TDD/BUILDING/REVIEWING/DEPLOYING each get a column. A PAUSED voyage stays
+// in the column of the stage it was paused in (recovered from the live stream
+// for the active voyage), rather than always jumping to Building.
 const COLUMNS: { key: string; label: string; statuses: VoyageStatus[] }[] = [
   { key: "planning", label: "Planning", statuses: ["CHARTED", "PLANNING"] },
   { key: "pdd", label: "PDD", statuses: ["PDD"] },
@@ -19,8 +22,22 @@ const COLUMNS: { key: string; label: string; statuses: VoyageStatus[] }[] = [
   { key: "deploying", label: "Deploying", statuses: ["DEPLOYING"] },
 ];
 
-function columnFor(status: VoyageStatus): string {
+export function columnFor(status: VoyageStatus): string {
   return COLUMNS.find((c) => c.statuses.includes(status))?.key ?? "planning";
+}
+
+// A PAUSED voyage keeps the column of the stage it was paused in. For the active
+// (streamed) voyage we recover that stage from the live reducer status; without
+// it (non-active / no events) we fall back to the polled status.
+export function columnForVoyage(
+  voyage: Pick<VoyageListItem, "id" | "status">,
+  activeId: string | null,
+  liveStatus: VoyageStatus | null,
+): string {
+  if (voyage.id === activeId && voyage.status === "PAUSED" && liveStatus) {
+    return columnFor(liveStatus);
+  }
+  return columnFor(voyage.status);
 }
 
 export function SeaChart() {
@@ -33,6 +50,20 @@ export function SeaChart() {
 
   const activeVoyages = active.data?.pages.flatMap((p) => p.items) ?? [];
   const terminalVoyages = terminal.data?.pages.flatMap((p) => p.items) ?? [];
+
+  // Live overlay for the currently-streamed voyage: the playback reducer tracks
+  // phase status and the last stage entered from the WS within ~1s, so its card
+  // doesn't wait on the 15s status poll (and a PAUSED card keeps its stage).
+  const activeId = useVoyageStore((s) => s.activeVoyageId);
+  const derived = useDerivedState();
+
+  const livePhaseStatus = (v: VoyageListItem): Record<string, string> | undefined => {
+    if (v.id !== activeId) return undefined;
+    const ws: Record<string, string> = {};
+    for (const [n, s] of Object.entries(derived.phaseStatus)) ws[n] = s;
+    // Poll gives the full phase set; WS gives the freshest per-phase status.
+    return { ...v.phase_status, ...ws };
+  };
 
   const openDrawer = usePlaybackStore((s) => s.openDrawer);
 
@@ -58,7 +89,7 @@ export function SeaChart() {
   }
 
   const byColumn = (key: string): VoyageListItem[] =>
-    activeVoyages.filter((v) => columnFor(v.status) === key);
+    activeVoyages.filter((v) => columnForVoyage(v, activeId, derived.status) === key);
 
   return (
     <div className="flex h-full flex-col gap-4">
@@ -81,7 +112,13 @@ export function SeaChart() {
               </header>
               <div className="flex flex-col gap-2 p-2">
                 {cards.map((v) => (
-                  <SeaChartCard key={v.id} voyage={v} onSelect={select} onOpen={open} />
+                  <SeaChartCard
+                    key={v.id}
+                    voyage={v}
+                    livePhaseStatus={livePhaseStatus(v)}
+                    onSelect={select}
+                    onOpen={open}
+                  />
                 ))}
               </div>
             </section>

--- a/src/frontend/components/observation-deck/SeaChartCard.tsx
+++ b/src/frontend/components/observation-deck/SeaChartCard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo } from "react";
-import { useVoyageProgress } from "@/hooks/useVoyageProgress";
+import { computeProgress } from "@/hooks/useVoyageProgress";
 import { useFocusStore } from "@/stores/focus";
 import { useVoyageStore } from "@/stores/voyage";
 import type { VoyageListItem } from "@/lib/types";
@@ -19,14 +19,19 @@ function relativeTime(ts: number | null): string {
 
 export function SeaChartCard({
   voyage,
+  livePhaseStatus,
   onOpen,
   onSelect,
 }: {
   voyage: VoyageListItem;
+  // Live, WS-derived phase status for the active voyage (overrides the polled
+  // snapshot so chips flip within ~1s; falls back to the poll when absent).
+  livePhaseStatus?: Record<string, string>;
   onOpen?: (id: string) => void;
   onSelect?: (id: string) => void;
 }) {
-  const progress = useVoyageProgress(voyage);
+  const phaseStatus = livePhaseStatus ?? voyage.phase_status;
+  const progress = computeProgress(voyage.status, phaseStatus);
   const setHoveredPhase = useFocusStore((s) => s.setHoveredPhase);
   const lastEventTs = useVoyageStore(
     (s) => s.buffers[voyage.id]?.lastEventTs ?? null,
@@ -79,7 +84,7 @@ export function SeaChartCard({
           </div>
           {/* Cross-view: hovering a phase highlights it elsewhere. */}
           <div className="mt-1 flex flex-wrap gap-1">
-            {Object.keys(voyage.phase_status).map((p) => (
+            {Object.keys(phaseStatus).map((p) => (
               <span
                 key={p}
                 onMouseEnter={() => setHoveredPhase(Number(p))}


### PR DESCRIPTION
Fixes #55.

Frontend-only polish pack. Each item was independently shippable; this PR does the three implementable ones.

## Changes
- [x] **PAUSED column placement.** `SeaChart` mapped `PAUSED` into the Building column regardless of stage. The DB drops the pre-pause stage (status is overwritten to `PAUSED`), but the playback reducer still tracks the last `pipeline_stage_entered`. So for the **active (streamed) voyage**, `columnForVoyage` recovers the pre-pause stage from the reducer and keeps the card in that column — a voyage paused in PDD stays in **PDD**, still badged PAUSED. Non-active/eventless paused voyages fall back to the Building column as before.
- [x] **Per-phase build state from WS, not 15s polling.** The active voyage's card phase status is overlaid from the reducer (`phase_build_started` / `tests_passed` / `phase_build_failed`), so chips and the progress bar flip within ~1s. The poll stays as the base phase set + reconciliation (`{...poll, ...ws}`).
- [x] **Terminal-state affordances.** Intervention buttons were *hidden* on COMPLETED/FAILED/CANCELLED. They're now **visible but disabled** with a `"Voyage is in a terminal state"` tooltip and a `(read-only)` marker — so the read-only state is legible and no requests are fired that 409 server-side.
- [ ] **Crew Map zoom/pan / completion edge** — intentionally left for a future pass (the issue flags this as fine for v1, tracking-only).

## Acceptance criteria
- [x] Pausing a voyage in PDD keeps its card in the PDD column with a PAUSED badge (for the active voyage).
- [x] Phase chips update from WS events within ~1s during BUILDING (poll remains as fallback).
- [x] Intervention buttons are disabled with tooltips for terminal voyages; no failing requests fired from the UI.

## Note on scope
The live overlay (items 1 & 2) applies to the **active/streamed voyage**, since only its WS buffer is populated — which is the realistic case (you pause/watch the voyage you're viewing). A fully cross-voyage version would need the backend to persist the pre-pause stage; out of scope for this polish pass.

## Tests
`columnForVoyage` extracted as a pure function with unit tests (`SeaChart.test.ts`). Frontend `tsc`/`next lint` clean, `72` vitest tests pass (+5).

https://claude.ai/code/session_01GC6ekfqN4PxAXEu6nyJG32

---
_Generated by [Claude Code](https://claude.ai/code/session_01GC6ekfqN4PxAXEu6nyJG32)_