### PR TITLE
feat(cabin): per-user persistent sandbox container + reaper [deck 0b]

### DIFF
--- a/pdd/prompts/features/deck-capabilities/deck-cap-0b-cabin.md
+++ b/pdd/prompts/features/deck-capabilities/deck-cap-0b-cabin.md
@@ -1,0 +1,143 @@
+# Prompt: The Cabin — per-user persistent sandbox container (Phase 0b)
+
+**File**: pdd/prompts/features/deck-capabilities/deck-cap-0b-cabin.md
+**Created**: 2026-06-22
+**Updated**: 2026-06-22
+**Depends on**: Auth (Phase 4 — `get_current_user`, default-deny middleware), the
+`User` model, `Settings` (`GRANDLINE_` env prefix), the **Sea Chest** (Phase 0a —
+`SeaChestService(session, settings).reveal(user_id, kind)`), and the established
+swappable-backend pattern (`ExecutionBackend`/`DeploymentBackend`/
+`BrowserCheckBackend`). `aiodocker` is in `requirements.txt` but MUST stay a LAZY
+import (never module-top) so app startup and the test suite never need Docker.
+
+**Project type**: Backend (FastAPI + Pydantic v2 + SQLAlchemy async)
+
+## Context
+
+GrandLine is a One Piece-themed multi-agent software-orchestration platform. Phase 0
+is the keystone foundation for the deck-capabilities epic: a **Cabin** (per-user
+container) + a **Sea Chest** (per-user credential vault). The Sea Chest (Phase 0a)
+is built — it stores secrets encrypted at rest and reveals them INTERNALLY. This
+phase, **0b**, builds the runtime half: the **Cabin**.
+
+In One Piece a cabin is a crew member's own quarters aboard the ship. Here it is a
+**persistent, per-user, isolated container** that holds the user's credentials
+(materialized from the Sea Chest) and will later run their workloads — C0
+device-login Claude Code, A3 git ops, B0–B3 preview + interactive terminal. This
+phase delivers ONLY the substrate: Cabin **lifecycle + secret materialization +
+idle reaper** behind a swappable backend. It does NOT build the preview/terminal
+(B0–B3) or the credential-capture UI (C0/A3).
+
+PLAN reference: PLAN-deck-capabilities.md, Phase 0 = Cabin + Sea Chest. This is the
+**Cabin** half; the Sea Chest is the sibling (already built).
+
+## Locked design decisions
+
+- **Persistent, per-user.** ONE Cabin per user, reused across voyages (not
+  per-voyage, not one-shot like the Execution sandbox). This is the evolution of
+  `ExecutionService._sandboxes` from ephemeral to long-lived.
+- **Idle reaper + hard max lifetime.** A background task destroys Cabins idle past
+  `cabin_idle_timeout_seconds` OR older than `cabin_max_lifetime_seconds`. A Cabin
+  must never outlive its need.
+- **Swappable backend, Null default.** Mirror the
+  `ExecutionBackend`/`DeploymentBackend`/`BrowserCheckBackend` seam: a
+  deterministic, container-free **`NullCabinBackend` is the CI-safe default**; the
+  real **`GVisorCabinBackend`** is opt-in and lazily imports `aiodocker`.
+- **gVisor isolation, reused but persistent.** The real backend reuses the
+  `execution/gvisor_backend.py` isolation (runsc runtime, labels, readonly rootfs,
+  tmpfs, mem/cpu limits) but the container is PERSISTENT and may allow-list egress
+  (deny-by-default) rather than `NetworkMode: none`.
+
+## Security requirements (NON-NEGOTIABLE)
+
+- **Secrets materialized INTO the Cabin only.** The Cabin reveals the user's Sea
+  Chest secrets (`reveal(user_id, "claude_code"|"github")`) and injects them inside
+  the container as env/files at spawn (e.g. `CLAUDE_CODE_OAUTH_TOKEN`, the GitHub
+  token). Secrets are NEVER returned to the browser, NEVER put in `CabinStatus`,
+  NEVER logged or placed in an exception message.
+- **`CabinStatus` carries NO secret.** Status is `{user_id, cabin_id, state,
+  created_at, last_active, network_allow}` — provenance + lifecycle only.
+- **Deny-by-default egress.** The Cabin's network egress is an allow-list
+  (`cabin_network_allow`, default `[]` = deny all). Only the hosts a phase needs
+  (e.g. `api.github.com` for git, the Anthropic endpoint for Claude Code) are
+  opened, and only by explicit config.
+- **Per-user isolation.** A user only ever touches THEIR Cabin. The API is
+  owner-scoped via `get_current_user` — there is no path to another user's Cabin.
+- **Lazy `aiodocker` import.** Importing the gVisor backend module must NOT import
+  `aiodocker`; the import lives inside the methods. If `aiodocker` is unavailable,
+  raise a clear `CabinError`, never an opaque `ImportError`. App startup + tests
+  stay Docker-free.
+
+## Task
+
+1. **Backend ABC** `app/cabin/backend.py` — `CabinBackend` ABC + `CabinError`, plus
+   Pydantic `CabinInfo` / `CabinStatus` / `CabinRunResult` (status carries NO
+   secret). Methods: `ensure(user_id, *, secrets, network_allow) -> CabinInfo`
+   (get-or-create the user's persistent Cabin, materialize `secrets` by kind, apply
+   the egress allow-list), `run(user_id, command, *, timeout) -> CabinRunResult`
+   (one-shot exec inside the Cabin), `status(user_id) -> CabinStatus`,
+   `destroy(user_id) -> None`, `close() -> None`.
+2. **Null backend** `app/cabin/null_backend.py` — `NullCabinBackend`: deterministic,
+   in-memory, container-free default. Tracks Cabins in a dict; `run` returns a
+   canned success; records THAT secrets were materialized (by kind) WITHOUT storing
+   or echoing their values. The CI default.
+3. **gVisor backend** `app/cabin/gvisor_backend.py` — `GVisorCabinBackend`: real
+   persistent-per-user gVisor container. Lazy `import aiodocker` inside methods;
+   raise `CabinError` if unavailable. Reuse the `execution/gvisor_backend.py`
+   isolation but persistent; egress restricted to `network_allow`; secrets injected
+   as env at spawn, never logged. Opt-in only.
+4. **Factory** `app/cabin/factory.py` — `create_cabin_backend(settings)` on
+   `settings.cabin_backend` (default `"null"`, `"gvisor"` opt-in, unknown ->
+   `ValueError`). Lazy backend imports inside the branches.
+5. **Service** `app/services/cabin_service.py` — `CabinService(backend, settings)` +
+   reuse `CabinError`. In-memory per-user registry with `created_at`/`last_active`
+   (process-local, v1 single-worker — note like `pipeline_tasks`). `ensure(user_id,
+   session)` reveals the user's Sea Chest secrets for the kinds present and calls
+   `backend.ensure(...)`; `run(user_id, session, command, *, timeout)` ensures then
+   runs; `status`/`destroy`; `reap_idle(*, now=None)` destroys idle-past-timeout OR
+   past-max-lifetime Cabins (inject `now` for unit tests).
+6. **Settings**: `cabin_backend: str = "null"`, `cabin_idle_timeout_seconds = 1800`,
+   `cabin_max_lifetime_seconds = 3600`, `cabin_reap_interval_seconds = 300`,
+   `cabin_network_allow: list[str] = []` (deny-by-default; document each kind's
+   needed hosts as a comment).
+7. **App wiring** (`main.py`): construct `app.state.cabin_service` on startup; spawn
+   a background reaper task looping `await cabin_service.reap_idle()` every
+   `cabin_reap_interval_seconds`, cancelled + awaited on shutdown (mirroring the
+   pipeline-task drain); close the backend on shutdown.
+8. **API** `app/api/v1/cabin.py` (default-deny via `get_current_user`, per-user):
+   `GET /api/v1/cabin` (my Cabin status), `POST /api/v1/cabin` (ensure/wake ->
+   status), `DELETE /api/v1/cabin` (destroy -> 204). Register in `router.py`.
+
+## Output format
+
+- Type-annotated Python, async, Pydantic v2, classes PascalCase, functions
+  snake_case, One Piece themed naming ("Cabin"). New artifacts only under
+  `src/backend/app/`, `src/backend/tests/`, and the named pdd files.
+- TDD: failing tests first, then implement to green. Null backend / mocked sessions
+  (`AsyncMock`/`MagicMock`), no Docker, no Postgres.
+
+## Constraints
+
+- Mirror the `ExecutionBackend`/`DeploymentBackend`/`BrowserCheckBackend` swap: ABC
+  behind a factory, Null deterministic default, gVisor opt-in with a LAZY
+  `aiodocker` import inside methods.
+- In-memory registry only — NO migration needed (note v1 single-worker, like
+  `pipeline_tasks`). If a DB audit table were added it would chain
+  `down_revision='c1d2e3f4a5b6'`; not needed here.
+- Secrets materialized into the Cabin ONLY — never logged, never in `CabinStatus`/
+  API responses. Deny-by-default egress. Do NOT break existing tests. No git.
+
+## Edge Cases
+
+- `cabin_backend` unset -> Null backend (the CI default).
+- `cabin_backend="gvisor"` but `aiodocker` absent -> `CabinError` (clear message),
+  never an opaque `ImportError`; importing the module never imports `aiodocker`.
+- `cabin_backend="podman"` (unknown) -> `ValueError`.
+- `ensure` twice for one user -> ONE Cabin (get-or-create), `last_active` refreshed.
+- `ensure` reveals only the kinds the user has connected; an absent kind is skipped.
+- `reap_idle`: a Cabin idle past `cabin_idle_timeout_seconds` is reaped; a Cabin
+  older than `cabin_max_lifetime_seconds` is reaped even if recently active; a fresh
+  Cabin is kept. Returns the reaped user_ids.
+- `status`/`destroy` for a user with no Cabin -> `CabinError("NOT_FOUND")`.
+- No secret (value) ever appears in `CabinStatus`, an API response, a log line, or
+  an exception message — only the KINDS materialized are observable.

--- a/src/backend/app/api/v1/cabin.py
+++ b/src/backend/app/api/v1/cabin.py
@@ -1,0 +1,72 @@
+"""Cabin REST API (Phase 0b) — the requesting user's own persistent Cabin.
+
+Default-deny: every endpoint requires an authenticated user, and a user only ever
+touches THEIR Cabin (there is no path to another user's Cabin — the registry is
+keyed on ``user.id``). Responses are STATUS only (:class:`CabinStatus`) — never a
+secret value. Secrets are materialized INSIDE the Cabin from the Sea Chest and are
+never surfaced here.
+
+- ``GET /api/v1/cabin`` — my Cabin's status (404 if none).
+- ``POST /api/v1/cabin`` — ensure/wake my Cabin (materializes my Sea Chest secrets)
+  and return its status.
+- ``DELETE /api/v1/cabin`` — destroy my Cabin (204; 404 if none).
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.v1.dependencies import get_current_user
+from app.cabin.backend import CabinError, CabinStatus
+from app.models import get_db
+from app.models.user import User
+from app.services.cabin_service import CabinService
+
+router = APIRouter(prefix="/cabin", tags=["cabin"])
+
+
+def get_cabin_service(request: Request) -> CabinService:
+    svc: CabinService = request.app.state.cabin_service
+    return svc
+
+
+@router.get("", response_model=CabinStatus)
+async def get_cabin(
+    user: User = Depends(get_current_user),
+    service: CabinService = Depends(get_cabin_service),
+) -> CabinStatus:
+    """Return the requesting user's Cabin status (STATUS only — no secrets)."""
+    try:
+        return await service.status(user.id)
+    except CabinError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"error": {"code": exc.code, "message": exc.message}},
+        )
+
+
+@router.post("", response_model=CabinStatus)
+async def ensure_cabin(
+    user: User = Depends(get_current_user),
+    session: AsyncSession = Depends(get_db),
+    service: CabinService = Depends(get_cabin_service),
+) -> CabinStatus:
+    """Ensure/wake the requesting user's Cabin and return its status."""
+    return await service.ensure(user.id, session)
+
+
+@router.delete("", status_code=status.HTTP_204_NO_CONTENT, response_class=Response)
+async def destroy_cabin(
+    user: User = Depends(get_current_user),
+    service: CabinService = Depends(get_cabin_service),
+) -> Response:
+    """Destroy the requesting user's Cabin."""
+    try:
+        await service.destroy(user.id)
+    except CabinError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"error": {"code": exc.code, "message": exc.message}},
+        )
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/src/backend/app/api/v1/router.py
+++ b/src/backend/app/api/v1/router.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter
 
 from app.api.v1.auth import router as auth_router
 from app.api.v1.bedside_browser import router as bedside_browser_router
+from app.api.v1.cabin import router as cabin_router
 from app.api.v1.captain import router as captain_router
 from app.api.v1.dial import router as dial_router
 from app.api.v1.doctor import router as doctor_router
@@ -42,3 +43,4 @@ v1_router.include_router(standing_orders_router)
 v1_router.include_router(sea_chest_router)
 v1_router.include_router(triggers_router)
 v1_router.include_router(bedside_browser_router)
+v1_router.include_router(cabin_router)

--- a/src/backend/app/cabin/__init__.py
+++ b/src/backend/app/cabin/__init__.py
@@ -1,0 +1,9 @@
+"""The Cabin — per-user persistent sandbox container (Phase 0b).
+
+A Cabin is a persistent, per-user, isolated container that holds the user's
+credentials (materialized from the Sea Chest) and runs their workloads. The
+backend is swappable behind :class:`CabinBackend` (mirroring
+``ExecutionBackend``/``DeploymentBackend``/``BrowserCheckBackend``): the
+deterministic, container-free :class:`NullCabinBackend` is the CI-safe default,
+and :class:`GVisorCabinBackend` is the opt-in real backend.
+"""

--- a/src/backend/app/cabin/backend.py
+++ b/src/backend/app/cabin/backend.py
@@ -1,0 +1,117 @@
+"""CabinBackend ABC — the swappable seam for the per-user Cabin (Phase 0b).
+
+Mirrors ``ExecutionBackend`` / ``DeploymentBackend`` / ``BrowserCheckBackend``: a
+clean async ABC behind a factory so a real container runtime can be swapped in
+without the service layer ever importing ``aiodocker``. The v1 default
+(:class:`NullCabinBackend`) needs no container at all, keeping CI and the test
+suite Docker-free.
+
+Security note: a Cabin materializes the user's secrets INSIDE the container only.
+None of the value types below carry a secret value — ``CabinStatus`` exposes
+provenance + lifecycle (``state``, timestamps, the egress allow-list, and the
+KINDS of secret materialized), never the secrets themselves.
+"""
+
+from __future__ import annotations
+
+import uuid
+from abc import ABC, abstractmethod
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+CabinState = Literal["running", "idle", "destroyed"]
+
+
+class CabinError(Exception):
+    """Raised when a Cabin operation fails (e.g. backend unavailable, not found)."""
+
+    def __init__(self, code: str, message: str) -> None:
+        self.code = code
+        self.message = message
+        super().__init__(message)
+
+
+class CabinInfo(BaseModel):
+    """The handle returned by ``ensure`` — identifies the user's persistent Cabin.
+
+    ``materialized_kinds`` records WHICH kinds of secret were injected into the
+    container (e.g. ``["claude_code", "github"]``) — never their values.
+    """
+
+    model_config = ConfigDict(from_attributes=True)
+
+    cabin_id: str
+    user_id: uuid.UUID
+    state: CabinState = "running"
+    materialized_kinds: list[str] = Field(default_factory=list)
+    network_allow: list[str] = Field(default_factory=list)
+
+
+class CabinStatus(BaseModel):
+    """A Cabin's STATUS as returned by the API — never carries a secret value."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    cabin_id: str
+    user_id: uuid.UUID
+    state: CabinState
+    created_at: datetime
+    last_active: datetime
+    materialized_kinds: list[str] = Field(default_factory=list)
+    network_allow: list[str] = Field(default_factory=list)
+
+
+class CabinRunResult(BaseModel):
+    """The outcome of a one-shot ``run`` inside the Cabin."""
+
+    cabin_id: str
+    exit_code: int
+    stdout: str
+    stderr: str
+    timed_out: bool = False
+    duration_seconds: float
+
+
+class CabinBackend(ABC):
+    @abstractmethod
+    async def ensure(
+        self,
+        user_id: uuid.UUID,
+        *,
+        secrets: dict[str, str],
+        network_allow: list[str],
+    ) -> CabinInfo:
+        """Get-or-create the user's persistent Cabin.
+
+        ``secrets`` maps kind -> plaintext secret (e.g. ``{"claude_code": "...",
+        "github": "..."}``); the backend materializes them INSIDE the container
+        (env/files) by kind and never logs/returns the values. ``network_allow`` is
+        the deny-by-default egress allow-list applied to the Cabin.
+        """
+        ...
+
+    @abstractmethod
+    async def run(
+        self,
+        user_id: uuid.UUID,
+        command: list[str] | str,
+        *,
+        timeout: int,
+    ) -> CabinRunResult:
+        """Run a one-shot command inside the user's Cabin."""
+        ...
+
+    @abstractmethod
+    async def status(self, user_id: uuid.UUID) -> CabinStatus:
+        """Query the user's Cabin state (raises ``CabinError`` if none)."""
+        ...
+
+    @abstractmethod
+    async def destroy(self, user_id: uuid.UUID) -> None:
+        """Tear down the user's Cabin (idempotent)."""
+        ...
+
+    async def close(self) -> None:
+        """Release resources (e.g. the Docker client session)."""

--- a/src/backend/app/cabin/factory.py
+++ b/src/backend/app/cabin/factory.py
@@ -1,0 +1,29 @@
+"""Factory for creating Cabin backends.
+
+Mirrors ``app.execution.factory`` / ``app.browser.factory``: selects the backend on
+the ``cabin_backend`` setting (env ``GRANDLINE_CABIN_BACKEND``). The default is
+``"null"`` (deterministic, container-free, CI-safe); ``"gvisor"`` opts into the real
+persistent-per-user container backend. An unknown value raises ``ValueError``.
+
+The backend imports are LAZY (inside the branches) so that selecting the Null
+backend never imports the gVisor module's ``aiodocker``-touching code path.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.cabin.backend import CabinBackend
+
+
+def create_cabin_backend(settings: Any) -> CabinBackend:
+    name = getattr(settings, "cabin_backend", "null")
+    if name == "null":
+        from app.cabin.null_backend import NullCabinBackend
+
+        return NullCabinBackend()
+    if name == "gvisor":
+        from app.cabin.gvisor_backend import GVisorCabinBackend
+
+        return GVisorCabinBackend(settings)
+    raise ValueError(f"Unknown cabin backend: {name}")

--- a/src/backend/app/cabin/gvisor_backend.py
+++ b/src/backend/app/cabin/gvisor_backend.py
@@ -1,0 +1,277 @@
+"""GVisorCabinBackend — the opt-in REAL per-user Cabin backend (Phase 0b).
+
+Selected only by config (``GRANDLINE_CABIN_BACKEND=gvisor``); the default stays
+:class:`NullCabinBackend`. ``aiodocker`` is **lazily imported inside the methods**
+so that importing this module — and therefore app startup and the whole test
+suite — never requires ``aiodocker`` or a running Docker daemon. If ``aiodocker``
+is unavailable, the methods raise a clear :class:`CabinError` (never an opaque
+``ImportError``).
+
+This reuses the gVisor isolation from ``app/execution/gvisor_backend.py`` (runsc
+runtime, managed labels, readonly rootfs, tmpfs, mem/cpu limits) but with two
+differences that make it a CABIN rather than a one-shot sandbox:
+
+- **Persistent + per-user.** One long-lived container per user, reused across
+  voyages (tracked by the ``grandline.cabin`` + ``grandline.user_id`` labels).
+- **Deny-by-default egress allow-list.** Instead of ``NetworkMode: none``, the
+  Cabin attaches to a bridge only when ``network_allow`` is non-empty; an empty
+  allow-list keeps egress fully denied.
+
+Security: the user's secrets are injected as environment variables INSIDE the
+container at spawn and are NEVER logged or returned. ``CabinStatus`` carries only
+provenance (state, timestamps, the egress allow-list, and the KINDS materialized).
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from asyncio import wait_for
+from datetime import UTC, datetime
+from typing import Any
+
+from app.cabin.backend import (
+    CabinBackend,
+    CabinError,
+    CabinInfo,
+    CabinRunResult,
+    CabinStatus,
+)
+
+logger = logging.getLogger(__name__)
+
+# Maps a Sea Chest credential kind to the environment variable the Cabin exposes it
+# under. The values are materialized INSIDE the container only — never logged.
+_KIND_ENV = {
+    "claude_code": "CLAUDE_CODE_OAUTH_TOKEN",
+    "github": "GITHUB_TOKEN",
+}
+
+
+def _parse_memory(value: str) -> int:
+    """Parse a memory limit string to bytes (supports 'm'/'g' suffixes)."""
+    value = value.strip().lower()
+    if not value:
+        raise ValueError("Empty memory limit")
+    suffix = value[-1]
+    if suffix in ("m", "g"):
+        numeric = value[:-1]
+        if not numeric:
+            raise ValueError(f"Invalid memory limit: {value!r}")
+        n = int(numeric)
+        return n * 1024 * 1024 * (1024 if suffix == "g" else 1)
+    if not value.isdigit():
+        raise ValueError(f"Invalid memory limit suffix: {value!r}")
+    return int(value)
+
+
+def _secret_env(secrets: dict[str, str]) -> dict[str, str]:
+    """Map known secret kinds to their container env vars (values, never logged)."""
+    env: dict[str, str] = {}
+    for kind, value in secrets.items():
+        var = _KIND_ENV.get(kind)
+        if var is not None:
+            env[var] = value
+    return env
+
+
+class GVisorCabinBackend(CabinBackend):
+    """Real persistent-per-user gVisor container (opt-in)."""
+
+    def __init__(self, settings: Any) -> None:
+        self._settings = settings
+        self._docker: Any = None
+        # Process-local map of user_id -> container id for the running Cabin.
+        self._cabins: dict[uuid.UUID, str] = {}
+
+    def _client(self) -> Any:
+        """Lazily construct the aiodocker client (kept out of module import time)."""
+        if self._docker is None:
+            try:
+                import aiodocker
+            except ImportError as exc:  # pragma: no cover - exercised via patched import
+                raise CabinError(
+                    "BACKEND_UNAVAILABLE",
+                    "aiodocker is not available. The 'gvisor' cabin backend requires "
+                    "aiodocker and a running Docker daemon with the gVisor (runsc) "
+                    "runtime; use the default 'null' backend if Docker is unavailable.",
+                ) from exc
+            self._docker = aiodocker.Docker()
+        return self._docker
+
+    def _network_mode(self, network_allow: list[str]) -> str:
+        # Deny-by-default: no allow-list -> no egress. A non-empty allow-list
+        # attaches to the bridge (host-level firewalling enforces the allow-list).
+        return "bridge" if network_allow else "none"
+
+    async def ensure(
+        self,
+        user_id: uuid.UUID,
+        *,
+        secrets: dict[str, str],
+        network_allow: list[str],
+    ) -> CabinInfo:
+        client = self._client()
+        from aiodocker.exceptions import DockerError  # lazy
+
+        materialized_kinds = sorted(secrets.keys())
+        env = _secret_env(secrets)
+
+        existing = self._cabins.get(user_id)
+        if existing is not None:
+            try:
+                container = client.containers.container(existing)
+                await container.show()
+                return CabinInfo(
+                    cabin_id=existing,
+                    user_id=user_id,
+                    state="running",
+                    materialized_kinds=materialized_kinds,
+                    network_allow=list(network_allow),
+                )
+            except DockerError:
+                logger.info("Cabin %s for user %s is gone, recreating", existing, user_id)
+                self._cabins.pop(user_id, None)
+
+        config = {
+            "Image": self._settings.execution_image,
+            "Cmd": ["tail", "-f", "/dev/null"],
+            "Env": [f"{k}={v}" for k, v in env.items()],
+            "Labels": {
+                "grandline.user_id": str(user_id),
+                "grandline.cabin": "true",
+                "grandline.managed": "true",
+            },
+            "HostConfig": {
+                "Runtime": self._settings.execution_gvisor_runtime,
+                "Memory": _parse_memory(self._settings.execution_memory_limit),
+                "CpuQuota": self._settings.execution_cpu_quota,
+                "CpuPeriod": self._settings.execution_cpu_period,
+                "NetworkMode": self._network_mode(network_allow),
+                "ReadonlyRootfs": True,
+                "Tmpfs": {
+                    "/workspace": "rw,size=256m",
+                    "/tmp": "rw,size=64m",
+                    "/home": "rw,size=64m",
+                },
+            },
+        }
+        try:
+            container = await client.containers.create_or_replace(
+                name=f"grandline-cabin-{user_id}",
+                config=config,
+            )
+            await container.start()
+        except DockerError as exc:
+            raise CabinError("ENSURE_FAILED", f"Failed to ensure cabin: {exc}") from exc
+
+        self._cabins[user_id] = container.id
+        return CabinInfo(
+            cabin_id=container.id,
+            user_id=user_id,
+            state="running",
+            materialized_kinds=materialized_kinds,
+            network_allow=list(network_allow),
+        )
+
+    async def run(
+        self,
+        user_id: uuid.UUID,
+        command: list[str] | str,
+        *,
+        timeout: int,
+    ) -> CabinRunResult:
+        client = self._client()
+        from aiodocker.exceptions import DockerError  # lazy
+
+        cabin_id = self._cabins.get(user_id)
+        if cabin_id is None:
+            raise CabinError("NOT_FOUND", "No cabin for user")
+
+        cmd = ["sh", "-c", command] if isinstance(command, str) else command
+        try:
+            container = client.containers.container(cabin_id)
+            exec_obj = await container.exec(cmd=cmd, tty=False)
+            stream = exec_obj.start(detach=False)
+            stdout_buf = b""
+            stderr_buf = b""
+            timed_out = False
+
+            async def _read() -> None:
+                nonlocal stdout_buf, stderr_buf
+                while True:
+                    msg = await stream.read_out()
+                    if msg is None:
+                        break
+                    if msg.stream == 1:
+                        stdout_buf += msg.data
+                    elif msg.stream == 2:
+                        stderr_buf += msg.data
+
+            try:
+                await wait_for(_read(), timeout=timeout)
+            except TimeoutError:
+                timed_out = True
+                await stream.close()
+
+            inspect_data = await exec_obj.inspect()
+            exit_code = inspect_data.get("ExitCode")
+            if exit_code is None:
+                exit_code = -1
+        except DockerError as exc:
+            raise CabinError("RUN_FAILED", f"Cabin run failed: {exc}") from exc
+
+        return CabinRunResult(
+            cabin_id=cabin_id,
+            exit_code=exit_code,
+            stdout=stdout_buf.decode(errors="replace"),
+            stderr=stderr_buf.decode(errors="replace"),
+            timed_out=timed_out,
+            duration_seconds=0.0,
+        )
+
+    async def status(self, user_id: uuid.UUID) -> CabinStatus:
+        client = self._client()
+        from aiodocker.exceptions import DockerError  # lazy
+
+        cabin_id = self._cabins.get(user_id)
+        if cabin_id is None:
+            raise CabinError("NOT_FOUND", "No cabin for user")
+        try:
+            container = client.containers.container(cabin_id)
+            info = await container.show()
+        except DockerError as exc:
+            raise CabinError("NOT_FOUND", f"Cabin not found: {cabin_id}") from exc
+
+        docker_state = info["State"]["Status"]
+        state = "running" if docker_state == "running" else "idle"
+        created_str = info["Created"]
+        created_at = datetime.fromisoformat(created_str.replace("Z", "+00:00"))
+        return CabinStatus(
+            cabin_id=cabin_id,
+            user_id=user_id,
+            state=state,
+            created_at=created_at,
+            last_active=datetime.now(UTC),
+            materialized_kinds=[],
+            network_allow=[],
+        )
+
+    async def destroy(self, user_id: uuid.UUID) -> None:
+        cabin_id = self._cabins.pop(user_id, None)
+        if cabin_id is None:
+            return
+        client = self._client()
+        from aiodocker.exceptions import DockerError  # lazy
+
+        try:
+            container = client.containers.container(cabin_id)
+            await container.kill()
+            await container.delete(force=True)
+        except DockerError:
+            logger.debug("Cabin %s already removed", cabin_id)
+
+    async def close(self) -> None:
+        if self._docker is not None:
+            await self._docker.close()
+            self._docker = None

--- a/src/backend/app/cabin/null_backend.py
+++ b/src/backend/app/cabin/null_backend.py
@@ -1,0 +1,118 @@
+"""NullCabinBackend — the deterministic, container-free v1 default for the Cabin.
+
+The analogue of ``InProcessDeploymentBackend`` / ``NullBrowserBackend``: no real
+container, fully deterministic, CI-safe. It tracks Cabins in an in-memory dict and
+returns a canned success from ``run``.
+
+Security: ``ensure`` records only the KINDS of secret materialized (the dict keys),
+NEVER the secret values — the values are dropped on the floor here exactly as the
+gVisor backend injects them inside the container and forgets them. Nothing in this
+module stores, echoes, or logs a secret value.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+from app.cabin.backend import (
+    CabinBackend,
+    CabinError,
+    CabinInfo,
+    CabinRunResult,
+    CabinStatus,
+)
+
+
+class _NullCabin:
+    """In-memory record of a Cabin — provenance only, never a secret value."""
+
+    def __init__(
+        self,
+        cabin_id: str,
+        user_id: uuid.UUID,
+        materialized_kinds: list[str],
+        network_allow: list[str],
+    ) -> None:
+        self.cabin_id = cabin_id
+        self.user_id = user_id
+        self.materialized_kinds = materialized_kinds
+        self.network_allow = network_allow
+        now = datetime.now(UTC)
+        self.created_at = now
+        self.last_active = now
+
+
+class NullCabinBackend(CabinBackend):
+    """Deterministic, container-free backend used for v1 and tests."""
+
+    def __init__(self) -> None:
+        self._cabins: dict[uuid.UUID, _NullCabin] = {}
+
+    async def ensure(
+        self,
+        user_id: uuid.UUID,
+        *,
+        secrets: dict[str, str],
+        network_allow: list[str],
+    ) -> CabinInfo:
+        # Record ONLY the kinds materialized — never the secret values.
+        materialized_kinds = sorted(secrets.keys())
+        cabin = self._cabins.get(user_id)
+        if cabin is None:
+            cabin = _NullCabin(
+                cabin_id=f"null-cabin-{user_id}",
+                user_id=user_id,
+                materialized_kinds=materialized_kinds,
+                network_allow=list(network_allow),
+            )
+            self._cabins[user_id] = cabin
+        else:
+            # Re-materialize: refresh the recorded provenance + egress allow-list.
+            cabin.materialized_kinds = materialized_kinds
+            cabin.network_allow = list(network_allow)
+            cabin.last_active = datetime.now(UTC)
+        return CabinInfo(
+            cabin_id=cabin.cabin_id,
+            user_id=user_id,
+            state="running",
+            materialized_kinds=cabin.materialized_kinds,
+            network_allow=cabin.network_allow,
+        )
+
+    async def run(
+        self,
+        user_id: uuid.UUID,
+        command: list[str] | str,
+        *,
+        timeout: int,
+    ) -> CabinRunResult:
+        cabin = self._cabins.get(user_id)
+        if cabin is None:
+            raise CabinError("NOT_FOUND", "No cabin for user")
+        cabin.last_active = datetime.now(UTC)
+        return CabinRunResult(
+            cabin_id=cabin.cabin_id,
+            exit_code=0,
+            stdout="",
+            stderr="",
+            timed_out=False,
+            duration_seconds=0.0,
+        )
+
+    async def status(self, user_id: uuid.UUID) -> CabinStatus:
+        cabin = self._cabins.get(user_id)
+        if cabin is None:
+            raise CabinError("NOT_FOUND", "No cabin for user")
+        return CabinStatus(
+            cabin_id=cabin.cabin_id,
+            user_id=user_id,
+            state="running",
+            created_at=cabin.created_at,
+            last_active=cabin.last_active,
+            materialized_kinds=cabin.materialized_kinds,
+            network_allow=cabin.network_allow,
+        )
+
+    async def destroy(self, user_id: uuid.UUID) -> None:
+        self._cabins.pop(user_id, None)

--- a/src/backend/app/core/config.py
+++ b/src/backend/app/core/config.py
@@ -86,6 +86,24 @@ class Settings(BaseSettings):
     # NEVER stored in code or the DB — credentials are encrypted at rest with this.
     seachest_key: str | None = None
 
+    # Cabin (Phase 0b): the per-user persistent sandbox container. The backend is
+    # swappable (env GRANDLINE_CABIN_BACKEND): "null" (default) is deterministic and
+    # container-free (CI-safe, the analogue of InProcessDeploymentBackend); "gvisor"
+    # opts into a real persistent-per-user gVisor container (lazily imports aiodocker
+    # — NOT needed for startup or tests).
+    cabin_backend: str = "null"
+    # Idle reaper + hard max lifetime: a Cabin is destroyed once idle past the idle
+    # timeout OR older than the max lifetime, whichever comes first, so a Cabin never
+    # outlives its need. The reaper loop runs every reap-interval seconds.
+    cabin_idle_timeout_seconds: int = 1800  # 30 min idle
+    cabin_max_lifetime_seconds: int = 3600  # 60 min hard cap
+    cabin_reap_interval_seconds: int = 300  # reaper cadence
+    # Deny-by-default egress allow-list for the Cabin (empty == no egress). Only the
+    # hosts a materialized credential needs should be opened, e.g.
+    # ["api.github.com", "github.com"] for the github token (A3 git ops) and the
+    # Anthropic endpoint (e.g. "api.anthropic.com") for the claude_code token (C0).
+    cabin_network_allow: list[str] = []
+
     # Demo mode (#56): a scripted voyage replayable via `make demo`, no API key.
     demo_mode: bool = False
 

--- a/src/backend/app/main.py
+++ b/src/backend/app/main.py
@@ -10,11 +10,13 @@ from redis.asyncio import ConnectionPool, Redis
 
 from app.api.v1.router import v1_router
 from app.browser.factory import create_browser_backend
+from app.cabin.factory import create_cabin_backend
 from app.core.config import settings
 from app.core.middleware import DefaultDenyMiddleware
 from app.den_den_mushi.mushi import DenDenMushi
 from app.deployment.in_process import InProcessDeploymentBackend
 from app.execution.factory import create_backend, create_git_backend
+from app.services.cabin_service import CabinService
 from app.services.execution_service import ExecutionService
 from app.services.git_service import GitService
 
@@ -28,6 +30,21 @@ _CORS_ALLOW_METHODS = ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"]
 _CORS_ALLOW_HEADERS = ["Authorization", "Content-Type"]
 
 _DEFAULT_JWT_SECRET = "change-me-in-production"
+
+
+async def _cabin_reaper_loop(cabin_service: CabinService) -> None:
+    """Periodically reap idle / over-lifetime Cabins until cancelled on shutdown."""
+    interval = settings.cabin_reap_interval_seconds
+    while True:
+        try:
+            await asyncio.sleep(interval)
+            reaped = await cabin_service.reap_idle()
+            if reaped:
+                logger.info("Cabin reaper destroyed %d idle/expired cabin(s)", len(reaped))
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.warning("Cabin reaper loop iteration failed", exc_info=True)
 
 
 def validate_production_settings() -> None:
@@ -66,6 +83,15 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
 
     app.state.browser_backend = create_browser_backend(settings)
 
+    # Cabin (Phase 0b): the per-user persistent sandbox. Like the pipeline-task
+    # registry, the Cabin registry is process-local (v1 single-worker).
+    cabin_service = CabinService(create_cabin_backend(settings), settings)
+    app.state.cabin_service = cabin_service
+
+    # Background idle reaper: destroys Cabins idle past the timeout OR past the hard
+    # max lifetime. Cancelled + awaited on shutdown, mirroring the pipeline-task drain.
+    reaper_task = asyncio.create_task(_cabin_reaper_loop(cabin_service))
+
     # Process-local registry of in-flight pipeline tasks. Keyed by voyage_id.
     # Multi-worker deployments are out of scope for v1 (single-worker fleet).
     pipeline_tasks: dict[uuid.UUID, asyncio.Task[None]] = {}
@@ -86,6 +112,15 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
                 len(still_pending),
                 _PIPELINE_SHUTDOWN_TIMEOUT_S,
             )
+
+    # Stop the Cabin reaper and tear down the Cabins it manages.
+    reaper_task.cancel()
+    try:
+        await reaper_task
+    except asyncio.CancelledError:
+        pass
+    await cabin_service.cleanup_all()
+    await cabin_service.close()
 
     await app.state.deployment_backend.close()
     await app.state.browser_backend.close()

--- a/src/backend/app/services/cabin_service.py
+++ b/src/backend/app/services/cabin_service.py
@@ -1,0 +1,153 @@
+"""CabinService — per-user persistent Cabin lifecycle + secret materialization.
+
+The Cabin (Phase 0b) is the runtime half of the Phase 0 foundation: a persistent,
+per-user, isolated container that holds the user's credentials (materialized from
+the Sea Chest) and runs their workloads. This service is the persistent, reaping
+evolution of ``ExecutionService``:
+
+- It keeps a **process-local** per-user registry with ``created_at``/``last_active``
+  timestamps. Multi-worker deployments are out of scope for v1 (single-worker
+  fleet), exactly like ``app.state.pipeline_tasks``.
+- ``ensure`` reveals the user's Sea Chest secrets (``SeaChestService.reveal``) for
+  the kinds they have connected and hands them to the backend to materialize INSIDE
+  the Cabin. The secret values never leave this method's call into the backend —
+  they are never stored on the service, returned, or logged.
+- ``reap_idle`` destroys Cabins idle past ``cabin_idle_timeout_seconds`` OR older
+  than ``cabin_max_lifetime_seconds`` (hard max lifetime). ``now`` is injectable so
+  the reaper is unit-testable without sleeping or a real clock.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.cabin.backend import CabinBackend, CabinError, CabinRunResult, CabinStatus
+from app.core.config import Settings
+from app.services.sea_chest_service import SeaChestService
+
+logger = logging.getLogger(__name__)
+
+# The Sea Chest kinds a Cabin materializes. Each is revealed (if connected) and
+# injected by the backend under a kind-specific env var; an unconnected kind is
+# simply skipped (no secret to inject).
+_MATERIALIZED_KINDS: tuple[str, ...] = ("claude_code", "github")
+
+
+@dataclass
+class _CabinRecord:
+    """Process-local bookkeeping for one user's Cabin (no secret value here)."""
+
+    user_id: uuid.UUID
+    created_at: datetime
+    last_active: datetime
+
+
+class CabinService:
+    """Owns the per-user Cabin registry, reaping, and secret materialization."""
+
+    def __init__(self, backend: CabinBackend, settings: Settings) -> None:
+        self._backend = backend
+        self._settings = settings
+        # Process-local registry (v1 single-worker, like ``pipeline_tasks``).
+        self._cabins: dict[uuid.UUID, _CabinRecord] = {}
+
+    async def ensure(self, user_id: uuid.UUID, session: AsyncSession) -> CabinStatus:
+        """Get-or-create the user's Cabin, materializing their Sea Chest secrets.
+
+        Reveals each connected credential kind via ``SeaChestService.reveal`` and
+        passes the plaintext secrets to the backend, which injects them INSIDE the
+        Cabin. The secrets are never stored on the service, returned, or logged.
+        """
+        sea_chest = SeaChestService(session, self._settings)
+        secrets: dict[str, str] = {}
+        for kind in _MATERIALIZED_KINDS:
+            secret = await sea_chest.reveal(user_id, kind)
+            if secret is not None:
+                secrets[kind] = secret
+
+        await self._backend.ensure(
+            user_id,
+            secrets=secrets,
+            network_allow=list(self._settings.cabin_network_allow),
+        )
+        self._touch(user_id)
+        return await self._backend.status(user_id)
+
+    async def run(
+        self,
+        user_id: uuid.UUID,
+        session: AsyncSession,
+        command: list[str] | str,
+        *,
+        timeout: int | None = None,
+    ) -> CabinRunResult:
+        """Ensure the user's Cabin exists, then run a one-shot command inside it."""
+        await self.ensure(user_id, session)
+        effective_timeout = (
+            timeout if timeout is not None else self._settings.execution_default_timeout
+        )
+        result = await self._backend.run(user_id, command, timeout=effective_timeout)
+        self._touch(user_id, refresh_only=True)
+        return result
+
+    async def status(self, user_id: uuid.UUID) -> CabinStatus:
+        """Return the user's Cabin status (raises ``CabinError`` if none)."""
+        if user_id not in self._cabins:
+            raise CabinError("NOT_FOUND", "No cabin for user")
+        return await self._backend.status(user_id)
+
+    async def destroy(self, user_id: uuid.UUID) -> None:
+        """Destroy the user's Cabin (raises ``CabinError`` if none)."""
+        if user_id not in self._cabins:
+            raise CabinError("NOT_FOUND", "No cabin for user")
+        self._cabins.pop(user_id, None)
+        await self._backend.destroy(user_id)
+
+    async def reap_idle(self, *, now: datetime | None = None) -> list[uuid.UUID]:
+        """Destroy idle-past-timeout OR past-max-lifetime Cabins.
+
+        Returns the reaped user_ids. ``now`` is injectable for deterministic tests.
+        """
+        current = now or datetime.now(UTC)
+        idle_limit = self._settings.cabin_idle_timeout_seconds
+        max_lifetime = self._settings.cabin_max_lifetime_seconds
+
+        reaped: list[uuid.UUID] = []
+        for user_id, record in list(self._cabins.items()):
+            idle_for = (current - record.last_active).total_seconds()
+            age = (current - record.created_at).total_seconds()
+            if idle_for >= idle_limit or age >= max_lifetime:
+                self._cabins.pop(user_id, None)
+                try:
+                    await self._backend.destroy(user_id)
+                except Exception:
+                    logger.warning("Failed to reap cabin for user %s", user_id)
+                reaped.append(user_id)
+        return reaped
+
+    async def cleanup_all(self) -> None:
+        """Destroy every tracked Cabin (called on shutdown)."""
+        for user_id in list(self._cabins.keys()):
+            try:
+                await self._backend.destroy(user_id)
+            except Exception:
+                logger.warning("Failed to destroy cabin for user %s", user_id)
+        self._cabins.clear()
+
+    async def close(self) -> None:
+        """Release the backend's resources."""
+        await self._backend.close()
+
+    def _touch(self, user_id: uuid.UUID, *, refresh_only: bool = False) -> None:
+        """Stamp ``last_active`` (and ``created_at`` on first creation)."""
+        now = datetime.now(UTC)
+        record = self._cabins.get(user_id)
+        if record is None:
+            self._cabins[user_id] = _CabinRecord(user_id=user_id, created_at=now, last_active=now)
+        else:
+            record.last_active = now

--- a/src/backend/tests/test_cabin_api.py
+++ b/src/backend/tests/test_cabin_api.py
@@ -1,0 +1,109 @@
+"""Tests for the Cabin REST API (direct endpoint calls, owner-scoped).
+
+GET/POST/DELETE all operate on the requesting user's OWN Cabin (keyed on
+``user.id``); the status response carries no secret.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+from app.cabin.backend import CabinError, CabinStatus
+
+USER_ID = uuid.uuid4()
+
+
+def _user() -> MagicMock:
+    u = MagicMock()
+    u.id = USER_ID
+    return u
+
+
+def _status() -> CabinStatus:
+    now = datetime.now(UTC)
+    return CabinStatus(
+        cabin_id="null-cabin",
+        user_id=USER_ID,
+        state="running",
+        created_at=now,
+        last_active=now,
+        materialized_kinds=["github"],
+        network_allow=["api.github.com"],
+    )
+
+
+class TestGetCabin:
+    async def test_returns_status(self) -> None:
+        from app.api.v1.cabin import get_cabin
+
+        service = AsyncMock()
+        service.status = AsyncMock(return_value=_status())
+
+        result = await get_cabin(user=_user(), service=service)
+
+        assert result.cabin_id == "null-cabin"
+        service.status.assert_awaited_once_with(USER_ID)
+
+    async def test_404_when_no_cabin(self) -> None:
+        from app.api.v1.cabin import get_cabin
+
+        service = AsyncMock()
+        service.status = AsyncMock(side_effect=CabinError("NOT_FOUND", "No cabin for user"))
+
+        with pytest.raises(HTTPException) as exc:
+            await get_cabin(user=_user(), service=service)
+        assert exc.value.status_code == 404
+
+    async def test_status_response_has_no_secret(self) -> None:
+        from app.api.v1.cabin import get_cabin
+
+        service = AsyncMock()
+        service.status = AsyncMock(return_value=_status())
+
+        result = await get_cabin(user=_user(), service=service)
+        dumped = result.model_dump_json()
+        # Only kinds + allow-list provenance — no secret value field exists at all.
+        assert "secret" not in dumped.lower()
+        assert "token" not in dumped.lower()
+
+
+class TestEnsureCabin:
+    async def test_ensures_and_returns_status(self) -> None:
+        from app.api.v1.cabin import ensure_cabin
+
+        service = AsyncMock()
+        service.ensure = AsyncMock(return_value=_status())
+        session = AsyncMock()
+
+        result = await ensure_cabin(user=_user(), session=session, service=service)
+
+        assert result.state == "running"
+        service.ensure.assert_awaited_once_with(USER_ID, session)
+
+
+class TestDestroyCabin:
+    async def test_returns_204(self) -> None:
+        from app.api.v1.cabin import destroy_cabin
+
+        service = AsyncMock()
+        service.destroy = AsyncMock()
+
+        result = await destroy_cabin(user=_user(), service=service)
+
+        assert result.status_code == 204
+        service.destroy.assert_awaited_once_with(USER_ID)
+
+    async def test_404_when_no_cabin(self) -> None:
+        from app.api.v1.cabin import destroy_cabin
+
+        service = AsyncMock()
+        service.destroy = AsyncMock(side_effect=CabinError("NOT_FOUND", "No cabin for user"))
+
+        with pytest.raises(HTTPException) as exc:
+            await destroy_cabin(user=_user(), service=service)
+        assert exc.value.status_code == 404

--- a/src/backend/tests/test_cabin_backend.py
+++ b/src/backend/tests/test_cabin_backend.py
@@ -1,0 +1,112 @@
+"""Tests for the Cabin backends (Phase 0b).
+
+Mirrors test_browser_backend / test_execution_backend: Null backend determinism +
+secret-free status, factory selection + unknown -> ValueError, and the gVisor
+backend raising a clean CabinError when aiodocker is patched absent (no Docker, no
+real gVisor required).
+"""
+
+from __future__ import annotations
+
+import builtins
+import uuid
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from app.cabin.backend import CabinError
+from app.cabin.factory import create_cabin_backend
+from app.cabin.gvisor_backend import GVisorCabinBackend
+from app.cabin.null_backend import NullCabinBackend
+
+USER_ID = uuid.uuid4()
+OTHER_USER = uuid.uuid4()
+
+
+class TestNullBackendDeterminism:
+    async def test_ensure_creates_and_reuses_one_cabin(self) -> None:
+        backend = NullCabinBackend()
+        info1 = await backend.ensure(USER_ID, secrets={}, network_allow=[])
+        info2 = await backend.ensure(USER_ID, secrets={}, network_allow=[])
+        assert info1.cabin_id == info2.cabin_id
+        assert info1.user_id == USER_ID
+
+    async def test_run_returns_canned_success(self) -> None:
+        backend = NullCabinBackend()
+        await backend.ensure(USER_ID, secrets={}, network_allow=[])
+        result = await backend.run(USER_ID, "echo hi", timeout=30)
+        assert result.exit_code == 0
+        assert result.timed_out is False
+
+    async def test_run_without_cabin_raises(self) -> None:
+        backend = NullCabinBackend()
+        with pytest.raises(CabinError):
+            await backend.run(OTHER_USER, "echo", timeout=5)
+
+    async def test_status_records_kinds_not_secret_values(self) -> None:
+        backend = NullCabinBackend()
+        await backend.ensure(
+            USER_ID,
+            secrets={"claude_code": "super-secret-token", "github": "ghp_secret"},
+            network_allow=["api.github.com"],
+        )
+        status = await backend.status(USER_ID)
+        # The KINDS are observable; the secret VALUES are not present anywhere.
+        assert status.materialized_kinds == ["claude_code", "github"]
+        assert status.network_allow == ["api.github.com"]
+        dumped = status.model_dump_json()
+        assert "super-secret-token" not in dumped
+        assert "ghp_secret" not in dumped
+
+    async def test_status_without_cabin_raises(self) -> None:
+        backend = NullCabinBackend()
+        with pytest.raises(CabinError):
+            await backend.status(OTHER_USER)
+
+    async def test_destroy_is_idempotent(self) -> None:
+        backend = NullCabinBackend()
+        await backend.ensure(USER_ID, secrets={}, network_allow=[])
+        await backend.destroy(USER_ID)
+        await backend.destroy(USER_ID)  # must not raise
+        with pytest.raises(CabinError):
+            await backend.status(USER_ID)
+
+    async def test_close_is_noop(self) -> None:
+        backend = NullCabinBackend()
+        await backend.close()  # must not raise
+
+
+class TestFactorySelection:
+    def test_default_is_null(self) -> None:
+        backend = create_cabin_backend(SimpleNamespace())
+        assert isinstance(backend, NullCabinBackend)
+
+    def test_explicit_null(self) -> None:
+        backend = create_cabin_backend(SimpleNamespace(cabin_backend="null"))
+        assert isinstance(backend, NullCabinBackend)
+
+    def test_gvisor_selected(self) -> None:
+        backend = create_cabin_backend(SimpleNamespace(cabin_backend="gvisor"))
+        assert isinstance(backend, GVisorCabinBackend)
+
+    def test_unknown_raises_value_error(self) -> None:
+        with pytest.raises(ValueError, match="Unknown cabin backend"):
+            create_cabin_backend(SimpleNamespace(cabin_backend="podman"))
+
+
+class TestGVisorBackendMissingLib:
+    async def test_ensure_raises_clean_error_when_aiodocker_absent(self) -> None:
+        backend = GVisorCabinBackend(SimpleNamespace())
+
+        real_import = builtins.__import__
+
+        def _fake_import(name: str, *args: object, **kwargs: object) -> object:
+            if name == "aiodocker" or name.startswith("aiodocker."):
+                raise ImportError("No module named 'aiodocker'")
+            return real_import(name, *args, **kwargs)
+
+        with patch.object(builtins, "__import__", _fake_import):
+            with pytest.raises(CabinError) as exc:
+                await backend.ensure(USER_ID, secrets={}, network_allow=[])
+        assert exc.value.code == "BACKEND_UNAVAILABLE"

--- a/src/backend/tests/test_cabin_service.py
+++ b/src/backend/tests/test_cabin_service.py
@@ -1,0 +1,194 @@
+"""Tests for CabinService (Null backend + mocked Sea Chest reveal).
+
+Covers: ensure creates + reuses one Cabin per user; ensure reveals the user's Sea
+Chest secrets and passes them to backend.ensure (no secret leaks into status);
+reap_idle destroys idle-past-timeout AND past-max-lifetime cabins while keeping
+fresh ones (now injected); status/destroy. No Docker, no Postgres.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.cabin.backend import CabinError
+from app.cabin.null_backend import NullCabinBackend
+from app.services.cabin_service import CabinService
+
+USER_ID = uuid.uuid4()
+OTHER_USER = uuid.uuid4()
+
+
+def _settings(**overrides: object) -> SimpleNamespace:
+    base = {
+        "cabin_idle_timeout_seconds": 1800,
+        "cabin_max_lifetime_seconds": 3600,
+        "cabin_reap_interval_seconds": 300,
+        "cabin_network_allow": [],
+        "execution_default_timeout": 30,
+        "seachest_key": "test-key",
+        "debug": True,
+    }
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+@pytest.fixture
+def session() -> AsyncMock:
+    return AsyncMock()
+
+
+class TestEnsure:
+    async def test_ensure_creates_and_reuses_one_cabin(
+        self, session: AsyncMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        reveal = AsyncMock(return_value=None)
+        monkeypatch.setattr(
+            "app.services.cabin_service.SeaChestService.reveal", reveal, raising=True
+        )
+        service = CabinService(NullCabinBackend(), _settings())
+
+        s1 = await service.ensure(USER_ID, session)
+        s2 = await service.ensure(USER_ID, session)
+
+        assert s1.cabin_id == s2.cabin_id
+        # One record per user in the registry.
+        assert list(service._cabins.keys()) == [USER_ID]
+
+    async def test_ensure_reveals_secrets_and_passes_to_backend(
+        self, session: AsyncMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        async def _reveal(self: object, user_id: uuid.UUID, kind: str) -> str | None:
+            return {"claude_code": "oauth-secret", "github": "gh-secret"}.get(kind)
+
+        monkeypatch.setattr(
+            "app.services.cabin_service.SeaChestService.reveal", _reveal, raising=True
+        )
+        backend = MagicMock()
+        backend.ensure = AsyncMock()
+        backend.status = AsyncMock(
+            return_value=SimpleNamespace(cabin_id="c", user_id=USER_ID, state="running")
+        )
+        service = CabinService(backend, _settings(cabin_network_allow=["api.github.com"]))
+
+        await service.ensure(USER_ID, session)
+
+        backend.ensure.assert_awaited_once()
+        _, kwargs = backend.ensure.call_args
+        assert kwargs["secrets"] == {
+            "claude_code": "oauth-secret",
+            "github": "gh-secret",
+        }
+        assert kwargs["network_allow"] == ["api.github.com"]
+
+    async def test_status_carries_no_secret(
+        self, session: AsyncMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        async def _reveal(self: object, user_id: uuid.UUID, kind: str) -> str | None:
+            return "TOP-SECRET-VALUE" if kind == "github" else None
+
+        monkeypatch.setattr(
+            "app.services.cabin_service.SeaChestService.reveal", _reveal, raising=True
+        )
+        service = CabinService(NullCabinBackend(), _settings())
+
+        status = await service.ensure(USER_ID, session)
+
+        assert "TOP-SECRET-VALUE" not in status.model_dump_json()
+        # Only the KIND is observable.
+        assert status.materialized_kinds == ["github"]
+
+    async def test_ensure_skips_unconnected_kinds(
+        self, session: AsyncMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        reveal = AsyncMock(return_value=None)
+        monkeypatch.setattr(
+            "app.services.cabin_service.SeaChestService.reveal", reveal, raising=True
+        )
+        backend = MagicMock()
+        backend.ensure = AsyncMock()
+        backend.status = AsyncMock(
+            return_value=SimpleNamespace(cabin_id="c", user_id=USER_ID, state="running")
+        )
+        service = CabinService(backend, _settings())
+
+        await service.ensure(USER_ID, session)
+
+        _, kwargs = backend.ensure.call_args
+        assert kwargs["secrets"] == {}
+
+
+class TestStatusDestroy:
+    async def test_status_without_cabin_raises(self) -> None:
+        service = CabinService(NullCabinBackend(), _settings())
+        with pytest.raises(CabinError):
+            await service.status(OTHER_USER)
+
+    async def test_destroy_removes_cabin(
+        self, session: AsyncMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            "app.services.cabin_service.SeaChestService.reveal",
+            AsyncMock(return_value=None),
+            raising=True,
+        )
+        service = CabinService(NullCabinBackend(), _settings())
+        await service.ensure(USER_ID, session)
+        await service.destroy(USER_ID)
+        with pytest.raises(CabinError):
+            await service.status(USER_ID)
+
+    async def test_destroy_without_cabin_raises(self) -> None:
+        service = CabinService(NullCabinBackend(), _settings())
+        with pytest.raises(CabinError):
+            await service.destroy(OTHER_USER)
+
+
+class TestReapIdle:
+    async def test_reaps_idle_and_lifetime_keeps_fresh(self) -> None:
+        backend = MagicMock()
+        backend.destroy = AsyncMock()
+        service = CabinService(
+            backend,
+            _settings(cabin_idle_timeout_seconds=1800, cabin_max_lifetime_seconds=3600),
+        )
+        now = datetime(2026, 6, 22, 12, 0, 0, tzinfo=UTC)
+
+        # idle_user: created recently but idle for > 30 min -> reaped (idle).
+        idle_user = uuid.uuid4()
+        # old_user: recently active but older than 60 min -> reaped (max lifetime).
+        old_user = uuid.uuid4()
+        # fresh_user: created + active recently -> kept.
+        fresh_user = uuid.uuid4()
+
+        from app.services.cabin_service import _CabinRecord
+
+        service._cabins[idle_user] = _CabinRecord(
+            user_id=idle_user,
+            created_at=now - timedelta(minutes=40),
+            last_active=now - timedelta(minutes=31),
+        )
+        service._cabins[old_user] = _CabinRecord(
+            user_id=old_user,
+            created_at=now - timedelta(minutes=61),
+            last_active=now - timedelta(seconds=10),
+        )
+        service._cabins[fresh_user] = _CabinRecord(
+            user_id=fresh_user,
+            created_at=now - timedelta(minutes=5),
+            last_active=now - timedelta(seconds=10),
+        )
+
+        reaped = await service.reap_idle(now=now)
+
+        assert set(reaped) == {idle_user, old_user}
+        assert list(service._cabins.keys()) == [fresh_user]
+        assert backend.destroy.await_count == 2
+
+    async def test_reap_empty_registry(self) -> None:
+        service = CabinService(NullCabinBackend(), _settings())
+        assert await service.reap_idle(now=datetime.now(UTC)) == []


### PR DESCRIPTION
## Deck Capabilities — Phase 0b: the Cabin (per-user sandbox)

**Stacked on [Sea Chest 0a](https://github.com/harshal2802/GrandLine/pull/76).** The runtime half of the Phase 0 foundation — completes the per-user substrate that A3 / C0 / B0–B3 build on.

A **Cabin** is a persistent, per-user, isolated container that materializes the user's Sea Chest secrets and (later) runs their workloads. This PR is lifecycle + secret materialization + idle reaper only — no preview/terminal yet.

### Design (per locked decisions)
- **Swappable backend** mirroring `ExecutionBackend`/`BrowserCheckBackend`: **`NullCabinBackend`** is the deterministic, container-free **CI default**; **`GVisorCabinBackend`** is opt-in (`GRANDLINE_CABIN_BACKEND=gvisor`) with a **lazy `aiodocker` import** — verified `import app.main` works with no Docker.
- **Persistent per-user** Cabins with an **idle reaper + hard max-lifetime** (`reap_idle` tested by injecting `now`), run as a background task in the lifespan and drained on shutdown.
- **Secrets materialized into the cabin only**, revealed from the Sea Chest via `SeaChestService.reveal` — never logged, never returned. `CabinStatus` exposes `materialized_kinds` (which kinds exist, not the values).
- **Deny-by-default egress** allow-list (`cabin_network_allow`).
- In-memory per-user registry (process-local; v1 single-worker, noted like `pipeline_tasks`).

### What's included
- `app/cabin/{backend,null_backend,gvisor_backend,factory}.py`, `CabinService` (`ensure`/`run`/`status`/`destroy`/`reap_idle`), reaper wiring in `main.py`, REST `GET`/`POST`/`DELETE /api/v1/cabin` (default-deny, owner-scoped).
- Poneglyph `deck-cap-0b`; `decisions.md` + `project.md` updated. No migration (in-memory registry).

### Methodology
TDD: **pytest 1205 passed**, ruff format + check + mypy clean, app imports without Docker.

### Next
With the foundation complete: **C0** (device-code `claude login` in the Cabin), **A3** (per-user GitHub in the Cabin), then **B0–B3** (preview + logs + embed + terminal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GXQ1SRy9xCseygdQVp8YZe)_