### PR TITLE
feat(demo): scripted demo voyage replayable through the real stack, no API key (#56)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,3 +160,19 @@ smoke: ## Run the Phase 15.4 manual-test smoke script (requires infra + api-mock
 		GRANDLINE_DATABASE_URL=postgresql+psycopg://grandline:grandline@localhost:5432/grandline \
 		GRANDLINE_REDIS_URL=redis://localhost:6379/0 \
 		PYTHONPATH=. python3 -m scripts.smoke_pipeline_api
+
+.PHONY: demo
+demo: podman-start ## Seed + replay the scripted demo voyage (no API key needed)
+	@$(DOCKER_HOST_EXPORT); \
+	cd $(BACKEND) && source venv/bin/activate && \
+		GRANDLINE_DATABASE_URL=postgresql+psycopg://grandline:grandline@localhost:5432/grandline \
+		GRANDLINE_REDIS_URL=redis://localhost:6379/0 \
+		PYTHONPATH=. python3 -m scripts.demo
+
+.PHONY: demo-clean
+demo-clean: ## Remove all seeded demo data (voyage, user, event stream)
+	@$(DOCKER_HOST_EXPORT); \
+	cd $(BACKEND) && source venv/bin/activate && \
+		GRANDLINE_DATABASE_URL=postgresql+psycopg://grandline:grandline@localhost:5432/grandline \
+		GRANDLINE_REDIS_URL=redis://localhost:6379/0 \
+		PYTHONPATH=. python3 -m scripts.demo --cleanup

--- a/README.md
+++ b/README.md
@@ -86,6 +86,20 @@ Supported providers:
 | `ollama` | none | Local models via `GRANDLINE_OLLAMA_BASE_URL` |
 | `claude_code` | Claude Code CLI login | Runs the local `claude` CLI in print mode — works with a Claude subscription (`claude login` / `CLAUDE_CODE_OAUTH_TOKEN`) or `ANTHROPIC_API_KEY`; no key stored in GrandLine. Install: `npm install -g @anthropic-ai/claude-code`. Tune via `GRANDLINE_CLAUDE_CODE_*` env vars (see `src/backend/.env.example`). |
 
+## Try it without API keys (demo mode)
+
+Want to watch the crew sail before wiring up a provider? After `make setup`:
+
+```bash
+make demo        # seeds a demo voyage and replays a recorded run (~50s)
+```
+
+It prints a login (`demo@grandline.io` / `demo-voyage`) and a deck URL. Open it
+to watch the Sea Chart, Crew Map, and Ship's Log animate through a real voyage —
+Pause/Cancel work against the replay. `make demo-clean` removes the seeded data.
+The replay runs entirely through the real Den Den Mushi stream; no LLM provider
+is called.
+
 ## Development
 
 This project follows **PDD** (Prompt Driven Development) and **TDD** (Test Driven Development) — the Log Pose.

--- a/src/backend/app/core/config.py
+++ b/src/backend/app/core/config.py
@@ -59,6 +59,9 @@ class Settings(BaseSettings):
     git_author_email: str = "crew@grandline.dev"
     github_api_token: str = ""
 
+    # Demo mode (#56): a scripted voyage replayable via `make demo`, no API key.
+    demo_mode: bool = False
+
     # CORS
     cors_origins: list[str] = ["http://localhost:3000"]
 

--- a/src/backend/app/demo/__init__.py
+++ b/src/backend/app/demo/__init__.py
@@ -1,0 +1,2 @@
+"""Demo mode (#56): replay a recorded voyage through the real Den Den Mushi
+stream so the Observation Deck can be experienced without API keys."""

--- a/src/backend/app/demo/replayer.py
+++ b/src/backend/app/demo/replayer.py
@@ -1,0 +1,117 @@
+"""Demo voyage replayer (#56).
+
+Publishes the recorded `DEMO_SCRIPT` to `grandline:events:{voyage_id}` with
+realistic pacing, updating the voyage's status/phase_status so the Sea Chart
+poll and badges keep up. Honors live interventions by re-reading the voyage row
+between steps: a **Pause** (status PAUSED) halts the replay until resumed; a
+**Cancel** (status CANCELLED) stops it. No LLM provider is involved.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import uuid
+from collections.abc import Awaitable, Callable
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.demo.script import DEMO_SCRIPT, DemoStep, build_events
+from app.den_den_mushi.constants import stream_key
+from app.den_den_mushi.mushi import DenDenMushi
+from app.models.enums import VoyageStatus
+from app.models.voyage import Voyage
+
+logger = logging.getLogger(__name__)
+
+SessionFactory = Callable[[], AsyncSession]
+Sleeper = Callable[[float], Awaitable[None]]
+
+
+class DemoReplayer:
+    def __init__(
+        self,
+        mushi: DenDenMushi,
+        session_factory: SessionFactory,
+        voyage_id: uuid.UUID,
+        *,
+        speed: float = 1.0,
+        sleep: Sleeper = asyncio.sleep,
+        pause_poll_seconds: float = 1.0,
+    ) -> None:
+        self._mushi = mushi
+        self._session_factory = session_factory
+        self._voyage_id = voyage_id
+        self._speed = speed if speed > 0 else 1.0
+        self._sleep = sleep
+        self._pause_poll = pause_poll_seconds
+
+    async def run(self) -> str:
+        """Replay the script. Returns the terminal reason: 'completed' or
+        'cancelled'."""
+        stream = stream_key(self._voyage_id)
+        for step in DEMO_SCRIPT:
+            await self._sleep(step.delay / self._speed)
+
+            gate = await self._await_runnable()
+            if gate == "cancelled":
+                logger.info("Demo voyage %s cancelled — stopping replay", self._voyage_id)
+                return "cancelled"
+
+            for event in build_events(step, self._voyage_id):
+                await self._mushi.publish(stream, event)
+
+            await self._apply_changes(step)
+
+        logger.info("Demo voyage %s replay complete", self._voyage_id)
+        return "completed"
+
+    async def _await_runnable(self) -> str:
+        """Block while the voyage is PAUSED; return 'cancelled' if it is, else
+        'running' once it is not paused."""
+        while True:
+            status = await self._current_status()
+            if status == VoyageStatus.CANCELLED.value:
+                return "cancelled"
+            if status != VoyageStatus.PAUSED.value:
+                return "running"
+            await self._sleep(self._pause_poll)
+
+    async def _current_status(self) -> str | None:
+        async with self._session_factory() as session:
+            voyage = await session.get(Voyage, self._voyage_id)
+            return voyage.status if voyage is not None else None
+
+    async def _apply_changes(self, step: DemoStep) -> None:
+        if step.stage is None and step.phase_status is None:
+            return
+        async with self._session_factory() as session:
+            voyage = await session.get(Voyage, self._voyage_id)
+            if voyage is None:
+                return
+            # Don't clobber a Pause/Cancel that landed during this step.
+            if voyage.status in (VoyageStatus.PAUSED.value, VoyageStatus.CANCELLED.value):
+                if step.phase_status is None:
+                    return
+            elif step.stage is not None:
+                voyage.status = step.stage
+            if step.phase_status is not None:
+                voyage.phase_status = {**(voyage.phase_status or {}), **step.phase_status}
+            session.add(voyage)
+            await session.commit()
+
+
+async def load_demo_voyage_id(session: AsyncSession) -> uuid.UUID | None:
+    """Most recent demo voyage id (seeded with the demo marker), or None."""
+    result = await session.execute(
+        select(Voyage.id)
+        .where(Voyage.target_repo == DEMO_TARGET_REPO)
+        .order_by(Voyage.created_at.desc())
+        .limit(1)
+    )
+    return result.scalar_one_or_none()
+
+
+# Sentinel marking a seeded demo voyage (no is_demo column / migration needed).
+DEMO_TARGET_REPO = "grandline/demo"

--- a/src/backend/app/demo/replayer.py
+++ b/src/backend/app/demo/replayer.py
@@ -14,7 +14,6 @@ import logging
 import uuid
 from collections.abc import Awaitable, Callable
 
-from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.demo.script import DEMO_SCRIPT, DemoStep, build_events
@@ -100,17 +99,6 @@ class DemoReplayer:
                 voyage.phase_status = {**(voyage.phase_status or {}), **step.phase_status}
             session.add(voyage)
             await session.commit()
-
-
-async def load_demo_voyage_id(session: AsyncSession) -> uuid.UUID | None:
-    """Most recent demo voyage id (seeded with the demo marker), or None."""
-    result = await session.execute(
-        select(Voyage.id)
-        .where(Voyage.target_repo == DEMO_TARGET_REPO)
-        .order_by(Voyage.created_at.desc())
-        .limit(1)
-    )
-    return result.scalar_one_or_none()
 
 
 # Sentinel marking a seeded demo voyage (no is_demo column / migration needed).

--- a/src/backend/app/demo/script.py
+++ b/src/backend/app/demo/script.py
@@ -1,0 +1,172 @@
+"""The recorded demo voyage — a scripted event timeline (#56).
+
+Mirrors `docs/assets/deck.js` (the GitHub Pages mockup) using the real
+`event_type` strings published on `grandline:events:{voyage_id}`. Each step
+emits a `crew_action_recorded` (fills the Ship's Log) plus the matching typed
+event (pulses the Crew Map and drives the playback reducer's status/phase
+chips), so the deck consumes the demo exactly like a live voyage.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+
+from app.den_den_mushi.events import (
+    CodeGeneratedEvent,
+    CrewActionRecordedEvent,
+    DenDenMushiEvent,
+    DeploymentCompletedEvent,
+    DeploymentStartedEvent,
+    HealthCheckWrittenEvent,
+    PhaseBuildFailedEvent,
+    PhaseBuildStartedEvent,
+    PipelineCompletedEvent,
+    PipelineStageEnteredEvent,
+    PipelineStartedEvent,
+    PoneglyphDraftedEvent,
+    TestsPassedEvent,
+    ValidationPassedEvent,
+    VoyagePlanCreatedEvent,
+)
+from app.models.enums import CrewRole
+
+# event_type -> typed event class for the events the demo emits.
+_EVENT_CLASSES: dict[str, type[DenDenMushiEvent]] = {
+    "pipeline_started": PipelineStartedEvent,
+    "pipeline_stage_entered": PipelineStageEnteredEvent,
+    "voyage_plan_created": VoyagePlanCreatedEvent,
+    "poneglyph_drafted": PoneglyphDraftedEvent,
+    "health_check_written": HealthCheckWrittenEvent,
+    "phase_build_started": PhaseBuildStartedEvent,
+    "code_generated": CodeGeneratedEvent,
+    "tests_passed": TestsPassedEvent,
+    "phase_build_failed": PhaseBuildFailedEvent,
+    "validation_passed": ValidationPassedEvent,
+    "deployment_started": DeploymentStartedEvent,
+    "deployment_completed": DeploymentCompletedEvent,
+    "pipeline_completed": PipelineCompletedEvent,
+}
+
+
+@dataclass(frozen=True)
+class DemoStep:
+    """One beat of the recorded voyage."""
+
+    delay: float  # seconds to pace before this step fires (at 1x speed)
+    event_type: str  # typed Den Den Mushi event_type
+    role: CrewRole
+    summary: str  # Ship's Log line
+    stage: str | None = None  # voyage status to set + stage_entered payload
+    phase: int | None = None  # phase_number payload (build/test events)
+    phase_status: dict[str, str] | None = None  # voyage.phase_status changes after
+    extra: dict[str, str] = field(default_factory=dict)  # extra typed payload
+
+
+def _typed_payload(step: DemoStep) -> dict[str, object]:
+    payload: dict[str, object] = dict(step.extra)
+    if step.event_type == "pipeline_stage_entered" and step.stage:
+        payload["voyage_status"] = step.stage
+    if step.phase is not None:
+        payload["phase_number"] = step.phase
+    return payload
+
+
+def build_events(step: DemoStep, voyage_id: uuid.UUID) -> list[DenDenMushiEvent]:
+    """Events to publish for one step: the Ship's Log row first, then the typed
+    event last so the Crew Map's label reflects the typed activity, not the
+    raw crew_action_recorded."""
+    now = datetime.now(UTC).isoformat()
+    details: dict[str, object] = {"demo": True}
+    if step.phase is not None:
+        details["phase_number"] = step.phase
+
+    crew_action = CrewActionRecordedEvent(
+        voyage_id=voyage_id,
+        source_role=step.role,
+        payload={
+            "crew_action_id": str(uuid.uuid4()),
+            "event_id": str(uuid.uuid4()),
+            "action_type": step.event_type,
+            "summary": step.summary,
+            "created_at": now,
+            "details": details,
+        },
+    )
+
+    event_cls = _EVENT_CLASSES[step.event_type]
+    # Each subclass fixes event_type via a Literal default; mypy only sees the
+    # base type[DenDenMushiEvent] whose event_type is required.
+    typed = event_cls(  # type: ignore[call-arg]
+        voyage_id=voyage_id,
+        source_role=step.role,
+        payload=_typed_payload(step),
+    )
+    return [crew_action, typed]
+
+
+# The recorded voyage: "Build a telemetry pipeline", 4 phases. ~47s at 1x.
+DEMO_SCRIPT: list[DemoStep] = [
+    DemoStep(0.6, "pipeline_started", CrewRole.CAPTAIN,
+             "Voyage accepted — task handed to the Captain", stage="PLANNING"),
+    DemoStep(1.4, "pipeline_stage_entered", CrewRole.CAPTAIN,
+             "Entered stage PLANNING", stage="PLANNING"),
+    DemoStep(2.6, "voyage_plan_created", CrewRole.CAPTAIN,
+             "Mission decomposed into 4 phases: schema, ingest API, worker, dashboard"),
+    DemoStep(1.5, "pipeline_stage_entered", CrewRole.NAVIGATOR,
+             "Entered stage PDD", stage="PDD"),
+    DemoStep(2.2, "poneglyph_drafted", CrewRole.NAVIGATOR,
+             "Poneglyph drafted for phase 1 — telemetry tables + Alembic migration", phase=1),
+    DemoStep(1.9, "poneglyph_drafted", CrewRole.NAVIGATOR,
+             "Poneglyphs drafted for phases 2–4 — endpoints, worker, contracts"),
+    DemoStep(1.5, "pipeline_stage_entered", CrewRole.DOCTOR,
+             "Entered stage TDD", stage="TDD"),
+    DemoStep(2.6, "health_check_written", CrewRole.DOCTOR,
+             "12 failing health checks written (pytest) — red as expected, TDD holds"),
+    DemoStep(1.5, "pipeline_stage_entered", CrewRole.SHIPWRIGHT,
+             "Entered stage BUILDING — 2 parallel Shipwrights on independent phases",
+             stage="BUILDING"),
+    DemoStep(1.2, "phase_build_started", CrewRole.SHIPWRIGHT,
+             "Phase 1 build started on branch agent/shipwright/vg-7f3a2c", phase=1,
+             phase_status={"1": "BUILDING"}),
+    DemoStep(2.3, "code_generated", CrewRole.SHIPWRIGHT,
+             "Phase 1 iteration 1 — 6 files generated, running Doctor's checks in sandbox",
+             phase=1),
+    DemoStep(2.1, "tests_passed", CrewRole.SHIPWRIGHT,
+             "Phase 1 green — 4/4 checks passing, committed to agent branch", phase=1,
+             phase_status={"1": "BUILT"}),
+    DemoStep(1.3, "phase_build_started", CrewRole.SHIPWRIGHT,
+             "Phases 2 + 3 build started (parallel layer)",
+             phase_status={"2": "BUILDING", "3": "BUILDING"}),
+    DemoStep(2.4, "code_generated", CrewRole.SHIPWRIGHT,
+             "Phase 2 iteration 1 — 2/5 checks failing, analyzing tracebacks", phase=2),
+    DemoStep(2.2, "code_generated", CrewRole.SHIPWRIGHT,
+             "Phase 2 iteration 2 — regenerated handler with idempotency key", phase=2),
+    DemoStep(1.8, "tests_passed", CrewRole.SHIPWRIGHT,
+             "Phase 3 green — worker drains queue in sandbox run", phase=3,
+             phase_status={"3": "BUILT"}),
+    DemoStep(1.7, "tests_passed", CrewRole.SHIPWRIGHT,
+             "Phase 2 green on iteration 2 — Vivre Card checkpointed", phase=2,
+             phase_status={"2": "BUILT"}),
+    DemoStep(1.3, "phase_build_started", CrewRole.SHIPWRIGHT,
+             "Phase 4 build started — dashboard endpoint", phase=4,
+             phase_status={"4": "BUILDING"}),
+    DemoStep(2.4, "tests_passed", CrewRole.SHIPWRIGHT,
+             "Phase 4 green — 12/12 health checks passing overall", phase=4,
+             phase_status={"4": "BUILT"}),
+    DemoStep(1.5, "pipeline_stage_entered", CrewRole.DOCTOR,
+             "Entered stage REVIEWING", stage="REVIEWING"),
+    DemoStep(2.6, "validation_passed", CrewRole.DOCTOR,
+             "Full suite re-run in clean sandbox — 12/12 passing, coverage 91%"),
+    DemoStep(1.5, "pipeline_stage_entered", CrewRole.HELMSMAN,
+             "Entered stage DEPLOYING", stage="DEPLOYING"),
+    DemoStep(1.6, "deployment_started", CrewRole.HELMSMAN,
+             "Deploying tier=preview ref=agent/shipwright/vg-7f3a2c"),
+    DemoStep(2.8, "deployment_completed", CrewRole.HELMSMAN,
+             "Preview live — https://preview-vg7f3a.grandline.dev",
+             extra={"url": "https://preview-vg7f3a.grandline.dev", "tier": "preview"}),
+    DemoStep(1.7, "pipeline_completed", CrewRole.CAPTAIN,
+             "Voyage COMPLETED — preview deployed, awaiting fleet admiral for production",
+             stage="COMPLETED"),
+]

--- a/src/backend/app/demo/seed.py
+++ b/src/backend/app/demo/seed.py
@@ -1,0 +1,109 @@
+"""Seed + teardown for the demo voyage (#56).
+
+Creates a loginable demo user and a clearly-badged demo voyage (plus a dial
+config so the Dial panel renders). The replayer drives everything else through
+the event stream; nothing here needs an API key. `cleanup_demo` removes the
+seeded rows and the Redis event stream.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from redis.asyncio import Redis
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import hash_password
+from app.demo.replayer import DEMO_TARGET_REPO
+from app.den_den_mushi.constants import stream_key
+from app.models.dial_config import DialConfig
+from app.models.user import User
+from app.models.voyage import Voyage
+
+DEMO_EMAIL = "demo@grandline.io"
+DEMO_USERNAME = "demo"
+DEMO_PASSWORD = "demo-voyage"
+DEMO_TITLE = "🎬 Demo Voyage — Telemetry Pipeline"
+
+_DEMO_DIAL_MAPPING = {
+    role: {"provider": "anthropic", "model": "claude-sonnet-4-20250514"}
+    for role in ("captain", "navigator", "shipwright", "doctor", "helmsman")
+}
+
+
+async def _get_or_create_demo_user(session: AsyncSession) -> User:
+    existing = (
+        await session.execute(select(User).where(User.email == DEMO_EMAIL))
+    ).scalar_one_or_none()
+    if existing is not None:
+        return existing
+    user = User(
+        id=uuid.uuid4(),
+        email=DEMO_EMAIL,
+        username=DEMO_USERNAME,
+        hashed_password=hash_password(DEMO_PASSWORD),
+    )
+    session.add(user)
+    await session.flush()
+    return user
+
+
+async def seed_demo(session: AsyncSession) -> Voyage:
+    """Create a fresh demo voyage (CHARTED, 4 pending phases) owned by the demo
+    user. Returns the voyage."""
+    user = await _get_or_create_demo_user(session)
+
+    voyage = Voyage(
+        id=uuid.uuid4(),
+        user_id=user.id,
+        title=DEMO_TITLE,
+        description="A scripted voyage replayed through the real stack — no API key needed.",
+        status="CHARTED",
+        target_repo=DEMO_TARGET_REPO,
+        phase_status={"1": "PENDING", "2": "PENDING", "3": "PENDING", "4": "PENDING"},
+    )
+    session.add(voyage)
+
+    session.add(
+        DialConfig(
+            id=uuid.uuid4(),
+            voyage_id=voyage.id,
+            role_mapping=_DEMO_DIAL_MAPPING,
+            fallback_chain={"captain": [{"provider": "openai", "model": "gpt-4o"}]},
+        )
+    )
+
+    await session.commit()
+    await session.refresh(voyage)
+    return voyage
+
+
+async def cleanup_demo(session: AsyncSession, redis: Redis | None = None) -> int:
+    """Delete all seeded demo voyages (by marker), their dial configs, the demo
+    user, and the Redis event streams. Returns the number of voyages removed."""
+    voyages = (
+        (await session.execute(select(Voyage).where(Voyage.target_repo == DEMO_TARGET_REPO)))
+        .scalars()
+        .all()
+    )
+    for voyage in voyages:
+        await session.execute(delete(DialConfig).where(DialConfig.voyage_id == voyage.id))
+        if redis is not None:
+            await redis.delete(stream_key(voyage.id))
+    for voyage in voyages:
+        await session.delete(voyage)
+
+    # Remove the demo user once its voyages are gone.
+    user = (
+        await session.execute(select(User).where(User.email == DEMO_EMAIL))
+    ).scalar_one_or_none()
+    if user is not None:
+        remaining = (
+            await session.execute(select(Voyage.id).where(Voyage.user_id == user.id))
+        ).first()
+        if remaining is None:
+            await session.delete(user)
+
+    await session.commit()
+    return len(voyages)

--- a/src/backend/scripts/demo.py
+++ b/src/backend/scripts/demo.py
@@ -1,0 +1,67 @@
+"""Run the scripted demo voyage (#56): seed a demo user + voyage and replay the
+recorded event timeline through the real Den Den Mushi stream — no API key.
+
+    python -m scripts.demo            # seed (fresh) + replay at 1x
+    python -m scripts.demo --speed 2  # replay faster
+    python -m scripts.demo --cleanup  # remove demo data and exit
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+
+from redis.asyncio import Redis
+
+from app.core.config import settings
+from app.demo.replayer import DemoReplayer
+from app.demo.seed import DEMO_EMAIL, DEMO_PASSWORD, cleanup_demo, seed_demo
+from app.den_den_mushi.mushi import DenDenMushi
+from app.models import async_session, engine
+
+
+async def _cleanup_only() -> None:
+    redis: Redis = Redis.from_url(settings.redis_url, decode_responses=True)
+    try:
+        async with async_session() as session:
+            removed = await cleanup_demo(session, redis)
+        print(f"Removed {removed} demo voyage(s).")
+    finally:
+        await redis.aclose()
+        await engine.dispose()
+
+
+async def _run(speed: float) -> None:
+    redis: Redis = Redis.from_url(settings.redis_url, decode_responses=True)
+    mushi = DenDenMushi(redis)
+    try:
+        async with async_session() as session:
+            await cleanup_demo(session, redis)  # start from a clean slate
+            voyage = await seed_demo(session)
+
+        print(f"Demo voyage seeded: {voyage.id}")
+        print(f"  Log in:   http://localhost:3000/login  ({DEMO_EMAIL} / {DEMO_PASSWORD})")
+        print(f"  Watch it: http://localhost:3000/app/sea-chart?voyage={voyage.id}")
+        print("Replaying… (Pause/Cancel in the deck affect this replay)")
+
+        result = await DemoReplayer(mushi, async_session, voyage.id, speed=speed).run()
+        print(f"Demo {result}.")
+    finally:
+        await redis.aclose()
+        await engine.dispose()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Replay the scripted demo voyage.")
+    parser.add_argument("--speed", type=float, default=1.0, help="playback speed multiplier")
+    parser.add_argument("--cleanup", action="store_true", help="remove demo data and exit")
+    args = parser.parse_args()
+
+    if args.cleanup:
+        asyncio.run(_cleanup_only())
+    else:
+        asyncio.run(_run(args.speed))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/backend/tests/test_demo_replayer.py
+++ b/src/backend/tests/test_demo_replayer.py
@@ -1,0 +1,125 @@
+"""Tests for the demo replayer's pacing + intervention gating (#56)."""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.demo.replayer import DemoReplayer
+from app.demo.script import DEMO_SCRIPT
+
+VOYAGE_ID = uuid.uuid4()
+
+
+class _Voyage:
+    def __init__(self, status: str = "CHARTED") -> None:
+        self.status = status
+        self.phase_status: dict[str, str] = {}
+
+
+class _Session:
+    def __init__(self, voyage: _Voyage) -> None:
+        self._voyage = voyage
+
+    async def __aenter__(self) -> _Session:
+        return self
+
+    async def __aexit__(self, *_exc: object) -> bool:
+        return False
+
+    async def get(self, _model: object, _vid: uuid.UUID) -> _Voyage:
+        return self._voyage
+
+    def add(self, _obj: object) -> None:
+        pass
+
+    async def commit(self) -> None:
+        pass
+
+
+def _factory(voyage: _Voyage):
+    return lambda: _Session(voyage)
+
+
+@pytest.mark.asyncio
+async def test_replays_all_events_in_order_and_completes() -> None:
+    voyage = _Voyage("CHARTED")
+    mushi = AsyncMock()
+    mushi.publish = AsyncMock(return_value="1-0")
+
+    replayer = DemoReplayer(
+        mushi, _factory(voyage), VOYAGE_ID, speed=1000, sleep=AsyncMock()
+    )
+    result = await replayer.run()
+
+    assert result == "completed"
+    # Two events per step (crew_action_recorded + typed).
+    assert mushi.publish.await_count == len(DEMO_SCRIPT) * 2
+    first_event = mushi.publish.await_args_list[0].args[1]
+    assert first_event.event_type == "crew_action_recorded"
+    # Status + phase progression were applied.
+    assert voyage.status == "COMPLETED"
+    assert voyage.phase_status == {"1": "BUILT", "2": "BUILT", "3": "BUILT", "4": "BUILT"}
+
+
+@pytest.mark.asyncio
+async def test_cancel_stops_the_replay() -> None:
+    voyage = _Voyage("CANCELLED")
+    mushi = AsyncMock()
+    mushi.publish = AsyncMock()
+
+    replayer = DemoReplayer(
+        mushi, _factory(voyage), VOYAGE_ID, speed=1000, sleep=AsyncMock()
+    )
+    result = await replayer.run()
+
+    assert result == "cancelled"
+    mushi.publish.assert_not_awaited()  # stopped before publishing the first step
+
+
+@pytest.mark.asyncio
+async def test_pause_blocks_until_resumed() -> None:
+    voyage = _Voyage("PAUSED")
+    mushi = AsyncMock()
+    mushi.publish = AsyncMock()
+
+    pause_polls = 0
+
+    async def sleep(secs: float) -> None:
+        nonlocal pause_polls
+        # The pause poll uses pause_poll_seconds (0.5); flip to running after one
+        # poll so the replay proceeds. Step delays are tiny (speed=1000).
+        if abs(secs - 0.5) < 1e-9:
+            pause_polls += 1
+            voyage.status = "BUILDING"
+
+    replayer = DemoReplayer(
+        mushi,
+        _factory(voyage),
+        VOYAGE_ID,
+        speed=1000,
+        sleep=sleep,
+        pause_poll_seconds=0.5,
+    )
+    result = await replayer.run()
+
+    assert result == "completed"
+    assert pause_polls >= 1  # it actually waited on the pause at least once
+    assert mushi.publish.await_count == len(DEMO_SCRIPT) * 2
+
+
+@pytest.mark.asyncio
+async def test_apply_changes_does_not_clobber_a_concurrent_pause() -> None:
+    # If a Pause lands mid-step, the status update must not overwrite PAUSED.
+    voyage = _Voyage("PAUSED")
+    mushi = AsyncMock()
+    mushi.publish = AsyncMock()
+
+    replayer = DemoReplayer(mushi, _factory(voyage), VOYAGE_ID, sleep=AsyncMock())
+    # Directly exercise _apply_changes with a stage-changing step.
+    stage_step = next(s for s in DEMO_SCRIPT if s.stage == "PDD")
+    await replayer._apply_changes(stage_step)
+
+    assert voyage.status == "PAUSED"  # not flipped to PDD

--- a/src/backend/tests/test_demo_script.py
+++ b/src/backend/tests/test_demo_script.py
@@ -1,0 +1,68 @@
+"""Tests for the recorded demo script (#56)."""
+
+from __future__ import annotations
+
+import uuid
+
+from app.demo.script import (
+    _EVENT_CLASSES,
+    DEMO_SCRIPT,
+    build_events,
+)
+
+VOYAGE_ID = uuid.uuid4()
+
+
+def test_every_step_has_a_known_event_class() -> None:
+    for step in DEMO_SCRIPT:
+        assert step.event_type in _EVENT_CLASSES, step.event_type
+
+
+def test_script_starts_charted_and_ends_completed() -> None:
+    assert DEMO_SCRIPT[0].event_type == "pipeline_started"
+    last = DEMO_SCRIPT[-1]
+    assert last.event_type == "pipeline_completed"
+    assert last.stage == "COMPLETED"
+
+
+def test_all_four_phases_reach_built() -> None:
+    final: dict[str, str] = {}
+    for step in DEMO_SCRIPT:
+        if step.phase_status:
+            final.update(step.phase_status)
+    assert final == {"1": "BUILT", "2": "BUILT", "3": "BUILT", "4": "BUILT"}
+
+
+def test_total_runtime_is_under_a_minute() -> None:
+    assert sum(s.delay for s in DEMO_SCRIPT) < 60
+
+
+def test_build_events_emits_log_row_then_typed_event() -> None:
+    step = DEMO_SCRIPT[9]  # phase 1 build started
+    assert step.event_type == "phase_build_started"
+    events = build_events(step, VOYAGE_ID)
+
+    assert len(events) == 2
+    crew_action, typed = events
+    # Ship's Log row first.
+    assert crew_action.event_type == "crew_action_recorded"
+    assert crew_action.payload["summary"] == step.summary
+    assert crew_action.payload["action_type"] == "phase_build_started"
+    assert crew_action.source_role == step.role
+    # Typed event last (drives Crew Map + reducer).
+    assert typed.event_type == "phase_build_started"
+    assert typed.payload["phase_number"] == 1
+    assert typed.voyage_id == VOYAGE_ID
+
+
+def test_stage_entered_carries_voyage_status_payload() -> None:
+    step = next(s for s in DEMO_SCRIPT if s.event_type == "pipeline_stage_entered")
+    _, typed = build_events(step, VOYAGE_ID)
+    assert typed.payload["voyage_status"] == step.stage
+
+
+def test_deployment_completed_carries_url() -> None:
+    step = next(s for s in DEMO_SCRIPT if s.event_type == "deployment_completed")
+    _, typed = build_events(step, VOYAGE_ID)
+    assert typed.payload["url"].startswith("https://")
+    assert typed.payload["tier"] == "preview"

--- a/src/frontend/components/landing/Navbar.tsx
+++ b/src/frontend/components/landing/Navbar.tsx
@@ -40,12 +40,22 @@ export default function Navbar() {
               {link.label}
             </a>
           ))}
-          <span
-            className="cursor-default rounded-lg bg-ocean-700/50 px-4 py-2 text-sm text-ocean-400"
-            title="Coming soon"
-          >
-            Chart a Course
-          </span>
+          {process.env.NEXT_PUBLIC_DEMO_MODE === "true" ? (
+            <a
+              href="/app/sea-chart"
+              className="rounded-lg bg-ocean-500 px-4 py-2 text-sm font-medium text-ocean-950 hover:bg-ocean-400"
+              title="Watch the scripted demo voyage"
+            >
+              Watch the Demo →
+            </a>
+          ) : (
+            <span
+              className="cursor-default rounded-lg bg-ocean-700/50 px-4 py-2 text-sm text-ocean-400"
+              title="Coming soon"
+            >
+              Chart a Course
+            </span>
+          )}
         </div>
       </div>
     </nav>


### PR DESCRIPTION
Fixes #56.

## Problem
The first-run experience requires a provider key (and a charted course, and LLM spend) before the product's wow moment — watching the crew sail — ever appears. The GitHub Pages mockup faked this in-browser; this brings the same to the **real app**.

## Fix
A demo mode that replays a recorded voyage through the **real** Den Den Mushi stream, so the deck consumes it exactly like a live voyage — no LLM provider involved.

- **`app/demo/script.py`** — a 25-step recorded timeline (mirrors `docs/assets/deck.js`) using the real `event_type` strings. Each step emits a `crew_action_recorded` (fills the Ship's Log) **plus** the matching typed event (pulses the Crew Map, drives the playback reducer's status/phase chips). ~46s at 1×.
- **`app/demo/replayer.py`** — paces the script onto `grandline:events:{voyage_id}` and updates the voyage's `status`/`phase_status` so the Sea Chart poll + badges keep up. It re-reads the voyage row between steps, so a **Pause** halts the replay and a **Cancel** stops it (and it won't clobber a Pause that lands mid-step).
- **`app/demo/seed.py`** — a loginable demo user (`demo@grandline.io` / `demo-voyage`) + a clearly-badged demo voyage (`🎬 Demo Voyage`) + a dial config so the Dial panel renders. `cleanup_demo` removes the rows and the Redis stream.
- **`scripts/demo.py`** + **`make demo`** / **`make demo-clean`** — seed (fresh each run) and replay; prints the login + deck URL.
- **`GRANDLINE_DEMO_MODE`** setting; the landing page's disabled "Chart a Course" button becomes a **"Watch the Demo →"** deep-link to the deck when `NEXT_PUBLIC_DEMO_MODE` is set.

## Acceptance criteria
- [x] Fresh clone + `make demo` (no API keys) → the deck shows a voyage sailing CHARTED → COMPLETED within ~60s (~46s at 1×).
- [x] Demo voyage clearly badged (`🎬 Demo Voyage`, `target_repo=grandline/demo`); `make demo-clean` removes seeded data + the event stream.
- [x] **Pause** halts the replayer and **Cancel** stops it; the demo is replayable (re-run `make demo`).

## Scope note
Per the issue, no real pipeline semantics are changed — the replayer publishes recorded events rather than running a scripted dial adapter through the graph. Pause and Cancel are the interventions wired to the replay; **Resume** isn't special-cased (resuming a demo voyage would spawn the real pipeline, which needs keys) — re-running `make demo` reseeds a fresh replay.

## Tests
Backend `960 passed, 19 skipped`; `ruff`/`mypy` clean (modulo the pre-existing `python-jose` stub). New: `test_demo_script.py` (event classes resolve, CHARTED→COMPLETED, all phases reach BUILT, <60s) and `test_demo_replayer.py` (full-sequence replay, Cancel-stop, Pause-blocks-until-resumed, no-clobber-on-pause). Frontend `tsc`/`next lint` clean, `72` vitest tests pass.

https://claude.ai/code/session_01GC6ekfqN4PxAXEu6nyJG32

---
_Generated by [Claude Code](https://claude.ai/code/session_01GC6ekfqN4PxAXEu6nyJG32)_